### PR TITLE
feat: add pr skill for PR body generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ AI エージェント用のカスタムスキル集です。
 |-------|-------------|
 | [commit](commit/) | コミットメッセージとブランチ名を提案 |
 | [commit-monorepo](commit-monorepo/) | モノレポ向けのコミットメッセージとブランチ名を提案 |
+| [pr](pr/) | PR 本文をマークダウン形式で提案 |
 
 ## Setup
 
@@ -42,6 +43,8 @@ agent-skills/
 ├── commit/
 │   └── SKILL.md
 ├── commit-monorepo/
+│   └── SKILL.md
+├── pr/
 │   └── SKILL.md
 └── .samples/
     └── ...

--- a/pr/SKILL.md
+++ b/pr/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: pr
+description: Suggest PR body in markdown format
+---
+
+## Workflow
+
+### 1. Check Context
+- Current branch name
+- Commit history (git log --oneline main..HEAD)
+- Files changed (git diff --name-status main)
+
+### 2. PR Body Format
+Output in a markdown code block.
+
+**Structure:**
+```markdown
+## Summary
+
+Brief description of what this PR does.
+
+## Changes
+
+- Change 1
+- Change 2
+
+## Details
+
+Optional: technical details, implementation notes, etc.
+
+## Checklist
+
+- [ ] Item 1
+- [ ] Item 2
+```
+
+### 3. Guidelines
+
+- Use clear, concise language
+- Focus on *what* and *why*
+- Keep summary under 2-3 sentences
+- Checklist should reflect actual changes
+
+### 4. Output Format
+
+**Wrap the entire PR body in a markdown code block:**
+
+~~~
+```markdown
+## Summary
+...
+```
+~~~


### PR DESCRIPTION
## Summary                                                                
                                                                          
Adds a new `pr` skill that generates well-structured PR bodies in markdown
  format. This skill analyzes the git context (branch name, commits, and
changed files) to create relevant PR descriptions.                        
                                                                          
## Changes

- Added `pr/SKILL.md` with workflow and PR body format guidelines
- Updated `README.md` to include the new skill in the documentation

## Checklist

- [x] Skill file created with proper structure
- [x] Documentation updated in README
- [x] Verified `/pr` command works as expected