### PR TITLE
refactor: rename skill-creator to my-skill-author

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI エージェント用のカスタムスキル集です。
 | [pr](pr/) | コンテキストからPR本文をマークダウン形式で提案 |
 | [pr-github](pr-github/) | PR本文作成後にGitHubにPRを作成 |
 | [plan-to-issue-skill](plan-to-issue-skill/) | 設計プラン合意後に Issue を作成 |
-| [skill-creator](skill-creator/) | SKILL.md ファイルの作成と改善 |
+| [my-skill-author](my-skill-author/) | SKILL.md ファイルの作成と改善 |
 
 ## Setup
 
@@ -68,7 +68,7 @@ agent-skills/
 │   └── SKILL.md
 ├── plan-to-issue-skill/
 │   └── SKILL.md
-├── skill-creator/
+├── my-skill-author/
 │   └── SKILL.md
 └── .samples/
     └── ...

--- a/my-skill-author/SKILL.md
+++ b/my-skill-author/SKILL.md
@@ -1,10 +1,12 @@
 ---
-name: skill-creator
+name: my-skill-author
 description: >
   Used when creating or improving SKILL.md files.
   Triggered by "create a skill", "write a SKILL.md", "turn this workflow into a skill",
   or when reviewing/improving existing skills.
 ---
+
+> **Custom Skill Active**: `agent-skills/my-skill-author/SKILL.md` が使用されています🧰
 
 # 概要
 


### PR DESCRIPTION
## 概要

Codex のビルトイン `skill-creator` と名前が衝突するため、カスタムスキルを `my-skill-author` にリネームしました。

## 変更内容

- `skill-creator/` → `my-skill-author/` ディレクトリ名変更
- SKILL.md の `name` を `my-skill-author` に更新
- カスタムスキル実行確認メッセージを追加
- README.md の参照を更新

## 確認事項

- [x] スキル名が Codex ビルトインと区別できる
- [x] README のリンクが正しく更新されている
