### PR TITLE
Add claude-to-codex skills link skill

### DIFF
--- a/claude-to-codex-skills-link/SKILL.md
+++ b/claude-to-codex-skills-link/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: claude-to-codex-skills-link
+description: >
+  Use this when asked to make Claude Code skills available to Codex by creating a
+  `.codex/skills` symlink that points to `.claude/skills`. It captures the exact
+  symlink pattern that works in this repo and avoids the relative-path mistake that
+  breaks editor discovery.
+---
+
+# Claude To Codex Skills Link
+
+## Overview
+
+Use this skill when a project already stores skills under `.claude/skills` and you want Codex to reuse them through `.codex/skills`.
+It documents the exact symlink shape that worked here, including the path-resolution gotcha.
+
+## When to Use This Skill
+
+- When asked to let Codex use existing Claude Code skills
+- When a repo already has `.claude/skills` and is missing `.codex/skills`
+- When `.codex/skills` exists but editor or tool discovery is failing
+
+## What the Agent Does
+
+1. Check whether `.claude/skills` exists.
+2. Check whether `.codex/skills` already exists and what it points to.
+3. Create or recreate `.codex` and add the symlink using the working relative path.
+4. Verify the link with `readlink` and `readlink -f`.
+5. Confirm that files under `.codex/skills/...` are reachable.
+
+## Input and Output
+
+**Input:**
+- A repository with skills under `.claude/skills`
+
+**Output:**
+- `.codex/skills` symlinked to the same skill directory
+- Verification output showing the resolved target
+
+## Step Details
+
+### Step 1: Inspect Current State
+
+Check:
+- `.claude/skills`
+- `.codex`
+- `.codex/skills`
+
+If `.codex/skills` already exists, inspect it before changing anything.
+
+### Step 2: Use the Correct Relative Symlink
+
+From the project root, create:
+
+    .codex/skills -> ../.claude/skills
+
+Important:
+- Do not use `./.claude/skills` as the symlink target from inside `.codex`.
+- `./.claude/skills` resolves to `.codex/.claude/skills`, which is wrong.
+- The working target is `../.claude/skills`.
+
+### Step 3: Preferred Command Shape
+
+Use this sequence when the repo-local `.codex` layout needs to be created or reset:
+
+    rm -rf .codex
+    mkdir .codex
+    ln -s ../.claude/skills .codex/skills
+
+If you must preserve other contents in `.codex`, replace only the `skills` entry instead of removing the whole directory.
+
+### Step 4: Verify Resolution
+
+Run:
+
+    readlink .codex/skills
+    readlink -f .codex/skills
+
+Expected shape:
+- `readlink` returns `../.claude/skills`
+- `readlink -f` resolves to the repo's real `.claude/skills` directory
+
+### Step 5: Verify Traversal
+
+List a known file through the symlinked path, for example:
+
+    ls .codex/skills
+    ls .codex/skills/<skill-name>
+
+Do not stop after only checking the symlink string.
+Confirm that the linked directory contents are actually reachable.
+
+## Quality Check
+
+- [ ] `.claude/skills` exists
+- [ ] `.codex/skills` points to `../.claude/skills`
+- [ ] `readlink -f .codex/skills` resolves to the expected real directory
+- [ ] A file inside `.codex/skills/...` can be listed successfully
+- [ ] The link shape matches the pattern known to work with editor discovery in this repo
+
+## References
+
+- `references/symlink-notes.md`

--- a/claude-to-codex-skills-link/references/symlink-notes.md
+++ b/claude-to-codex-skills-link/references/symlink-notes.md
@@ -1,0 +1,26 @@
+# Symlink Notes
+
+## Known Good Pattern
+
+For this repository layout, the working symlink is:
+
+    .codex/skills -> ../.claude/skills
+
+This matches the monorepo-level pattern:
+
+    /home/u7dev/workspace/monorepo/.codex/skills -> ../.claude/skills
+
+## Known Bad Pattern
+
+This looks plausible but is wrong:
+
+    .codex/skills -> ./.claude/skills
+
+Why it fails:
+- Symlink targets are resolved relative to the symlink location, not the repo root.
+- From `.codex/skills`, `./.claude/skills` points at `.codex/.claude/skills`.
+
+## Practical Guidance
+
+- If a user says editor discovery or VSCode tree behavior still looks wrong, compare the repo-local link against a known working parent repo link with `readlink`.
+- When in doubt, recreate `.codex/skills` using `../.claude/skills` and verify with `readlink -f`.


### PR DESCRIPTION
## Issues

- None

## Why

This repository now includes a dedicated skill for reusing project-local Claude skills from Codex through a `.codex/skills` symlink. The workflow needed to capture the exact relative target that works here and the common broken variant so future setup does not regress.

## Summary

Add a new `claude-to-codex-skills-link` skill that documents when to use the symlink workflow, the correct link target, and the verification steps. Include a reference note that contrasts the known-good and known-bad symlink patterns.

## Changes

- add `claude-to-codex-skills-link/SKILL.md` with the end-to-end symlink workflow
- add `claude-to-codex-skills-link/references/symlink-notes.md` with the verified path notes
- document both verification commands and the relative-path pitfall

## Checklist

- [x] Added the new skill documentation
- [x] Added reference notes for the symlink pattern
- [ ] Tested in a separate target repository
