### PR TITLE
docs: add auto-execution instructions for user confirmation

### DIFF
--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -64,6 +64,22 @@ git add <file>
 git commit -m "type(scope): title" -m "body"
 ```
 
+### 7. User Confirmation
+If the user says "OK" after the suggestion, execute the following automatically:
+
+**On main/develop* branch:**
+```bash
+git switch -c <type>/<$dir-prefix>-<description>
+git add .  # only if files are not staged
+git commit -m "<type>(<scope>): <title>" -m "<body>"
+```
+
+**On other branches:**
+```bash
+git add .  # only if files are not staged
+git commit -m "<type>(<scope>): <title>" -m "<body>"
+```
+
 ## Examples
 
 **If in `/projects/monorepo/packages/auth`:**

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -54,3 +54,20 @@ git commit -m "<prefix>: <title>" -m "<body>"
 git add <file>
 # or use `git hunks` for specific changes
 git commit -m "title" -m "body"
+```
+
+### 6. User Confirmation
+If the user says "OK" after the suggestion, execute the following automatically:
+
+**On main/develop* branch:**
+```bash
+git switch -c <type>/<description>
+git add .  # only if files are not staged
+git commit -m "<prefix>: <title>" -m "<body>"
+```
+
+**On other branches:**
+```bash
+git add .  # only if files are not staged
+git commit -m "<prefix>: <title>" -m "<body>"
+```


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  Adds documentation for the automatic execution workflow that triggers when users respond with "OK" to commit message suggestions. This clarifies the expected behavior for both the standard commit skill and the monorepo variant.         

  ## Changes

  - Add "User Confirmation" step to `commit/SKILL.md`
  - Add "User Confirmation" step to `commit-monorepo/SKILL.md`

  ## Checklist

  - [ ] Documentation updated for both commit skills