### PR TITLE
refactor: separate branch creation from commit skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ AI エージェント用のカスタムスキル集です。
 
 | Skill | Description |
 |-------|-------------|
-| [commit](commit/) | コミットメッセージとブランチ名を提案 |
-| [commit-monorepo](commit-monorepo/) | モノレポ向けのコミットメッセージとブランチ名を提案 |
+| [commit](commit/) | コミットメッセージを提案 |
+| [commit-monorepo](commit-monorepo/) | モノレポ向けのコミットメッセージを提案 |
+| [branch](branch/) | ブランチ名を提案し、ブランチを作成 |
 | [pr](pr/) | PR 本文をマークダウン形式で提案 |
 | [plan-creator](plan-creator/) | 実装計画の作成と管理 |
 | [skill-creator](skill-creator/) | SKILL.md ファイルの作成と改善 |
@@ -47,6 +48,8 @@ agent-skills/
 ├── commit/
 │   └── SKILL.md
 ├── commit-monorepo/
+│   └── SKILL.md
+├── branch/
 │   └── SKILL.md
 ├── pr/
 │   └── SKILL.md

--- a/branch/SKILL.md
+++ b/branch/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: branch
+description: Suggest branch names and create branches
+---
+
+## Workflow
+
+### 1. Check Current Branch
+
+Run this git command to check the current branch:
+- `git branch --show-current`
+
+### 2. Determine Scope (for monorepo)
+
+If the project appears to be a monorepo (multiple packages/apps), get the current directory name:
+```bash
+basename "$(pwd)"
+```
+
+### 3. Branch Name
+
+**Standard format:** `<type>/<description>`
+
+**Monorepo format:** `<type>/<scope>-<description>` or `<type>/<scope>/<description>`
+
+**Types:** `feature/` `fix/` `docs/` `refactor/` `test/` `chore/`
+
+**Rules:**
+- Lowercase with hyphens (e.g., `feature/add-user-auth`)
+- 3-5 words, concise
+- Include issue# if applicable (e.g., `fix/issue-123-login-error`)
+- For monorepo: include scope as prefix (e.g., `feature/auth-add-oauth`)
+
+### 4. Output Format
+
+**On main/develop* branch:**
+```
+## Recommended Branch
+
+git checkout -b <type>/<description>
+```
+
+**On other branches:**
+```
+## Current Status
+Already on branch: <branch-name>
+
+## Suggested Branch (if needed)
+git checkout -b <type>/<description>
+```
+
+### 5. User Confirmation
+
+If the user says "OK" after the suggestion, execute the following automatically:
+
+**On main/develop* branch:**
+```bash
+git switch -c <type>/<description>
+```
+
+**On other branches:**
+Ask the user whether to create a new branch from current branch or checkout to main/develop first.

--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -1,58 +1,24 @@
 ---
 name: commit-monorepo
-description: Suggest commit messages and branch names for monorepo projects
+description: Suggest commit messages for monorepo projects
 ---
 
 ## Workflow
 
-### 1. Check Context
+### 1. Check Current Branch
 
-**IMPORTANT: Do NOT run any git commands yet.**
-
-First, check if sufficient context is already available in the conversation (changed files, current branch, staged changes, or current directory).
-
-**If context IS available:**
-1. Show the branch name and draft commit message
-2. Ask the user: "Is this information sufficient? If yes, I'll proceed."
-3. Wait for user confirmation
-4. If user responds with "OK" or confirmation, **output the final result**
-5. If user needs more info (NOT "OK"), run these git commands:
-   - `git diff HEAD`
-   - `git status --short`
-   - `pwd`
-
-**Preview format:**
-```
-Context is available.
-Branch: <branch-name>
-
-Proposed commit message:
-<type>(<scope>): <title>
-
-Is this sufficient? Reply "OK" to confirm this commit message.
-```
-
-**If context is NOT available, run this git command:**
+Run this git command to check the current branch:
 - `git branch --show-current`
 
 ### 2. Determine Scope
+
 Get the current directory name to use as the scope:
 ```bash
 basename "$(pwd)"
 ```
 
-### 3. Branch Name (only if on `main` or `develop*`)
-**Format:** `<type>/<$dir-prefix>-<description>`
+### 3. Commit Message Format
 
-**Types:** `feature/` `fix/` `docs/` `refactor/` `test/` `chore/`
-
-**Rules:**
-- Lowercase with hyphens (e.g., `feature/auth-add-user-auth`)
-- 3-5 words, concise
-- Include directory name as prefix after the type (e.g., `feature/auth-`)
-- Include issue# if applicable (e.g., `fix/api-issue-123-login-error`)
-
-### 4. Commit Message Format
 **Title (≤60 chars):**
 - Imperative mood ("add" not "adds")
 - Lowercase (except symbols/acronyms)
@@ -62,41 +28,26 @@ basename "$(pwd)"
 - Explain *what* and *why*
 - Imperative mood
 
-### 5. Output Format
+### 4. Output Format
 
-**On main/develop* branch:**
 ```
-## Recommended Branch
-git checkout -b <type>/<scope>/<description>
-
 ## Commit Message
+
 git commit -m "<type>(<scope>): <title>" -m "<body>"
 ```
 
