### PR TITLE
docs: add context availability check workflow to skills

### DIFF
--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -12,16 +12,28 @@ description: Suggest commit messages and branch names for monorepo projects
 First, check if sufficient context is already available in the conversation (changed files, current branch, staged changes, or current directory).
 
 **If context IS available:**
-1. Present what you know (files changed, current branch, staged files, current directory)
-2. Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
+1. Show the branch name and draft commit message
+2. Ask the user: "Is this information sufficient? If yes, I'll proceed."
 3. Wait for user confirmation
-4. If user responds with "OK" or confirmation, **skip directly to Step 2**
+4. If user responds with "OK" or confirmation, **output the final result**
+5. If user needs more info (NOT "OK"), run these git commands:
+   - `git diff HEAD`
+   - `git status --short`
+   - `pwd`
 
-**If context is NOT available, run these git commands:**
-- `git diff HEAD`
-- `git status --short`
+**Preview format:**
+```
+Context is available.
+Branch: <branch-name>
+
+Proposed commit message:
+<type>(<scope>): <title>
+
+Is this sufficient? Reply "OK" to confirm this commit message.
+```
+
+**If context is NOT available, run this git command:**
 - `git branch --show-current`
-- `pwd`
 
 ### 2. Determine Scope
 Get the current directory name to use as the scope:

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -12,14 +12,26 @@ description: Suggest commit messages and branch names
 First, check if sufficient context is already available in the conversation (changed files, current branch, or staged changes).
 
 **If context IS available:**
-1. Present what you know (files changed, current branch, staged files)
-2. Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
+1. Show the branch name and draft commit message
+2. Ask the user: "Is this information sufficient? If yes, I'll proceed."
 3. Wait for user confirmation
-4. If user responds with "OK" or confirmation, **skip directly to Step 2**
+4. If user responds with "OK" or confirmation, **output the final result**
+5. If user needs more info (NOT "OK"), run these git commands:
+   - `git diff HEAD`
+   - `git status --short`
 
-**If context is NOT available, run these git commands:**
-- `git diff HEAD`
-- `git status --short`
+**Preview format:**
+```
+Context is available.
+Branch: <branch-name>
+
+Proposed commit message:
+<type>: <title>
+
+Is this sufficient? Reply "OK" to confirm this commit message.
+```
+
+**If context is NOT available, run this git command:**
 - `git branch --show-current`
 
 ### 2. Branch Name (only if on `main` or `develop*`)

--- a/pr/SKILL.md
+++ b/pr/SKILL.md
@@ -12,15 +12,24 @@ description: Suggest PR body in markdown format
 First, check if sufficient context is already available in the conversation (branch name, commit history, or changed files).
 
 **If context IS available:**
-1. Present what you know (branch name, commits, files changed)
+1. Show the branch name only
 2. Ask the user: "Is this information sufficient? If yes, I'll proceed to Step 2."
 3. Wait for user confirmation
 4. If user responds with "OK" or confirmation, **skip directly to Step 2**
+5. If user needs more info (NOT "OK"), run these git commands:
+   - `git log --oneline main..HEAD`
+   - `git diff --name-status main`
 
-**If context is NOT available, run these git commands:**
+**Preview format:**
+```
+Context is available.
+Branch: <branch-name>
+
+Is this sufficient? Reply "OK" and I'll proceed to create the PR body.
+```
+
+**If context is NOT available, run this git command:**
 - `git branch --show-current`
-- `git log --oneline main..HEAD`
-- `git diff --name-status main`
 
 ### 2. PR Body Format
 Output in a markdown code block.


### PR DESCRIPTION
## Summary

Updates the workflow documentation in commit, commit-monorepo, and pr skills to include a context availability check at the start. This standardizes how skills handle pre-existing context versus running git commands unnecessarily.

## Changes

- Add context availability check workflow to `commit/SKILL.md`
- Add context availability check workflow to `commit-monorepo/SKILL.md`
- Add context availability check workflow to `pr/SKILL.md`
- Define preview format for showing branch and draft message
- Specify conditional git command execution based on context availability

## Checklist

- [x] Documentation updated for all three skills
- [x] Workflow format is consistent across skills
- [x] Preview format includes branch name and draft message