### PR TITLE
docs: translate skill files to Japanese

### DIFF
--- a/branch/SKILL.md
+++ b/branch/SKILL.md
@@ -1,62 +1,62 @@
 ---
 name: branch
-description: Suggest branch names and create branches
+description: ブランチ名の提案と作成ワークフロー
 ---
 
-## Workflow
+## ワークフロー
 
-### 1. Check Current Branch
+### 1. 現在のブランチを確認
 
-Run this git command to check the current branch:
+現在のブランチを確認するためのgitコマンドを実行:
 - `git branch --show-current`
 
-### 2. Determine Scope (for monorepo)
+### 2. スコープの決定（モノレポの場合）
 
-If the project appears to be a monorepo (multiple packages/apps), get the current directory name:
+プロジェクトがモノレポ（複数パッケージ/アプリ）の場合、現在のディレクトリ名を取得:
 ```bash
 basename "$(pwd)"
 ```
 
-### 3. Branch Name
+### 3. ブランチ名
 
-**Standard format:** `<type>/<description>`
+**標準形式:** `<type>/<description>`
 
-**Monorepo format:** `<type>/<scope>-<description>` or `<type>/<scope>/<description>`
+**モノレポ形式:** `<type>/<scope>-<description>` または `<type>/<scope>/<description>`
 
 **Types:** `feature/` `fix/` `docs/` `refactor/` `test/` `chore/`
 
-**Rules:**
-- Lowercase with hyphens (e.g., `feature/add-user-auth`)
-- 3-5 words, concise
-- Include issue# if applicable (e.g., `fix/issue-123-login-error`)
-- For monorepo: include scope as prefix (e.g., `feature/auth-add-oauth`)
+**ルール:**
+- 小文字でハイフン区切り（例: `feature/add-user-auth`）
+- 3〜5語で簡潔に
+- issue番号がある場合は含める（例: `fix/issue-123-login-error`）
+- モノレポの場合: スコープをプレフィックスとして含める（例: `feature/auth-add-oauth`）
 
-### 4. Output Format
+### 4. 出力形式
 
-**On main/develop* branch:**
+**main/develop*ブランチの場合:**
 ```
-## Recommended Branch
+## 推奨ブランチ
 
 git checkout -b <type>/<description>
 ```
 
-**On other branches:**
+**その他のブランチの場合:**
 ```
-## Current Status
-Already on branch: <branch-name>
+## 現在の状態
+現在のブランチ: <branch-name>
 
-## Suggested Branch (if needed)
+## 推奨ブランチ（必要な場合）
 git checkout -b <type>/<description>
 ```
 
-### 5. User Confirmation
+### 5. ユーザー確認
 
-If the user says "OK" after the suggestion, execute the following automatically:
+提案後にユーザーが「OK」と言った場合、以下を自動実行:
 
-**On main/develop* branch:**
+**main/develop*ブランチの場合:**
 ```bash
 git switch -c <type>/<description>
 ```
 
-**On other branches:**
-Ask the user whether to create a new branch from current branch or checkout to main/develop first.
+**その他のブランチの場合:**
+現在のブランチから新しいブランチを作成するか、先にmain/developにチェックアウトするかをユーザーに確認。

--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -1,62 +1,62 @@
 ---
 name: commit-monorepo
-description: Suggest commit messages for monorepo projects
+description: モノレプロジェクト向けコミットメッセージの提案ワークフロー
 ---
 
-## Workflow
+## ワークフロー
 
-### 1. Check Current Branch
+### 1. 現在のブランチを確認
 
-Run this git command to check the current branch:
+現在のブランチを確認するためのgitコマンドを実行:
 - `git branch --show-current`
 
-### 2. Determine Scope
+### 2. スコープの決定
 
-Get the current directory name to use as the scope:
+スコープとして使用する現在のディレクトリ名を取得:
 ```bash
 basename "$(pwd)"
 ```
 
-### 3. Commit Message Format
+### 3. コミットメッセージ形式
 
