### PR TITLE
docs: add context availability check to commit and pr skills

### DIFF
--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -5,13 +5,23 @@ description: Suggest commit messages and branch names for monorepo projects
 
 ## Workflow
 
-### 1. Check Changes
-```bash
-git diff HEAD
-git status --short
-git branch --show-current
-pwd
-```
+### 1. Check Context
+
+**IMPORTANT: Do NOT run any git commands yet.**
+
+First, check if sufficient context is already available in the conversation (changed files, current branch, staged changes, or current directory).
+
+**If context IS available:**
+1. Present what you know (files changed, current branch, staged files, current directory)
+2. Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
+3. Wait for user confirmation
+4. If user responds with "OK" or confirmation, **skip directly to Step 2**
+
+**If context is NOT available, run these git commands:**
+- `git diff HEAD`
+- `git status --short`
+- `git branch --show-current`
+- `pwd`
 
 ### 2. Determine Scope
 Get the current directory name to use as the scope:

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -5,12 +5,22 @@ description: Suggest commit messages and branch names
 
 ## Workflow
 
-### 1. Check Changes
-```bash
-git diff HEAD
-git status --short
-git branch --show-current
-```
+### 1. Check Context
+
+**IMPORTANT: Do NOT run any git commands yet.**
+
+First, check if sufficient context is already available in the conversation (changed files, current branch, or staged changes).
+
+**If context IS available:**
+1. Present what you know (files changed, current branch, staged files)
+2. Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
+3. Wait for user confirmation
+4. If user responds with "OK" or confirmation, **skip directly to Step 2**
+
+**If context is NOT available, run these git commands:**
+- `git diff HEAD`
+- `git status --short`
+- `git branch --show-current`
 
 ### 2. Branch Name (only if on `main` or `develop*`)
 **Format:** `<type>/<description>`

--- a/pr/SKILL.md
+++ b/pr/SKILL.md
@@ -7,17 +7,20 @@ description: Suggest PR body in markdown format
 
 ### 1. Check Context
 
-**Before gathering context, check if sufficient context is already available** (e.g., branch name, commit history, or changed files are already known from the conversation).
+**IMPORTANT: Do NOT run any git commands yet.**
 
-- If context is already available:
-  - Present what you know (branch name, commits, files changed)
-  - Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
-  - If the user responds with "OK" or confirmation, skip to Step 2
+First, check if sufficient context is already available in the conversation (branch name, commit history, or changed files).
 
-- If context is NOT available, gather it:
-  - Current branch name
-  - Commit history (git log --oneline main..HEAD)
-  - Files changed (git diff --name-status main)
+**If context IS available:**
+1. Present what you know (branch name, commits, files changed)
+2. Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
+3. Wait for user confirmation
+4. If user responds with "OK" or confirmation, **skip directly to Step 2**
+
+**If context is NOT available, run these git commands:**
+- `git branch --show-current`
+- `git log --oneline main..HEAD`
+- `git diff --name-status main`
 
 ### 2. PR Body Format
 Output in a markdown code block.


### PR DESCRIPTION
## Summary

Add context availability check to commit, commit-monorepo, and pr skills to avoid redundant git commands when sufficient context is already available in the conversation.

## Changes

- Update \`commit/SKILL.md\` with context check instructions
- Update \`commit-monorepo/SKILL.md\` with context check instructions  
- Update \`pr/SKILL.md\` with context check instructions

## Details

Each skill now follows this workflow:
1. Check if context (branch name, commits, changed files) is already available
2. If available, present it to user and ask for confirmation
3. If user confirms with "OK", skip to Step 2
4. Only run git commands if context is not available

## Checklist

- [x] commit/SKILL.md updated
- [x] commit-monorepo/SKILL.md updated
- [x] pr/SKILL.md updated