### PR TITLE
Add npm dependency skills and simplify README sync

### DIFF
--- a/.claude/skills/skills-readme-sync/SKILL.md
+++ b/.claude/skills/skills-readme-sync/SKILL.md
@@ -3,14 +3,14 @@ name: skills-readme-sync
 description: >
   Use this when adding, renaming, removing, or materially changing skills in this
   repository and the README may need to be updated. It synchronizes the README's
-  Available Skills table and Project Structure example with the current skill set.
+  Available Skills table with the current skill set.
 ---
 
 # Skills README Sync
 
 ## 概要
 
-このスキルは、`agent-skills` リポジトリ内のスキル変更に合わせて `README.md` のスキル一覧と構成例を同期する。
+このスキルは、`agent-skills` リポジトリ内のスキル変更に合わせて `README.md` のスキル一覧を同期する。
 スキル本体だけ直して README を更新し忘れる漏れを防ぐためのもの。
 
 ## このスキルを使用するタイミング
@@ -25,8 +25,7 @@ description: >
 
 1. 変更されたスキルと現在のスキル一覧を確認する。
 2. `README.md` の `Available Skills` を現在のスキル構成に合わせて更新する。
-3. `README.md` の `Project Structure` を現在のディレクトリ構成に合わせて更新する。
-4. 差分を確認し、README 以外を不用意に変更していないことを確認する。
+3. 差分を確認し、README 以外を不用意に変更していないことを確認する。
 
 ## 入力と出力
 
@@ -46,7 +45,6 @@ description: >
 - `.claude/skills/` 配下の各スキルディレクトリ
 - 各スキルの `SKILL.md`
 - `README.md` の `Available Skills`
-- `README.md` の `Project Structure`
 
 `find . -maxdepth 4 -name SKILL.md | sort` などで実在するスキルを確認し、README の列挙漏れや古い名前を見つける。
 
@@ -60,17 +58,16 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 - README では詳細手順を書きすぎない
 - 既存の日本語トーンに合わせる
 
-### Step 3: README の2か所を同期する
+### Step 3: README の一覧を同期する
 
 更新対象:
 - `Available Skills` の表
-- `Project Structure` のツリー
 
 注意:
-- スキル追加時は両方に追記する
-- スキル名変更時は両方で名前を揃える
-- スキル削除時は両方から消す
-- 配置場所が `.claude/skills/` の場合はリンク先とツリーの両方でそのパスを反映する
+- スキル追加時は一覧に追記する
+- スキル名変更時は一覧の名前とリンク先を揃える
+- スキル削除時は一覧から消す
+- 配置場所が `.claude/skills/` の場合は一覧のリンク先にそのパスを反映する
 - セットアップ手順など無関係な箇所は変更しない
 
 ### Step 4: 差分を検証する
@@ -78,13 +75,11 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 確認すること:
 - README に新旧の不整合が残っていない
 - 追加したスキル名とリンク先が一致している
-- ツリー表示が実際のディレクトリ構成と一致している
 - 意図しない文章変更が入っていない
 
 ## 品質チェック
 
 - [ ] 実在する全スキルが `Available Skills` に載っている
 - [ ] 各スキルのリンク先が正しい
-- [ ] `Project Structure` が現在の構成を反映している
 - [ ] 説明文が古いスキル名や古い用途を含んでいない
 - [ ] README 以外のファイルを変更する場合は、その必要性が明確である

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ AI エージェント用のカスタムスキル集です。
 | [github-issue-create-from-plan](github-issue-create-from-plan/) | 設計プラン合意後に GitHub Issue を作成する |
 | [github-pr-create](github-pr-create/) | PR 本文作成後に GitHub に PR を作成する |
 | [github-pr-review](github-pr-review/) | 指定した GitHub PR をレビューし、PR 上にコメントを投稿する |
+| [npm-dependency-major-upgrade](npm-dependency-major-upgrade/) | npm アプリの依存関係をメジャーバージョン更新する際の調査・確認・適用手順 |
+| [npm-dependency-update](npm-dependency-update/) | npm アプリの依存関係を非メジャーで安全に更新する際の手順 |
 | [skill-author](skill-author/) | SKILL.md ファイルの作成と改善を行う |
 | [start-implementation](start-implementation/) | Issue 確認から実装、検証、コミット、PR 準備までを進行管理する |
 | [skills-readme-sync](.claude/skills/skills-readme-sync/) | README のスキル一覧と構成例を現在のスキル構成へ同期する |
@@ -97,6 +99,10 @@ agent-skills/
 ├── github-pr-create/
 │   └── SKILL.md
 ├── github-pr-review/
