### PR TITLE
docs: clarify GitHub skill workflows

### DIFF
--- a/github-pr-create/SKILL.md
+++ b/github-pr-create/SKILL.md
@@ -52,7 +52,7 @@ EOF
 gh pr create --base "$BASE" --body-file "$FILE" --title "${PR_TITLE}" ${WEB:+--web}
 
 # 作成結果の確認
-gh pr view --head "$BRANCH" --json title,body,url
+gh pr view "$BRANCH" --json title,body,url
 ```
 
 ## 入力
@@ -66,7 +66,7 @@ gh pr view --head "$BRANCH" --json title,body,url
 - **main/master/develop 上で作業中**: 先に作業ブランチを作る
 - **コミットが未作成**: 先にコミットを作る
 - **Push失敗**: エラー内容を表示して手動対応を促す
-- **既存PRがある**: `gh pr view --head "$BRANCH"` で既存PRを確認する
+- **既存PRがある**: `gh pr view "$BRANCH" --json title,url` で既存PRを確認する
 - **本文更新が必要**: `gh api repos/<owner>/<repo>/pulls/<number> --method PATCH --field body="$(cat "$FILE")"` を使う
 
 ## 注意

--- a/github-pr-create/SKILL.md
+++ b/github-pr-create/SKILL.md
@@ -4,7 +4,14 @@ description: When instructed to create a PR for GitHub.
 ---
 
 ## 概要
-既存のPR本文を使ってGitHubにPRを作成。`git-pr-description` スキル実行後や本文作成済み状態で使用。リモートにブランチがなければ自動pushしてから `gh pr create` を実行。
+`gh` CLI を使って GitHub に PR を作成する。GitHub コネクタは使わない。`git-pr-description` スキル実行後や本文作成済み状態で使用し、必要なら push、PR 作成、作成後の確認まで行う。
+
+## 事前確認
+
+- `gh auth status` が成功することを確認する
+- 現在のブランチが `main` `master` `develop` 系なら、そのまま PR を作らず先に作業ブランチを作る
+- `BASE..HEAD` にコミットがない場合は、先にコミットを作る
+- 未追跡ファイルや無関係な変更は勝手に追加・コミットしない
 
 ## 実行手順
 
@@ -13,6 +20,23 @@ description: When instructed to create a PR for GitHub.
 BRANCH=$(git branch --show-current)
 BASE="${BASE_BRANCH:-main}"
 
+# gh 認証確認
+gh auth status
+
+# 保護ブランチ上では止める
+case "$BRANCH" in
+  main|master|develop)
+    echo "Create or switch to a work branch before opening a PR."
+    exit 1
+    ;;
+esac
+
+# PR対象のコミットがない場合は止める
+if [ -z "$(git log --oneline "${BASE}..HEAD")" ]; then
+  echo "No commits to include in the PR. Commit your changes first."
+  exit 1
+fi
+
 # リモート確認＆プッシュ（必要時）
 if [ -z "$(git ls-remote --heads origin $BRANCH)" ]; then
   git push -u origin $BRANCH
@@ -20,14 +44,15 @@ fi
 
 # PR作成（PR_BODYはコンテキストから取得）
 FILE=$(mktemp)
+trap 'rm -f "$FILE"' EXIT
 cat > "$FILE" << 'EOF'
 ${PR_BODY}
 EOF
 
 gh pr create --base "$BASE" --body-file "$FILE" --title "${PR_TITLE}" ${WEB:+--web}
 
-# 一時ファイル削除
-rm -f "$FILE"
+# 作成結果の確認
+gh pr view --head "$BRANCH" --json title,body,url
 ```
 
 ## 入力
@@ -38,4 +63,13 @@ rm -f "$FILE"
 
 ## エラー対応
 - **gh未インストール/未認証**: `gh auth login` を促す
+- **main/master/develop 上で作業中**: 先に作業ブランチを作る
+- **コミットが未作成**: 先にコミットを作る
 - **Push失敗**: エラー内容を表示して手動対応を促す
