### PR TITLE
refactor: translate skill descriptions from Japanese to English

### DIFF
--- a/branch/SKILL.md
+++ b/branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: branch
-description: ブランチ名の提案と作成ワークフロー
+description: Branch naming and creation workflow
 ---
 
 ## ワークフロー

--- a/commit-monorepo/SKILL.md
+++ b/commit-monorepo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-monorepo
-description: モノレプロジェクト向けコミットメッセージの提案ワークフロー
+description: Monorepo commit message suggestion workflow
 ---
 
 ## ワークフロー

--- a/commit/SKILL.md
+++ b/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: コミットメッセージの提案ワークフロー
+description: Commit message suggestion workflow
 ---
 
 ## ワークフロー

--- a/plan-creator/SKILL.md
+++ b/plan-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-creator
-description: plans/ディレクトリ内に生成されるプラン関連のスキル
+description: Plan-related skill for files generated in the plans/ directory
 ---
 
 ## ワークフロー

--- a/pr-github/SKILL.md
+++ b/pr-github/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: pr-github
 description: >
-  PR本文作成後にGitHubにPRを作成するワークフロー。
-  "PRを作成" または "GitHubにPRを作成" と言われた時、またはprスキル後にそのままPR作成を進めたい時に起動。
-  リモートブランチへのプッシュとghコマンドによるPR作成を行う。
+  Create GitHub PR after PR description is written.
+  Triggered by "create a PR" or "create a PR on GitHub", or when continuing after the pr skill.
+  Pushes to remote branch and creates PR via gh command.
 ---
 
 ## 概要

--- a/pr/SKILL.md
+++ b/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: PR本文の作成ワークフロー
+description: PR description creation workflow
 ---
 
 ## ワークフロー

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: skill-creator
 description: >
-  SKILL.mdファイルの作成や改善時に使用。
-  "create a skill"、"write a SKILL.md"、"turn this workflow into a skill" と言われた時、
-  または既存のスキルのレビューや改善を求められた時に起動。
+  Used when creating or improving SKILL.md files.
+  Triggered by "create a skill", "write a SKILL.md", "turn this workflow into a skill",
+  or when reviewing/improving existing skills.
 ---
 
 # 概要


### PR DESCRIPTION
## Summary

Closes #34

各skillのdescriptionを日本語から英語に翻訳し、トークン使用量の削減を図ります。

## Changes

- \`branch/SKILL.md\`: descriptionを「Branch naming and creation workflow」に変更
- \`commit/SKILL.md\`: descriptionを「Commit message suggestion workflow」に変更
- \`commit-monorepo/SKILL.md\`: descriptionを「Monorepo commit message suggestion workflow」に変更
- \`pr/SKILL.md\`: descriptionを「PR description creation workflow」に変更
- \`pr-github/SKILL.md\`: descriptionを英語に変更
- \`skill-creator/SKILL.md\`: descriptionを英語に変更
- \`plan-creator/SKILL.md\`: descriptionを「Plan-related skill for files generated in the plans/ directory」に変更

## Details

### 検証結果

LiteLLM Proxyを通して計測した結果、日本語descriptionの場合は約**105トークン**多く消費されることが確認されました。

| 言語 | promptトークン | 差分 |
|------|---------------|------|
| 英語 (en) | 15,533 | - |
| 日本語 (ja) | 15,638 | +105 |

## Checklist

- [ ] 各skillのdescriptionが正しく英語化されているか確認
- [ ] 機能に影響がないか確認（descriptionのみの変更）