### PR TITLE
Use git-commit-message for PR feedback commits

### DIFF
--- a/git-commit-message/SKILL.md
+++ b/git-commit-message/SKILL.md
@@ -36,7 +36,9 @@ basename "$(pwd)"
 - 命令形（add, fix, update など）
 - 小文字で記述（API などの頭字語は例外）
 - プレフィックス: `feat:` `fix:` `docs:` `style:` `refactor:` `test:` `chore:`
+- PR レビュー指摘への対応コミットでは、変更種別よりも feedback 対応であることを優先して `fb:` を使う
 - モノレポの場合: スコープ付き `feat(scope):` `fix(scope):` など
+- `fb:` でもスコープは通常ルールに従う。モノレポでは feedback ではなく対象プロジェクトや対象スキルを scope に入れる
 
 **本文（英語で記述）:**
 - 何を変更したか、および なぜ変更したかを説明

--- a/github-pr-feedback-address/SKILL.md
+++ b/github-pr-feedback-address/SKILL.md
@@ -113,7 +113,7 @@ GitHub PR に付いた review comments / conversation comments を確認し、�
 - commit message の生成には必ず `git-commit-message/SKILL.md` を使い、そのワークフローに従う。
 - `git-commit-message` 側に `git add .` の例があっても、このスキルでは使わない。stage 対象は必ずこのスキルで行った変更だけに限定する。
 - commit message は `git-commit-message` のルールに従い、feedback 対応であることが分かる Conventional Commits 形式にする。
-- feedback 対応であることは原則として scope の `feedback` で明示し、type は実際の変更内容に合わせる（例: `fix(feedback): ...`、ドキュメントのみなら `docs(feedback): ...`）。
+- feedback 対応であることは `git-commit-message` の feedback 対応用 type で表し、scope は通常ルールに従って対象プロジェクトや対象スキルを入れる。
 - コミット済みの変更が既にある場合は、必要に応じて新しい commit を追加する。既存 commit を勝手に amend / rebase しない。
 
 ## 7. push する

--- a/github-pr-feedback-address/SKILL.md
+++ b/github-pr-feedback-address/SKILL.md
@@ -113,6 +113,7 @@ GitHub PR に付いた review comments / conversation comments を確認し、�
 - commit message の生成には必ず `git-commit-message/SKILL.md` を使い、そのワークフローに従う。
 - `git-commit-message` 側に `git add .` の例があっても、このスキルでは使わない。stage 対象は必ずこのスキルで行った変更だけに限定する。
 - commit message は `git-commit-message` のルールに従い、feedback 対応であることが分かる Conventional Commits 形式にする。
+- feedback 対応であることは原則として scope の `feedback` で明示し、type は実際の変更内容に合わせる（例: `fix(feedback): ...`、ドキュメントのみなら `docs(feedback): ...`）。
 - コミット済みの変更が既にある場合は、必要に応じて新しい commit を追加する。既存 commit を勝手に amend / rebase しない。
 
 ## 7. push する

--- a/github-pr-feedback-address/SKILL.md
+++ b/github-pr-feedback-address/SKILL.md
@@ -110,7 +110,9 @@ GitHub PR に付いた review comments / conversation comments を確認し、�
 - `git status --short` と `git diff` で変更範囲を確認する。
 - このスキルで行った変更だけを stage する。
 - 未追跡ファイルや無関係な変更を勝手に commit しない。
-- commit message は feedback 対応であることが分かる短い文にする。
+- commit message の生成には必ず `git-commit-message/SKILL.md` を使い、そのワークフローに従う。
+- `git-commit-message` 側に `git add .` の例があっても、このスキルでは使わない。stage 対象は必ずこのスキルで行った変更だけに限定する。
+- commit message は `git-commit-message` のルールに従い、feedback 対応であることが分かる Conventional Commits 形式にする。
 - コミット済みの変更が既にある場合は、必要に応じて新しい commit を追加する。既存 commit を勝手に amend / rebase しない。
 
 ## 7. push する


### PR DESCRIPTION
## Issues

- Close #88

## Why

`github-pr-feedback-address` のコミットメッセージ品質がLLMごとにばらつかないように、既存の `git-commit-message` スキルへ明示的に寄せる必要がありました。

## Summary

`github-pr-feedback-address/SKILL.md` の commit 手順で、commit message 生成時に `git-commit-message/SKILL.md` を必ず使うようにしました。

## Changes

- `git-commit-message` のワークフローに従って commit message を生成するルールを追加
- `git-commit-message` 側の `git add .` 例よりも、このスキルで行った変更だけを stage する制約を優先することを明記
- feedback 対応であることが分かる Conventional Commits 形式にする方針へ更新

## Verification

- `rg "git-commit-message|commit message|git add \\." github-pr-feedback-address/SKILL.md` - passed
- `git diff --check` - passed
- README の Available Skills 表はスキル名・説明の変更ではないため更新不要と確認