+│   └── SKILL.md
+├── npm-dependency-major-upgrade/
+│   └── SKILL.md
+├── npm-dependency-update/
 │   └── SKILL.md
 ├── skill-author/
 │   └── SKILL.md

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AI エージェント用のカスタムスキル集です。
 | [npm-dependency-update](npm-dependency-update/) | npm アプリの依存関係を非メジャーで安全に更新する際の手順 |
 | [skill-author](skill-author/) | SKILL.md ファイルの作成と改善を行う |
 | [start-implementation](start-implementation/) | Issue 確認から実装、検証、コミット、PR 準備までを進行管理する |
-| [skills-readme-sync](.claude/skills/skills-readme-sync/) | README のスキル一覧と構成例を現在のスキル構成へ同期する |
+| [skills-readme-sync](.claude/skills/skills-readme-sync/) | README のスキル一覧を現在のスキル構成へ同期する |
 | [uv-dependency-major-upgrade](uv-dependency-major-upgrade/) | uv 管理の Python 依存関係をメジャーバージョン更新する際の調査・確認・適用手順 |
 | [uv-dependency-update](uv-dependency-update/) | uv 管理の Python 依存関係を非メジャーで広めにまとめて更新する際の手順 |
 
@@ -72,44 +72,3 @@ rm "$HOME/.codex/skills"
 ## Usage
 
 エージェントにスキルが認識されると、`/skill-name` または `@skill-name` と入力して呼び出せます。
-
-## Project Structure
-
-```
-agent-skills/
-├── .claude/
-│   └── skills/
-│       └── skills-readme-sync/
-│           └── SKILL.md
-├── README.md
-├── bun-dependency-major-upgrade/
-│   └── SKILL.md
-├── bun-dependency-update/
-│   └── SKILL.md
-├── codex-skills-link-from-claude/
-│   └── SKILL.md
-├── git-branch-create/
-│   └── SKILL.md
-├── git-commit-message/
-│   └── SKILL.md
-├── git-pr-description/
-│   └── SKILL.md
-├── github-issue-create-from-plan/
-│   └── SKILL.md
-├── github-pr-create/
-│   └── SKILL.md
-├── github-pr-review/
-│   └── SKILL.md
-├── npm-dependency-major-upgrade/
-│   └── SKILL.md
-├── npm-dependency-update/
-│   └── SKILL.md
-├── skill-author/
-│   └── SKILL.md
-├── start-implementation/
-│   └── SKILL.md
-├── uv-dependency-major-upgrade/
-│   └── SKILL.md
-├── uv-dependency-update/
-│   └── SKILL.md
-```