+- **既存PRがある**: `gh pr view --head "$BRANCH"` で既存PRを確認する
+- **本文更新が必要**: `gh api repos/<owner>/<repo>/pulls/<number> --method PATCH --field body="$(cat "$FILE")"` を使う
+
+## 注意
+
+- Markdown を含む PR 本文は `gh pr create --body` に直接埋め込まず、原則 `--body-file` を使う
+- 作成後は `gh pr view --json title,body,url` でタイトル・本文・URL を確認する

--- a/github-pr-review/SKILL.md
+++ b/github-pr-review/SKILL.md
@@ -61,7 +61,7 @@ description: >
 ## 2. PR 情報を取得する
 
 - 最初に `gh auth status` を実行し、認証と対象権限を確認する。
-- `gh pr view` で PR のタイトル、説明、base/head、変更ファイル一覧を確認する。
+- `gh pr view --json title,body,url,baseRefName,headRefName,files` で PR のタイトル、説明、base/head、変更ファイル一覧を確認する。
 - `gh pr diff` で差分を取得する。
 - `gh api` または `gh pr view --comments` を使い、既存の review comments と overall comments を確認する。
 - 既存コメントに同じ論点がある場合は重複投稿しない。

--- a/github-pr-review/SKILL.md
+++ b/github-pr-review/SKILL.md
@@ -25,6 +25,11 @@ description: >
 - `gh` CLI が利用可能で、対象リポジトリへコメント権限のある認証が済んでいること
 - 必要に応じてユーザーから指定される観点や除外範囲
 
+## 前提
+
+- GitHub 連携は `gh` CLI / `gh api` を優先して使い、GitHub コネクタには依存しない
+- レビュー開始前に `gh auth status` が成功することを確認する
+
 ## 出力
 
 - GitHub PR 上の review comments
@@ -55,6 +60,7 @@ description: >
 
 ## 2. PR 情報を取得する
 
+- 最初に `gh auth status` を実行し、認証と対象権限を確認する。
 - `gh pr view` で PR のタイトル、説明、base/head、変更ファイル一覧を確認する。
 - `gh pr diff` で差分を取得する。
 - `gh api` または `gh pr view --comments` を使い、既存の review comments と overall comments を確認する。
@@ -89,11 +95,14 @@ description: >
 ## 6. コメントを投稿する
 
 - 複数コメントがある場合は、可能なら pending review としてまとめて送信する。
+- コメント投稿は `gh` CLI / `gh api` を使って行い、GitHub コネクタは使わない。
 - 使うコマンドや API は環境に合わせて選ぶが、行番号・ファイルパス・body を明示して投稿する。
 - 投稿前に、同一内容の既存コメントがないことを再確認する。
 - 投稿前に、すべてのコメント本文へ AI エージェント識別メタ情報が入っていることを確認する。
 - 投稿前に、コメント本文に文字列としての `\n` が残っていないことを確認する。
+- 複数行コメントはシェル引数へ直接埋め込みすぎず、必要なら一時ファイルや JSON 入力を使って本文崩れを避ける。
 - CLI や API の制約で inline comment ができない場合のみ、overall review comment を使う。
+- 投稿後は `gh api` または `gh pr view --comments` で、意図した本文が実際に投稿されていることを確認する。
 
 ## 7. ユーザーへ報告する
 


### PR DESCRIPTION
## Issues
- None

## Why
Recent updates to the GitHub-related skills changed behavior around PR creation and review, but the usage guidance was still missing key operational checks. Documenting those checks reduces failed workflows on protected branches or unauthenticated `gh` sessions.

## Summary
Clarify the `github-pr-create` and `github-pr-review` skills for a `gh`-first workflow. Add prechecks and post-action verification steps so PR creation and review comment posting are more reliable.

## Changes
- add branch and commit prechecks plus auth verification to `github-pr-create`
- add `gh auth status`, `gh`/`gh api` preference, and posting verification guidance to `github-pr-review`

## Checklist
- [x] skill docs updated to match current intended workflow
- [x] diff reviewed locally