-**Title (≤60 chars):**
-- Imperative mood ("add" not "adds")
-- Lowercase (except symbols/acronyms)
-- Prefix with scope: `feat(scope):` `fix(scope):` `docs(scope):` `style(scope):` `refactor(scope):` `test(scope):` `chore(scope):`
+**タイトル（≤60文字）:**
+- 命令形（"add"而非"adds"）
+- 小文字（記号・頭字語を除く）
+- スコープ付きプレフィックス: `feat(scope):` `fix(scope):` `docs(scope):` `style(scope):` `refactor(scope):` `test(scope):` `chore(scope):`
 
-**Body:**
-- Explain *what* and *why*
-- Imperative mood
+**本文:**
+- *何を* および *なぜ* を説明
+- 命令形
 
-### 4. Output Format
+### 4. 出力形式
 
 ```
-## Commit Message
+## コミットメッセージ
 
 git commit -m "<type>(<scope>): <title>" -m "<body>"
 ```
 
-### 5. Staging
+### 5. ステージング
 
 ```bash
 git add <file>
-# or use `git hunks` for specific changes
+# または特定の変更には `git hunks` を使用
 git commit -m "type(scope): title" -m "body"
 ```
 
-### 6. User Confirmation
+### 6. ユーザー確認
 
-If the user says "OK" after the suggestion, execute the following automatically:
+提案後にユーザーが「OK」と言った場合、以下を自動実行:
 
 ```bash
-git add .  # only if files are not staged
+git add .  # ファイルがステージされていない場合のみ
 git commit -m "<type>(<scope>): <title>" -m "<body>"
 ```
 
-## Examples
+## 例
 
-**If in `/projects/monorepo/packages/auth`:**
-- Commit: `feat(auth): add OAuth2 support for Google login`
+**`/projects/monorepo/packages/auth` にいる場合:**
+- コミット: `feat(auth): add OAuth2 support for Google login`
 
-**If in `/projects/monorepo/apps/web`:**
-- Commit: `fix(web): resolve React hydration mismatch on SSR`
+**`/projects/monorepo/apps/web` にいる場合:**
+- コミット: `fix(web): resolve React hydration mismatch on SSR`

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -1,47 +1,47 @@
 ---
 name: commit
-description: Suggest commit messages
+description: コミットメッセージの提案ワークフロー
 ---
 
-## Workflow
+## ワークフロー
 
-### 1. Check Current Branch
+### 1. 現在のブランチを確認
 
-Run this git command to check the current branch:
+現在のブランチを確認するためのgitコマンドを実行:
 - `git branch --show-current`
 
-### 2. Commit Message Format
+### 2. コミットメッセージ形式
 
-**Title (≤60 chars):**
-- Imperative mood ("add" not "adds")
-- Lowercase (except symbols/acronyms)
-- Prefix: `feat:` `fix:` `docs:` `style:` `refactor:` `test:` `chore:`
+**タイトル（≤60文字）:**
+- 命令形（"add"而非"adds"）
+- 小文字（記号・頭字語を除く）
+- プレフィックス: `feat:` `fix:` `docs:` `style:` `refactor:` `test:` `chore:`
 
-**Body:**
-- Explain *what* and *why*
-- Imperative mood
+**本文:**
+- *何を* および *なぜ* を説明
+- 命令形
 
-### 3. Output Format
+### 3. 出力形式
 
 ```
-## Commit Message
+## コミットメッセージ
 
 git commit -m "<prefix>: <title>" -m "<body>"
 ```
 
-### 4. Staging
+### 4. ステージング
 
 ```bash
 git add <file>
-# or use `git hunks` for specific changes
+# または特定の変更には `git hunks` を使用
 git commit -m "title" -m "body"
 ```
 
-### 5. User Confirmation
+### 5. ユーザー確認
 
-If the user says "OK" after the suggestion, execute the following automatically:
+提案後にユーザーが「OK」と言った場合、以下を自動実行:
 
 ```bash
-git add .  # only if files are not staged
+git add .  # ファイルがステージされていない場合のみ
 git commit -m "<prefix>: <title>" -m "<body>"
 ```

