### PR TITLE
docs: README のエージェント表現を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent skills
 
-AI エージェント用のカスタムスキル集です。
+コーディングエージェント用のカスタムスキル集です。
 
 ## Available Skills
 


### PR DESCRIPTION
## Issues

- N/A

## Why

Codex や Claude Code 向けのスキル集であることが README 冒頭から分かるようにするためです。

## Summary

README の説明文を「AI エージェント」から「コーディングエージェント」に更新しました。

## Changes

- README 冒頭のリポジトリ説明文を更新

## Checklist

- [x] README の文言を確認
- [x] `git diff --check` を実行
