### PR TITLE
refactor: rename commit-message skills to shorter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ AI エージェント用のカスタムスキル集です。
 
 | Skill | Description |
 |-------|-------------|
-| [commit-message](commit-message/) | コミットメッセージとブランチ名を提案 |
-| [commit-message-monorepo](commit-message-monorepo/) | モノレポ向けのコミットメッセージとブランチ名を提案 |
+| [commit](commit/) | コミットメッセージとブランチ名を提案 |
+| [commit-monorepo](commit-monorepo/) | モノレポ向けのコミットメッセージとブランチ名を提案 |
 
 ## Setup
 
@@ -39,9 +39,9 @@ rm "$HOME/.claude/skills"
 ```
 agent-skills/
 ├── README.md
-├── commit-message/
+├── commit/
 │   └── SKILL.md
-├── commit-message-monorepo/
+├── commit-monorepo/
 │   └── SKILL.md
 └── .samples/
     └── ...

--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: commit-messages-monorepo
+name: commit-monorepo
 description: Suggest commit messages and branch names for monorepo projects
 ---
 

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: commit-messages
+name: commit
 description: Suggest commit messages and branch names
 ---
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  スキルのディレクトリ名を短縮して、より簡潔で使いやすくする。                                                                                                                                                             
                  
  ## Changes                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  - `commit-message/` → `commit/`
  - `commit-message-monorepo/` → `commit-monorepo/`

  ## Details

  - SKILL.md の `name` フィールドも合わせて更新
  - README.md のパスと説明を更新

  ## Checklist

  - [x] ディレクトリ名の変更
  - [x] SKILL.md の更新
  - [x] README.md の更新