--- a/plan-creator/SKILL.md
+++ b/plan-creator/SKILL.md
@@ -1,43 +1,46 @@
 ---
 name: plan-creator
-description: Skills related to plan files generated within the plans/ directory
+description: plans/ディレクトリ内に生成されるプラン関連のスキル
 ---
 
-## Workflow
+## ワークフロー
 
-### 1. Check Existing Plans
+### 1. 既存のプランを確認
+
 ```bash
 ls plans/ 2>/dev/null || echo "Directory does not exist"
 ls plans/ | grep "{project-name}_{task-description}" | sort -V | tail -1
 ```
 
-### 2. Generate Filename
-**Format:** `plans/{YYYY-MM-DD}_{project-name}_{task-description}_v{version}.md`
+### 2. ファイル名を生成
 
-**Components:**
-- `YYYY-MM-DD`: Current date (ISO 8601)
-- `project-name`: Directory name under `apps/` or `packages/` in kebab-case
-- `task-description`: 3-5 words summarizing the task in kebab-case
-- `version`: Integer starting from v1, increment for updates
+**形式:** `plans/{YYYY-MM-DD}_{project-name}_{task-description}_v{version}.md`
 
-### 3. Naming Rules
-- **Flat structure**: All files directly under `plans/`, no subdirectories
-- **No spaces**: Use hyphens `-` for word separation
-- **Version increment**: Always increment version when updating, keep history
+**構成要素:**
+- `YYYY-MM-DD`: 現在の日付（ISO 8601形式）
+- `project-name`: `apps/` または `packages/` 配下のディレクトリ名をkebab-caseで
+- `task-description`: タスクを要約した3〜5語をkebab-caseで
+- `version`: v1から始まる整数、更新時にインクリメント
 
-### 4. Special Cases
+### 3. 命名ルール
 
-**Cross-project tasks:**
-- Primary project first: `2024-01-15_web-shop_cross-mobile-sync_v1.md`
-- Or use `cross`: `2024-01-15_cross_auth-system-unification_v2.md`
+- **フラット構造**: すべてのファイルを `plans/` 直下に配置、サブディレクトリなし
+- **スペースなし**: 単語区切りにはハイフン `-` を使用
+- **バージョンインクリメント**: 更新時は必ずバージョンをインクリメントし、履歴を保持
 
-**Infrastructure/Tooling:**
-- Use `infra-` or `repo-` prefix: `2024-01-15_infra-terraform_eks-migration_v1.md`
+### 4. 特別なケース
 
-**Research/Investigation:**
-- Include `research`: `2024-01-15_api-gateway_research-grpc-migration_v1.md`
+**クロスプロジェクトタスク:**
+- 主要プロジェクトを先に: `2024-01-15_web-shop_cross-mobile-sync_v1.md`
+- または `cross` を使用: `2024-01-15_cross_auth-system-unification_v2.md`
 
-### 5. File Content Template
+**インフラストラクチャ/ツール:**
+- `infra-` または `repo-` プレフィックスを使用: `2024-01-15_infra-terraform_eks-migration_v1.md`
+
+**調査/リサーチ:**
+- `research` を含める: `2024-01-15_api-gateway_research-grpc-migration_v1.md`
+
+### 5. ファイル内容のテンプレート
 
 ```yaml
 ---
@@ -49,16 +52,16 @@ status: draft | ready | archived
 ---
 ```
 
-### 6. Output Format
+### 6. 出力形式
 
-When generating a plan file, output:
+プランを生成する際は以下を出力:
 
 ```
-## Plan File
+## プラン
 
-**Path:** `plans/YYYY-MM-DD_project-name_task-description_v1.md`
+**パス:** `plans/YYYY-MM-DD_project-name_task-description_v1.md`
 
-**Content:**
+**内容:**
 ```yaml
 ---
 created: YYYY-MM-DD
@@ -68,19 +71,19 @@ previous_version: null
 status: draft
 ---
 
-[Plan content here]
+[プラン内容をここに記述]
 ```
 ```
 
