### PR TITLE
docs: add Codex skill setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,23 @@ ln -sf "$(pwd)" "$HOME/.claude/skills"
 > [!NOTE]
 > `$HOME/.claude/skills` ディレクトリが既に存在する場合は、上記コマンドをそのまま実行してください。
 
+Codex を使用する場合:
+
+```sh
+git clone git@github.com:u7chan/agent-skills.git
+cd agent-skills
+mkdir -p "$HOME/.codex"
+ln -sfn "$(pwd)" "$HOME/.codex/skills"
+```
+
+> [!NOTE]
+> `"$HOME/.codex/skills"` が既に存在する場合は、上記コマンドをそのまま実行してください。
+
 シンボリックリンクを解除する場合:
 
 ```sh
 rm "$HOME/.claude/skills"
+rm "$HOME/.codex/skills"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Issues

- N/A

## Why

`agent-skills` を Codex で使う手順が README に不足しており、セットアップ方法が Claude 前提になっていました。  
利用者がツールごとの差異で迷わないように、Codex 向けの導線を明示する必要がありました。

## Summary

README に Codex 利用時のセットアップ手順を追加しました。  
あわせて、シンボリックリンク解除手順にも Codex 用パスを追記し、導入とクリーンアップの手順を揃えました。

## Changes

- README に Codex 用セットアップ手順を追加
- `~/.codex/skills` 向けの注意書きを追加
- シンボリックリンク解除手順に `rm "$HOME/.codex/skills"` を追加

## Checklist

- [x] 変更内容がドキュメントのみであることを確認
- [x] 既存の Claude 向け手順を壊していないことを確認
- [x] Codex 向けの導入と解除の両手順を記載

## Details（任意）

- 対象コミット: `95d14fe`
- 変更ファイル: `README.md`
