### PR TITLE
docs: clarify issue references in git-pr-description skill

### DIFF
--- a/git-pr-description/SKILL.md
+++ b/git-pr-description/SKILL.md
@@ -13,7 +13,8 @@ description: PR description creation workflow
 ```markdown
 ## Issues
 
-- Close {IssueId}
+- Close {IssueId}  <!-- Issue をクローズする場合 -->
+- Refs {IssueId}   <!-- 関連付けのみでクローズしない場合 -->
 
 ## Why
 
@@ -42,6 +43,7 @@ description: PR description creation workflow
 - 明確で簡潔な言葉を使用
 - *何を* および *なぜ* に焦点を当てる
 - Issue をクローズする場合、`Issues` セクションは `- Close {IssueId}` の形式にする
+- Issue をクローズしない場合、`Issues` セクションは `- Refs {IssueId}` の形式にする
 - サマリーは2〜3文以内に収める
 - チェックリストは実際の変更を反映させる
 
@@ -84,6 +86,7 @@ description: PR description creation workflow
 ```markdown
 ## Issues
 - Close {IssueId}
+- Refs {IssueId}
 
 ## Why
 ...

--- a/git-pr-description/SKILL.md
+++ b/git-pr-description/SKILL.md
@@ -13,7 +13,7 @@ description: PR description creation workflow
 ```markdown
 ## Issues
 
-- 関連するissue番号やリンク
+- Close {IssueId}
 
 ## Why
 
@@ -41,6 +41,7 @@ description: PR description creation workflow
 **ガイドライン:**
 - 明確で簡潔な言葉を使用
 - *何を* および *なぜ* に焦点を当てる
+- Issue をクローズする場合、`Issues` セクションは `- Close {IssueId}` の形式にする
 - サマリーは2〜3文以内に収める
 - チェックリストは実際の変更を反映させる
 
@@ -82,7 +83,7 @@ description: PR description creation workflow
 ~~~
 ```markdown
 ## Issues
-...
+- Close {IssueId}
 
 ## Why
 ...


### PR DESCRIPTION
## Issues
- Close #70

## Why
Issue を閉じるケースだけでなく、関連付けのみで閉じないケースも  スキルで明確に扱えるようにするためです。

## Summary
 の  セクション例とガイドラインを見直しました。Issue を閉じる場合は 、閉じない場合は  を使うことを明記しています。

## Changes
-  セクションの例に  と  の両方を追加
- ガイドラインに、閉じる場合と閉じない場合の書式を追加
- PR 本文の出力例を実際のルールに合わせて更新

## Checklist
- [x] Issue を閉じる場合の形式を明記
- [x] Issue を閉じない場合の形式を明記
- [x] スキル内の例とガイドラインを整合させた