-### 7. Search Patterns
+### 7. 検索パターン
 
 ```bash
-# Specific project plans
+# 特定のプロジェクトのプラン
 ls plans | grep "_web-shop_"
 
-# Date range
+# 日付範囲
 ls plans | grep "^2024-01-15"
 
-# Latest versions only
+# 最新バージョンのみ
 ls plans | awk -F'_v' '{print $1}' | sort | uniq
 ```

--- a/pr/SKILL.md
+++ b/pr/SKILL.md
@@ -1,75 +1,75 @@
 ---
 name: pr
-description: Suggest PR body in markdown format
+description: PR本文の作成ワークフロー
 ---
 
-## Workflow
+## ワークフロー
 
-### 1. PR Body Structure
+### 1. PR本文の構造
 
-Understand the output format first.
+まず出力形式を理解する。
 
-**Structure:**
+**構造:**
 ```markdown
 ## Summary
 
-Brief description of what this PR does.
+このPRで行う変更の簡潔な説明。
 
 ## Changes
 
-- Change 1
-- Change 2
+- 変更1
+- 変更2
 
 ## Details
 
-Optional: technical details, implementation notes, etc.
+任意: 技術的な詳細、実装メモなど
 
 ## Checklist
 
-- [ ] Item 1
-- [ ] Item 2
+- [ ] 項目1
+- [ ] 項目2
 ```
 
-**Guidelines:**
-- Use clear, concise language
-- Focus on *what* and *why*
-- Keep summary under 2-3 sentences
-- Checklist should reflect actual changes
+**ガイドライン:**
+- 明確で簡潔な言葉を使用
+- *何を* および *なぜ* に焦点を当てる
+- サマリーは2〜3文以内に収める
+- チェックリストは実際の変更を反映させる
 
-### 2. Check Context
+### 2. コンテキストを確認
 
-**IMPORTANT: Do NOT run any git commands yet.**
+**重要: まだgitコマンドは実行しない。**
 
-First, check if sufficient context is already available in the conversation (branch name, commit history, or changed files).
+まず、会話内に十分なコンテキスト（ブランチ名、コミット履歴、変更ファイル）が既に利用可能か確認する。
 
-**If context IS available:**
-1. Show the branch name only
-2. Ask the user: "Is this sufficient? Reply \"OK\" and I'll proceed to create the PR body."
-3. Wait for user confirmation
-4. If user responds with "OK" or confirmation, **skip directly to Step 3** and draft the PR body immediately
-5. If user needs more info (NOT "OK"), run these git commands:
+**コンテキストが利用可能な場合:**
+1. ブランチ名のみを表示
+2. ユーザーに尋ねる: "この情報で十分ですか？ \"OK\" と返信いただければPR本文の作成に進みます。"
+3. ユーザー確認を待つ
+4. ユーザーが「OK」または確認を返信した場合、**ステップ3に直接スキップ**して即座にPR本文を作成
+5. ユーザーがより多くの情報を必要とする場合（「OK」以外）:
    - `git log --oneline main..HEAD`
    - `git diff --name-status main`
 
-**Preview format:**
+**プレビュー形式:**
 ```
-Context is available.
-Branch: <branch-name>
+コンテキストが利用可能です。
+ブランチ: <branch-name>
 
-Is this sufficient? Reply "OK" and I'll proceed to create the PR body.
+この情報で十分ですか？ "OK" と返信いただければPR本文の作成に進みます。
 ```
 
-**If context is NOT available:**
-Immediately run these git commands to gather context (no user confirmation needed):
+**コンテキストが利用できない場合:**
+即座に以下のgitコマンドを実行してコンテキストを収集（ユーザー確認不要）:
 - `git branch --show-current`
 - `git log --oneline main..HEAD`
 - `git diff --name-status main`
 
-### 3. Draft PR Body
+### 3. PR本文の作成
 
-Create the PR body following the structure from Step 1, using the context gathered in Step 2.
+ステップ1の構造に従い、ステップ2で収集したコンテキストを使用してPR本文を作成。
 
