### PR TITLE
refactor: allow develop branch in naming logic

### DIFF
--- a/commit-message-monorepo/SKILL.md
+++ b/commit-message-monorepo/SKILL.md
@@ -19,7 +19,7 @@ Get the current directory name to use as the scope:
 basename "$(pwd)"
 ```
 
-### 3. Branch Name (only if on `main` or `develop-*`)
+### 3. Branch Name (only if on `main` or `develop*`)
 **Format:** `<type>/<$dir-prefix>-<description>`
 
 **Types:** `feature/` `fix/` `docs/` `refactor/` `test/` `chore/`
@@ -42,7 +42,7 @@ basename "$(pwd)"
 
 ### 5. Output Format
 
-**On main/develop-* branch:**
+**On main/develop* branch:**
 ```
 ## Recommended Branch
 git checkout -b <type>/<scope>/<description>

--- a/commit-message/SKILL.md
+++ b/commit-message/SKILL.md
@@ -12,7 +12,7 @@ git status --short
 git branch --show-current
 ```
 
-### 2. Branch Name (only if on `main` or `develop-*`)
+### 2. Branch Name (only if on `main` or `develop*`)
 **Format:** `<type>/<description>`
 
 **Types:** `feature/` `fix/` `docs/` `refactor/` `test/` `chore/`
@@ -34,7 +34,7 @@ git branch --show-current
 
 ### 4. Output Format
 
-**On main/develop-* branch:**
+**On main/develop* branch:**
 ```
 ## Recommended Branch
 git checkout -b <type>/<description>


### PR DESCRIPTION
Change condition from develop-* to develop* to support branches starting with 'develop', including 'develop' itself.