### PR TITLE
fix(branch): change git checkout -b to git switch -c

### DIFF
--- a/branch/SKILL.md
+++ b/branch/SKILL.md
@@ -65,7 +65,7 @@ basename "$(pwd)"
 ```
 ## 推奨ブランチ
 
-git checkout -b <type>/<description>
+git switch -c <type>/<description>
 ```
 
 **その他のブランチの場合:**
@@ -74,7 +74,7 @@ git checkout -b <type>/<description>
 現在のブランチ: <branch-name>
 
 ## 推奨ブランチ（必要な場合）
-git checkout -b <type>/<description>
+git switch -c <type>/<description>
 ```
 
 ### 6. ユーザー確認


### PR DESCRIPTION
## Summary

`branch` スキル内のブランチ作成コマンドを `git checkout -b` から `git switch -c` に変更しました。`git switch` は Git 2.23 で導入されたモダンなコマンドで、ブランチ操作の意図がより明確になります。

## Changes

- `branch/SKILL.md` の出力形式セクションで `git checkout -b` を `git switch -c` に置き換え

## Checklist

- [x] SKILL.md の出力例を更新
- [x] 既存の機能に影響いない変更