-**Wrap the entire PR body in a markdown code block:**
+**PR本文全体をマークダウンのコードブロックで囲む:**
 
 ~~~
 ```markdown

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -1,152 +1,152 @@
 ---
 name: skill-creator
 description: >
-  Use this skill when creating or improving a SKILL.md file.
-  Activate when told "create a skill", "write a SKILL.md", or "turn this workflow into a skill",
-  or when asked to review or improve an existing skill.
+  SKILL.mdファイルの作成や改善時に使用。
+  "create a skill"、"write a SKILL.md"、"turn this workflow into a skill" と言われた時、
+  または既存のスキルのレビューや改善を求められた時に起動。
 ---
 
-# Overview
+# 概要
 
-This skill is for designing, creating, and improving other skills (SKILL.md files).
-Identify which stage the user is at and begin assistance from the appropriate step.
-
----
-
-# When to Use This Skill
-
-- When told "I want to create a skill" or "please write a SKILL.md"
-- When told "turn this workflow into a skill" (extract the workflow from conversation history)
-- When asked to review or improve an existing SKILL.md
+このスキルは他のスキル（SKILL.mdファイル）の設計、作成、改善のためのもの。
+ユーザーがどの段階にいるかを特定し、適切なステップから支援を開始する。
 
 ---
 
-# What the Agent Does
+# このスキルを使用するタイミング
 
-1. Listen to the user's intent and goals
-2. Generate a draft SKILL.md following the "Creation Steps" below
-3. Self-verify using the quality checklist
-4. Output the result as a file
+- "I want to create a skill" または "please write a SKILL.md" と言われた時
+- "turn this workflow into a skill" と言われた時（会話履歴からワークフローを抽出）
+- 既存のSKILL.mdのレビューや改善を求められた時
 
 ---
 
-# Directory Structure
+# Agentが行うこと
 
-Create skills with the following structure. Only SKILL.md is required; add others as needed.
+1. ユーザーの意図と目標を聞く
+2. 以下の「作成ステップ」に従ってSKILL.mdのドラフトを生成
+3. 品質チェックリストを使用して自己検証
+4. 結果をファイルとして出力
+
+---
+
+# ディレクトリ構造
+
+以下の構造でスキルを作成。SKILL.mdのみ必須、その他は必要に応じて追加。
 
     my-skill/
-    ├── SKILL.md          # Main instruction file (required)
-    ├── reference.md      # Large specs, schemas, or glossaries (split out if content gets long)
-    ├── examples.md       # Concrete input/output examples (split out if 3+ examples)
-    └── scripts/          # Validation or transformation scripts (only if external tools are needed)
+    ├── SKILL.md          # メインの指示ファイル（必須）
+    ├── reference.md      # 大きな仕様、スキーマ、用語集（内容が長くなる場合は分割）
+    ├── examples.md       # 具体的な入出力例（例が3つ以上ある場合は分割）
+    └── scripts/          # 検証または変換スクリプト（外部ツールが必要な場合のみ）
         └── validate.py
 
-## File Split Criteria
+## ファイル分割の基準
 
-- If the main content exceeds 200 lines, move details to `reference.md`
-- If there are 3 or more input/output examples, split them into `examples.md`
-- If the process uses external APIs or libraries, place scripts under `scripts/`
+- メインコンテンツが200行を超える場合、詳細を `reference.md` に移動
+- 入出力例が3つ以上ある場合、`examples.md` に分割
+- 外部APIやライブラリを使用する場合、スクリプトを `scripts/` 配下に配置
 
 ---
 
-# SKILL.md Format
+# SKILL.mdの形式
 
 ## Front Matter
 
-Include the following at the top of the file.
+ファイルの先頭に以下を含める。
 
     ---
-    name: unique identifier for the skill (e.g., pdf-summarizer)
+    name: スキルの一意の識別子（例: pdf-summarizer）
     description: >
-      Describe what this skill does and when it should activate in 1–3 sentences.
-      Write trigger conditions specifically, such as "when told X" or "when given a Y file".
+      このスキルが何をするか、いつ起動すべきかを1〜3文で記述。
+      トリガー条件を具体的に記述（例: "when told X" または "when given a Y file"）。
     ---
 
-**Rules for `name`:**
-- Maximum 64 characters
-- Only lowercase letters, numbers, and hyphens
-- Do not use strings reserved for XML tags
-- Do not use reserved words (e.g., `anthropic`, `claude`, or other engine-specific terms)
-- Name using a verb or noun phrase (e.g., `invoice-parser`, `slide-creator`)
+**`name` のルール:**
+- 最大64文字
+- 小文字、数字、ハイフンのみ使用可能
+- XMLタグで予約されている文字列は使用不可
+- 予約語は使用不可（例: `anthropic`, `claude`、その他エンジン固有の用語）
+- 動詞または名詞句で命名（例: `invoice-parser`, `slide-creator`）
 
-**Rules for `description`:**
-- Required — do not omit
-- Maximum 1024 characters
-- Do not use strings reserved for XML tags
-- Must include both what the skill does (function) and when to use it (trigger)
-- Do not use vague language ("appropriately", "properly", "as needed")
+**`description` のルール:**
+- 必須 — 省略不可
+- 最大1024文字
+- XMLタグで予約されている文字列は使用不可
+- スキルの機能（何をするか）と使用タイミング（トリガー）の両方を含める
+- 曖昧な表現（"適切に"、"必要に応じて"など）は使用しない
 
-## Body Structure
+## 本文の構造
 
-Write the body in the following section order. Omit sections that are not needed.
+以下のセクション順序で本文を記述。不要なセクションは省略可能。
 
-1. **Overview** — Describe the problem this skill solves in 1–2 sentences
-2. **When to Use This Skill** — List trigger conditions as bullet points
-3. **What the Agent Does** — List execution steps as numbered items (avoid vague verbs)
-4. **Input and Output** — Explicitly state what is received and what is produced
-5. **Step Details** — Describe concrete operations for each step
-6. **Quality Check** — List completion criteria and verification points
-7. **References** — List paths to related files (if any)
-
----
-
-# Creation Steps
-
-## Step 1: Gather Intent
-
-If the conversation history contains a workflow, extract the following from it.
-If not, ask the user directly.
-
-- The problem or goal the skill should solve
-- Typical input (files, text, URLs, etc.)
-- Expected output (file format, content)
-- Main processing steps
-
-## Step 2: Generate Draft
-
-Using the gathered information, generate a SKILL.md following the format above.
-Follow these rules when writing steps:
-
-- Use imperative form consistently ("do X", "write Y", "ensure Z")
-- 1 step = 1 action — do not pack multiple operations into one line
-- Add warnings for steps that are prone to errors
-
-## Step 3: Quality Check
-
-Self-verify the generated SKILL.md on the following points.
-
-- [ ] Can you tell when to use it just by reading `description`?
-- [ ] Can you produce the output by following the steps from top to bottom?
-- [ ] Are there no vague expressions ("appropriately", "properly", "as needed") in the steps?
-- [ ] Are input and output explicitly stated?
-- [ ] Are there no nested code blocks? (Use indentation as an alternative for format examples)
-
-## Step 4: Output
-
-Save the completed SKILL.md to the specified path and present it to the user.
-If no path is specified, save it under `outputs/`.
+1. **概要** — このスキルが解決する問題を1〜2文で説明
+2. **このスキルを使用するタイミング** — トリガー条件を箇条書きで列挙
+3. **Agentが行うこと** — 実行ステップを番号付きリストで記述（曖昧な動詞は避ける）
+4. **入力と出力** — 受け取るものと生成するものを明確に記述
+5. **ステップの詳細** — 各ステップの具体的な操作を説明
+6. **品質チェック** — 完了基準と検証ポイントを列挙
+7. **参考資料** — 関連ファイルのパスを列挙（存在する場合）
 
 ---
 
-# Common Failure Patterns
+# 作成ステップ
 
-Avoid the following anti-patterns.
+## ステップ1: 意図の収集
 
-**Description is too abstract**
-- Bad: `This skill processes documents`
-- Good: `Activates when a PDF is provided or when told "summarize this", and generates a summary in English`
+会話履歴にワークフローが含まれる場合、そこから以下を抽出。
+含まれない場合はユーザーに直接尋ねる。
 
-**Steps are vague**
-- Bad: `Format it appropriately`
-- Good: `Use H2 (##) for headings and limit bullet point nesting to 2 levels`
+- スキルが解決すべき問題または目標
+- 典型的な入力（ファイル、テキスト、URLなど）
+- 期待される出力（ファイル形式、内容）
+- 主な処理ステップ
 
-**Nested code blocks**
-- Writing code blocks (triple backticks) inside SKILL.md will conflict with outer code blocks
-- Instead, use indentation (4 spaces) to show code examples
+## ステップ2: ドラフトの生成
+
+収集した情報を使用して、上記の形式に従ってSKILL.mdを生成。
+ステップを記述する際は以下のルールに従う:
+
+- 命令形を一貫して使用（"Xを行う"、"Yを書く"、"Zを確認する"）
+- 1ステップ = 1アクション — 複数の操作を1行に詰め込まない
+- エラーが発生しやすいステップには警告を追加
+
+## ステップ3: 品質チェック
+
+以下のポイントで生成したSKILL.mdを自己検証。
+
+- [ ] `description` を読むだけで使用タイミングがわかるか？
+- [ ] 上から下にステップを追うだけで出力を生成できるか？
+- [ ] ステップに曖昧な表現（"適切に"、"必要に応じて"など）はないか？
+- [ ] 入力と出力が明確に記述されているか？
+- [ ] ネストされたコードブロックはないか？（形式例にはインデントを使用）
+
+## ステップ4: 出力
+
+完成したSKILL.mdを指定されたパスに保存し、ユーザーに提示。
+パスが指定されていない場合は `outputs/` 配下に保存。
 
 ---
 
-# References
+# よくある失敗パターン
 
-- `examples.md` — Good and bad examples of SKILL.md (if available)
-- `reference.md` — Detailed front matter specification (if available)
+以下のアンチパターンを避ける。
+
+**説明が抽象的すぎる**
+- 悪い例: `This skill processes documents`
+- 良い例: `PDFが提供された時、または "summarize this" と言われた時に起動し、英語で要約を生成`
+
+**ステップが曖昧**
+- 悪い例: `Format it appropriately`
+- 良い例: `見出しにはH2（##）を使用し、箇条書きのネストは2レベルまでに制限`
+
+**ネストされたコードブロック**
+- SKILL.md内にコードブロック（トリプルバッククォート）を書くと、外側のコードブロックと競合する
+- 代わりに、コード例の表示にはインデント（4スペース）を使用
+
+---
+
+# 参考資料
+
+- `examples.md` — SKILL.mdの良い例と悪い例（存在する場合）
+- `reference.md` — Front Matterの詳細仕様（存在する場合）


### PR DESCRIPTION
#24

## Summary

6つのスキルファイル（SKILL.md）を英語から日本語に翻訳しました。
これにより、日本語ユーザーがスキルの内容をより理解しやすくなります。

## Changes

- `branch/SKILL.md` - ブランチ名の提案と作成ワークフローを日本語化
- `commit/SKILL.md` - コミットメッセージの提案ワークフローを日本語化
- `commit-monorepo/SKILL.md` - モノレプロジェクト向けコミットメッセージワークフローを日本語化
- `plan-creator/SKILL.md` - プラン作成スキルを日本語化
- `pr/SKILL.md` - PR本文作成ワークフローを日本語化
- `skill-creator/SKILL.md` - SKILL.md作成・改善スキルを日本語化

## Details

- Front Matterの`name`と`description`を日本語に翻訳
- ワークフローの各セクション見出しと説明文を日本語化
- gitコマンド、ファイルパス、コードブロックは翻訳対象外
- 技術用語は文脈に応じて適切に日本語表記

## Checklist

- [x] 6ファイルすべての日本語化が完了
- [x] Front Matter（name/description）を翻訳
- [x] 構造は変更せず内容のみ翻訳
- [x] gitコマンドやファイルパスは翻訳対象外

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)