### PR TITLE
docs: add plan-creator skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ AI エージェント用のカスタムスキル集です。
 | [commit](commit/) | コミットメッセージとブランチ名を提案 |
 | [commit-monorepo](commit-monorepo/) | モノレポ向けのコミットメッセージとブランチ名を提案 |
 | [pr](pr/) | PR 本文をマークダウン形式で提案 |
+| [plan-creator](plan-creator/) | 実装計画の作成と管理 |
 
 ## Setup
 
@@ -47,6 +48,8 @@ agent-skills/
 ├── commit-monorepo/
 │   └── SKILL.md
 ├── pr/
+│   └── SKILL.md
+├── plan-creator/
 │   └── SKILL.md
 └── .samples/
     └── ...


### PR DESCRIPTION
  ## Summary

  README.md に `plan-creator`
  スキルが記載されていなかったため、Available Skills
  テーブルと Project Structure に追加しました。

  ## Changes

  - Available Skills テーブルに `plan-creator` スキルを追加
  - Project Structure に `plan-creator/` ディレクトリを追加

  ## Checklist

  - [x] README.md のメンテナンス