### PR TITLE
Add browser-check skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ AI エージェント用のカスタムスキル集です。
 
 | Skill | Description |
 |-------|-------------|
+| [browser-check](browser-check/) | `browser-use` で localhost の画面確認を最小構成で進める |
 | [bun-dependency-update](bun-dependency-update/) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
 | [codex-skills-link-from-claude](codex-skills-link-from-claude/) | `.claude/skills` を `.codex/skills` から再利用できるようにリンクする |
 | [tailwind-ui-compose](tailwind-ui-compose/) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: browser-check
+description: AI browser checks for localhost UI testing.
+---
+
+# Browser Check
+
+`browser-use` を、`localhost` の画面確認用に最小構成で使う。
+
+## 基本
+
+```bash
+browser-use open http://localhost:3000
+browser-use state
+browser-use click 5
+browser-use input 3 "hello"
+browser-use screenshot
+browser-use close
+```
+
+`state` で要素番号を確認してから操作する。画面遷移後は必要に応じて再度 `state` を取る。
+
+## よく使うコマンド
+
+```bash
+browser-use open http://localhost:3000
+browser-use --headed open http://localhost:3000
+
+browser-use state
+browser-use screenshot
+
+browser-use click 5
+browser-use input 3 "hello"
+browser-use keys "Enter"
+browser-use scroll down
+
+browser-use get title
+browser-use wait selector "button[type=submit]"
+browser-use wait text "Saved"
+
+browser-use close
+```
+
+## 運用ルール
+
+- `localhost` や `127.0.0.1` の確認用途を優先する
+- まず `state` を見てから要素番号で操作する
+- 見た目や挙動を確認したい時は `--headed` を使う
+- 複雑な自動化より、1 コマンドずつ確実に進める
+
+## トラブルシュート
+
+- ブラウザがおかしい時: `browser-use close` してから再度 `open`
+- 要素が見つからない時: `browser-use scroll down` の後に `browser-use state`
+- 動作を見たい時: `browser-use --headed open <url>`


### PR DESCRIPTION
## Issues
- None

## Why
browser-use を使った localhost 向けの画面確認手順をスキルとして追加し、README の一覧と実体の不整合を防ぐためです。

## Summary
localhost UI テスト用の `browser-check` スキルを追加しました。
README の `Available Skills` に新しいスキルを反映しました。

## Changes
- `browser-check/SKILL.md` を追加
- `README.md` の `Available Skills` に `browser-check` を追加

## Checklist
- [x] 新しいスキルを追加
- [x] README の一覧を同期