-**On other branches:**
-```
-## Commit Message
-git commit -m "<type>(<scope>): <title>" -m "<body>"
-```
+### 5. Staging
 
-### 6. Staging
 ```bash
 git add <file>
 # or use `git hunks` for specific changes
 git commit -m "type(scope): title" -m "body"
 ```
 
-### 7. User Confirmation
+### 6. User Confirmation
+
 If the user says "OK" after the suggestion, execute the following automatically:
 
-**On main/develop* branch:**
-```bash
-git switch -c <type>/<$dir-prefix>-<description>
-git add .  # only if files are not staged
-git commit -m "<type>(<scope>): <title>" -m "<body>"
-```
-
-**On other branches:**
 ```bash
 git add .  # only if files are not staged
 git commit -m "<type>(<scope>): <title>" -m "<body>"
@@ -105,9 +56,7 @@ git commit -m "<type>(<scope>): <title>" -m "<body>"
 ## Examples
 
 **If in `/projects/monorepo/packages/auth`:**
-- Branch: `feature/auth-add-oauth-support`
 - Commit: `feat(auth): add OAuth2 support for Google login`
 
 **If in `/projects/monorepo/apps/web`:**
-- Branch: `fix/web-resolve-hydration-error`
 - Commit: `fix(web): resolve React hydration mismatch on SSR`

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -1,50 +1,17 @@
 ---
 name: commit
-description: Suggest commit messages and branch names
+description: Suggest commit messages
 ---
 
 ## Workflow
 
-### 1. Check Context
+### 1. Check Current Branch
 
-**IMPORTANT: Do NOT run any git commands yet.**
-
-First, check if sufficient context is already available in the conversation (changed files, current branch, or staged changes).
-
-**If context IS available:**
-1. Show the branch name and draft commit message
-2. Ask the user: "Is this information sufficient? If yes, I'll proceed."
-3. Wait for user confirmation
-4. If user responds with "OK" or confirmation, **output the final result**
-5. If user needs more info (NOT "OK"), run these git commands:
-   - `git diff HEAD`
-   - `git status --short`
-
-**Preview format:**
-```
-Context is available.
-Branch: <branch-name>
-
-Proposed commit message:
-<type>: <title>
-
-Is this sufficient? Reply "OK" to confirm this commit message.
-```
-
-**If context is NOT available, run this git command:**
+Run this git command to check the current branch:
 - `git branch --show-current`
 
-### 2. Branch Name (only if on `main` or `develop*`)
-**Format:** `<type>/<description>`
+### 2. Commit Message Format
 
-**Types:** `feature/` `fix/` `docs/` `refactor/` `test/` `chore/`
-
-**Rules:**
-- Lowercase with hyphens (e.g., `feature/add-user-auth`)
-- 3-5 words, concise
-- Include issue# if applicable (e.g., `fix/issue-123-login-error`)
-
-### 3. Commit Message Format
 **Title (≤60 chars):**
 - Imperative mood ("add" not "adds")
 - Lowercase (except symbols/acronyms)
@@ -54,41 +21,26 @@ Is this sufficient? Reply "OK" to confirm this commit message.
 - Explain *what* and *why*
 - Imperative mood
 
-### 4. Output Format
+### 3. Output Format
 
-**On main/develop* branch:**
 ```
-## Recommended Branch
-git checkout -b <type>/<description>
-
 ## Commit Message
+
 git commit -m "<prefix>: <title>" -m "<body>"
 ```
 
-**On other branches:**
-```
-## Commit Message
-git commit -m "<prefix>: <title>" -m "<body>"
-```
+### 4. Staging
 
-### 5. Staging
 ```bash
 git add <file>
 # or use `git hunks` for specific changes
 git commit -m "title" -m "body"
 ```
 
-### 6. User Confirmation
+### 5. User Confirmation
+
 If the user says "OK" after the suggestion, execute the following automatically:
 
-**On main/develop* branch:**
-```bash
-git switch -c <type>/<description>
-git add .  # only if files are not staged
-git commit -m "<prefix>: <title>" -m "<body>"
-```
-
-**On other branches:**
 ```bash
 git add .  # only if files are not staged
 git commit -m "<prefix>: <title>" -m "<body>"


### PR DESCRIPTION
## Summary

`commit` および `commit-monorepo` スキルからブランチ作成機能を分離し、独立した `branch` スキルを新規作成しました。これにより、各スキルの責任が明確になり、必要に応じてブランチ作成を実行・スキップできる柔軟性が向上します。

## Changes

- **新規**: `branch` スキルを作成（ブランチ名提案と作成を専門に行う）
- **修正**: `commit` スキルからブランチ作成関連のステップを削除
- **修正**: `commit-monorepo` スキルからブランチ作成関連のステップを削除
- **修正**: README のスキル説明と構成を更新

## Details

- `commit` / `commit-monorepo` スキルはコミットメッセージ生成に集中
- ブランチ作成が必要な場合は `/branch` スキルを個別に使用可能
- 不要な "Do NOT run any git commands yet" 警告を削除してシンプル化

## Checklist

- [x] `branch` スキルを新規作成
- [x] `commit` スキルからブランチ作成関連のステップを削除
- [x] `commit-monorepo` スキルからブランチ作成関連のステップを削除
- [x] README の更新

Closes #22