### PR TITLE
docs: add github-pr-reviewer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AI エージェント用のカスタムスキル集です。
 | [bun-nonmajor-updater](bun-nonmajor-updater/) | Bun アプリの依存関係を非メジャー更新する際の安全な更新手順 |
 | [claude-to-codex-skills-link](claude-to-codex-skills-link/) | `.claude/skills` を `.codex/skills` から使えるようにリンクする |
 | [commit](commit/) | コミットメッセージを提案 |
+| [github-pr-reviewer](github-pr-reviewer/) | 指定した GitHub PR をレビューし、PR 上にコメントを投稿する |
 | [pr](pr/) | コンテキストからPR本文をマークダウン形式で提案 |
 | [pr-github](pr-github/) | PR本文作成後にGitHubにPRを作成 |
 | [plan-to-issue-skill](plan-to-issue-skill/) | 設計プラン合意後に Issue を作成 |
@@ -70,6 +71,8 @@ agent-skills/
 ├── claude-to-codex-skills-link/
 │   └── SKILL.md
 ├── commit/
+│   └── SKILL.md
+├── github-pr-reviewer/
 │   └── SKILL.md
 ├── pr/
 │   └── SKILL.md


### PR DESCRIPTION
## Issues

- N/A

## Why

README の Available Skills と Project Structure に `github-pr-reviewer` が反映されておらず、実際のスキル構成とドキュメントがずれていました。
利用可能なスキル一覧を README と同期して、参照漏れを防ぐためです。

## Summary

`github-pr-reviewer` スキルを README に追加しました。
スキル一覧の表とディレクトリ構成例の両方を更新し、実際のリポジトリ構成に揃えています。

## Changes

- `Available Skills` に `github-pr-reviewer` を追加
- `Project Structure` に `github-pr-reviewer/` を追加

## Checklist

- [x] README のスキル一覧を更新
- [x] README の Project Structure を更新
- [x] 実在するスキル構成との整合を確認