--- a/npm-dependency-major-upgrade/SKILL.md
+++ b/npm-dependency-major-upgrade/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: npm-dependency-major-upgrade
+description: >
+  Use this when asked to upgrade an npm application's dependency across a major version.
+  This skill handles one package at a time, researches breaking changes with web search and
+  primary sources, confirms the plan with the user before applying the update, and validates
+  the app after compatibility fixes.
+---
+
+# npm Major Upgrader
+
+## Overview
+
+Use this skill for major-version dependency upgrades in an npm app.
+It is intentionally interactive: research first, confirm scope with the user, then upgrade one package at a time.
+
+## When to Use This Skill
+
+- When the requested dependency update crosses a major version boundary
+- When a direct dependency must move to a new major series
+- When the user wants breaking changes researched before editing code
+- When the upgrade risk is high enough that the agent should confirm each step
+
+## What the Agent Does
+
+1. Inspect the local project rules and the package's current usage before changing anything.
+2. Research the target major version with web search, prioritizing official migration guides, changelogs, and release notes.
+3. Summarize the likely impact and confirm the plan with the user before making changes.
+4. Upgrade only one package at a time.
+5. Apply the compatibility fixes required by the researched breaking changes.
+6. Run the project's validation commands and report what passed, failed, or remains unknown.
+
+## Input and Output
+
+**Input:**
+- An npm app with `package.json`
+- A request to upgrade one dependency across a major version boundary
+- Local project verification commands from `AGENTS.md`, `package.json`, or nearby docs
+
+**Output:**
+- A researched upgrade plan for one package
+- User-confirmed upgrade scope before edits
+- Updated dependency entry and `package-lock.json` or `npm-shrinkwrap.json`
+- Required application or test changes for compatibility
+- A concise report of upstream impact, code changes, and validation status
+
+## Step Details
+
+### Step 1: Inspect the Local Project Context
+
+Open `AGENTS.md` if it exists.
+Read `package.json` scripts and inspect where the package is used with `rg`.
+Note which dependency section the package belongs to and whether the repo uses `package-lock.json`, `npm-shrinkwrap.json`, or workspaces.
+
+Do not upgrade multiple major dependencies in one pass unless the user explicitly asks for that and confirms the order.
+
+### Step 2: Research Before Editing
+
+Use web search before making dependency or code changes.
+Prioritize primary sources:
+
+- official migration guides
+- official changelogs
+- official release notes
+- official API docs
+
+Use secondary sources only when primary sources do not cover a practical migration detail, and label that as an inference.
+
+Collect the minimum useful facts:
+
+- current version and target major version
+- breaking changes relevant to the package usage in this repo
+- required code migrations
+- config, runtime, peer dependency, or Node.js engine changes
+- test or behavior risks that need explicit verification
+
+### Step 3: Confirm the Plan With the User
+
+Before editing files, present a short upgrade checkpoint to the user that includes:
+
+- the package to upgrade
+- the current and target major versions
+- the main breaking changes that appear relevant
+- the expected code areas to touch
+- the validation commands that will be run
+
+Wait for user confirmation before applying the update.
+If the research shows unusually high risk or unclear migration guidance, say so plainly and do not proceed on assumption alone.
+
+### Step 4: Upgrade One Package at a Time
+
+Change only the selected package to the approved target major version.
+Avoid bundling unrelated dependency churn into the same change.
+
+Prefer `npm install <pkg>@<target>` with the correct save flag for the existing dependency section so `package.json` and the lockfile stay aligned.
+If manual range edits are required, run `npm install` afterward to synchronize `package-lock.json` or `npm-shrinkwrap.json`.
+
+### Step 5: Apply Compatibility Fixes
+
+Use the researched migration guidance to update the codebase.
+Do not guess at API changes that were not confirmed by local usage or source material.
+
+When updating code:
+
+- touch only call sites affected by the researched breaking changes
+- update tests that assert old behavior
+- preserve existing auth, path-safety, and route constraints in the target repo
+
+### Step 6: Validate and Report
+
+Run the required project checks after the change.
+For npm projects, prioritize:
+
+- `npm run lint` when a lint script exists
+- `npm test` when a test script exists
+
+Report:
+
+- what upstream sources were used
+- what code paths changed
+- whether validation passed
+- any remaining manual verification or follow-up upgrades
+
+## Interaction Rules
+
+- Treat major upgrades as an interactive workflow, not a fire-and-forget edit.
+- Stop for confirmation after research and before dependency edits.
+- If a second major upgrade is needed, finish or pause the current one before starting the next.
+- If web research is required for accuracy, perform it rather than relying on memory.
+
+## Quality Check
+
+- [ ] The upgrade scope is limited to one major dependency at a time
+- [ ] Primary-source web research was done before editing
+- [ ] The user confirmed the researched plan before the dependency was changed
+- [ ] Code and tests were updated only where the researched breaking changes required it
+- [ ] Required project validation commands were run or the blocker was stated clearly
+
+## References
+
+- `AGENTS.md`
+- `package.json`
+- `package-lock.json`

