### PR TITLE
docs: READMEのスキルリンクをSKILL.mdに直接リンク

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,50 +10,50 @@
 
 | Skill | Description |
 |-------|-------------|
-| [git-branch-create](git-branch-create/) | ブランチ名を提案し、ブランチを作成する |
-| [git-worktree-create](git-worktree-create/) | 独立した git worktree を作成し、並列作業用の作業領域を用意する |
-| [git-commit-message](git-commit-message/) | コミットメッセージを提案する |
-| [github-issue-create-from-plan](github-issue-create-from-plan/) | 設計プラン合意後に GitHub Issue を作成する |
-| [github-pr-create](github-pr-create/) | PR 本文生成を含めて GitHub に PR を作成する |
-| [github-pr-feedback-address](github-pr-feedback-address/) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う |
-| [github-pr-review](github-pr-review/) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う |
-| [github-pr-comment-reply](github-pr-comment-reply/) | GitHub PR の review comment や conversation comment に返信する |
+| [git-branch-create](git-branch-create/SKILL.md) | ブランチ名を提案し、ブランチを作成する |
+| [git-worktree-create](git-worktree-create/SKILL.md) | 独立した git worktree を作成し、並列作業用の作業領域を用意する |
+| [git-commit-message](git-commit-message/SKILL.md) | コミットメッセージを提案する |
+| [github-issue-create-from-plan](github-issue-create-from-plan/SKILL.md) | 設計プラン合意後に GitHub Issue を作成する |
+| [github-pr-create](github-pr-create/SKILL.md) | PR 本文生成を含めて GitHub に PR を作成する |
+| [github-pr-feedback-address](github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う |
+| [github-pr-review](github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う |
+| [github-pr-comment-reply](github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する |
 
 ### 実装フロー
 
 | Skill | Description |
 |-------|-------------|
-| [github-implement-pr](github-implement-pr/) | 既存スキルを参照しつつ Issue 確認から PR 作成まで進める |
-| [html-artifact-format](html-artifact-format/) | AI向けMarkdownと人間向けHTMLの成果物形式を判断し、規模別HTMLを生成する |
+| [github-implement-pr](github-implement-pr/SKILL.md) | 既存スキルを参照しつつ Issue 確認から PR 作成まで進める |
+| [html-artifact-format](html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLの成果物形式を判断し、規模別HTMLを生成する |
 
 ### 依存パッケージ更新
 
 | Skill | Description |
 |-------|-------------|
-| [bun-dependency-update](bun-dependency-update/) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
-| [npm-dependency-update](npm-dependency-update/) | npm アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
-| [uv-dependency-update](uv-dependency-update/) | uv 管理の Python 依存更新を非メジャー/major の分岐付きで安全に進める |
+| [bun-dependency-update](bun-dependency-update/SKILL.md) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
+| [npm-dependency-update](npm-dependency-update/SKILL.md) | npm アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
+| [uv-dependency-update](uv-dependency-update/SKILL.md) | uv 管理の Python 依存更新を非メジャー/major の分岐付きで安全に進める |
 
 ### UI / フロントエンド
 
 | Skill | Description |
 |-------|-------------|
-| [tailwind-ui-compose](tailwind-ui-compose/) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
-| [browser-check](browser-check/) | `browser-use` で localhost の画面確認を最小構成で進める |
+| [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
+| [browser-check](browser-check/SKILL.md) | `browser-use` で localhost の画面確認を最小構成で進める |
 
 ### アセット変換
 
 | Skill | Description |
 |-------|-------------|
-| [image-to-svg](image-to-svg/) | **experimental** — 画像（PNG/JPEG）を編集可能な SVG に変換する |
+| [image-to-svg](image-to-svg/SKILL.md) | **experimental** — 画像（PNG/JPEG）を編集可能な SVG に変換する |
 
 ### スキル管理 / セットアップ
 
 | Skill | Description |
 |-------|-------------|
-| [skill-author](skill-author/) | SKILL.md ファイルの作成と改善を行う |
-| [skills-readme-sync](.claude/skills/skills-readme-sync/) | **本リポジトリ専用** — README のスキル一覧を現在のスキル構成へ同期する |
-| [codex-skills-link-from-claude](codex-skills-link-from-claude/) | `.claude/skills` を `.codex/skills` から再利用できるようにリンクする |
+| [skill-author](skill-author/SKILL.md) | SKILL.md ファイルの作成と改善を行う |
+| [skills-readme-sync](.claude/skills/skills-readme-sync/SKILL.md) | **本リポジトリ専用** — README のスキル一覧を現在のスキル構成へ同期する |
+| [codex-skills-link-from-claude](codex-skills-link-from-claude/SKILL.md) | `.claude/skills` を `.codex/skills` から再利用できるようにリンクする |
 
 ## Naming Convention
 


### PR DESCRIPTION
## Summary

README.md の Available Skills セクション内の各スキルリンクを、ディレクトリへのリンクから `SKILL.md` ファイルへの直接リンクに変更します。

## Changes

- 全 16 スキルのリンクを `{dir_name}/` から `{dir_name}/SKILL.md` に更新
  - Git / GitHub 操作: 8 スキル
  - 実装フロー: 2 スキル
  - 依存パッケージ更新: 3 スキル
  - UI / フロントエンド: 2 スキル
  - アセット変換: 1 スキル
  - スキル管理 / セットアップ: 3 スキル

## Why

リンクをクリックした際にスキルディレクトリのファイル一覧ではなく、スキルの内容が記載された `SKILL.md` を直接開けるようにするため。