--- a/npm-dependency-update/SKILL.md
+++ b/npm-dependency-update/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: npm-dependency-update
+description: >
+  Use this when asked to update dependencies in an npm application, especially when the
+  request involves `package.json`, `package-lock.json`, a specific package, or refreshing
+  packages to newer non-major versions. It captures a safe workflow for preferring broad
+  range-preserving refreshes with `npm update` unless the user asks to move declared ranges,
+  applying targeted `npm install <pkg>@...` only when needed, and verifying the project
+  after compatibility fixes. Do not use it for major-version upgrades.
+---
+
+# npm Nonmajor Updater
+
+## Overview
+
+Use this skill when working on dependency updates in an npm app.
+It keeps package updates deliberate instead of blindly bumping versions or rewriting semver ranges.
+For non-major work, prefer broad range-preserving refreshes unless the user asked for a narrower change or a direct dependency range move.
+This skill is limited to non-major updates.
+
+## When to Use This Skill
+
+- When asked to update one package in an npm project
+- When asked to refresh multiple dependencies or the whole npm app
+- When `package.json` and `package-lock.json` need to be updated together
+- When a dependency bump may require code changes or test updates
+
+Do not use this skill for major-version upgrades.
+Handle those with a separate skill and workflow.
+
+## What the Agent Does
+
+1. Read the local project instructions, dependency manifest, and package scripts before changing dependencies.
+2. Inspect the current dependency entry and determine whether the request is range-preserving or requires moving a direct dependency within the same major series.
+3. Choose the broadest safe npm command that matches that intent instead of defaulting to narrowly targeted updates.
+4. Reject or defer the work if it would require a major-version bump.
+5. Update application code or tests if the new package behavior requires it.
+6. Run the project's validation commands and confirm the result.
+
+## Input and Output
+
+**Input:**
+- An npm app with `package.json`
+- An update request for one package or a set of packages
+- Project-specific verification commands from `AGENTS.md`, `package.json`, or nearby docs
+
+**Output:**
+- Updated dependency entries in `package.json` when needed
+- Updated `package-lock.json` or `npm-shrinkwrap.json`
+- Any required compatibility fixes in source or tests
+- A clear report of what changed and whether validation passed
+
+## Step Details
+
+### Step 1: Inspect the Local Project Rules
+
+Open `AGENTS.md` if it exists.
+Read `package.json` scripts and note the required verification commands.
+Check whether the repo uses `package-lock.json`, `npm-shrinkwrap.json`, or workspaces.
+
+### Step 2: Determine the Update Intent
+
+Decide which of these applies:
+
+- `range-preserving`: keep the declared semver range and refresh the lockfile-resolved version
+- `latest-within-major`: move a direct dependency declaration to a newer release without crossing the current major series
+- `targeted`: update only the package named by the user
+- `broad`: update multiple packages or all dependencies
+
+Treat a general refresh request as `broad` plus `range-preserving` unless the user explicitly asks to move declared ranges.
+Do not assume a major-version bump unless the user explicitly asks for a separate major-upgrade workflow.
+If the repo uses npm workspaces, determine whether the request applies to the root package or a specific workspace before running commands.
+
+### Step 3: Apply the Broadest Safe npm Command
+
+Prefer commands that match the requested scope while avoiding unnecessary PR fragmentation:
+
+- `npm update` for broader range-preserving refreshes
+- `npm update <pkg>` for a targeted update within the existing declared range
+- `npm install <pkg>@<version-or-range>` only when a direct dependency range must move forward within the same major series
+- `npm install` after manual `package.json` edits so the lockfile and installed tree are synchronized
+
+When replacing a direct dependency with `npm install <pkg>@...`, preserve its dependency class such as `dependencies` or `devDependencies`.
+When the user gives a general non-major refresh request, prefer `npm update` over splitting the work into many targeted updates.
+Use a targeted command only when the user named a package, asked for a narrow change, or when changing `package.json` for one dependency is the safer path.
+If only one package is supposed to change, avoid unrelated dependency churn.
+
+### Step 4: Guard Against Major Upgrades
+
+Before finishing the update, inspect the changed versions in `package.json` and `package-lock.json` or `npm-shrinkwrap.json`.
+
+If any dependency crossed a major version:
+
+- do not continue under this skill
+- report which package crossed the boundary
+- leave the request for a separate major-upgrade skill or workflow
+
+For non-major updates that still affect behavior:
+
+- inspect where the package is used with `rg`
+- update code only if the minor or patch release changed behavior in practice
+- update tests that assert the old behavior
+
+### Step 5: Validate the Result
+
+Run the narrowest meaningful checks first, then the required project checks.
+For npm projects, prioritize:
+
+- `npm run lint` when a lint script exists
+- `npm test` when a test script exists
+
+Run any additional project-specific commands required by `AGENTS.md` or nearby docs.
+If a command cannot run, state why and what remains unverified.
+
+## Quality Check
+
+- [ ] The chosen npm command matches the user's requested scope and defaults to a broad range-preserving refresh when no narrow scope was requested
+- [ ] No dependency was upgraded across a major boundary
+- [ ] `package.json` changed only when the requested update required it
+- [ ] `package-lock.json` or `npm-shrinkwrap.json` reflects the dependency update
+- [ ] Any behavior changes from non-major updates were handled in code or tests
+- [ ] Required project validation commands were run or the blocker was stated clearly
+
+## References
+
+- `AGENTS.md`
+- `package.json`
+- `package-lock.json`


### PR DESCRIPTION
## Issues

- None

## Why

The repository already had Bun and uv dependency update skills, but it was missing npm equivalents. While updating the README for the new skills, the Project Structure section also turned out to be redundant and increased maintenance cost.

## Summary

Add npm dependency update skills and simplify how README synchronization is maintained.

## Changes

- add `npm-dependency-update` for non-major npm dependency updates
- add `npm-dependency-major-upgrade` for researched, interactive major npm upgrades
- update `README.md` to include the new skills
- remove the README `Project Structure` section
- update `skills-readme-sync` so it only maintains `Available Skills`

## Checklist

- [x] Added two npm skill directories with `SKILL.md`
- [x] Updated `README.md` skill list
- [x] Simplified `skills-readme-sync` to match the new README policy
- [ ] Tests were run if applicable

## Details

No automated tests were run because this repository does not have a project-level test command for these documentation and skill definition changes.
