### PR TITLE
docs(browser-check): add browser launch mode selection

### DIFF
--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -48,8 +48,17 @@ browser-use close
 - 見た目や挙動を確認したい時は `--headed` を使う
 - 複雑な自動化より、1 コマンドずつ確実に進める
 
+## 起動モード選択
+
+- スキル起動時、まず `DISPLAY` 環境変数の有無を確認する
+- `DISPLAY` がない場合: GUIブラウザは起動できない旨を通知し、ヘッドレスモードに自動フォールバックする
+- `DISPLAY` がある場合: ユーザーに「GUIブラウザ表示 (推奨, headed)」または「ヘッドレス (headless)」を選んでもらう
+- GUIブラウザ表示 (headed) を選んだ場合は、`browser-use --headed open <url>` で起動する
+- ヘッドレス (headless) を選んだ場合、またはヘッドレスへフォールバックした場合は、`browser-use open <url>` で起動する
+
 ## トラブルシュート
 
 - ブラウザがおかしい時: `browser-use close` してから再度 `open`
 - 要素が見つからない時: `browser-use scroll down` の後に `browser-use state`
 - 動作を見たい時: `browser-use --headed open <url>`
+- `DISPLAY` 環境変数がない時: `--headed` は使わず、ヘッドレスモードで実行

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -54,11 +54,11 @@ browser-use close
 - `DISPLAY` がない場合: GUIブラウザは起動できない旨を通知し、ヘッドレスモードに自動フォールバックする
 - `DISPLAY` がある場合: ユーザーに「GUIブラウザ表示 (推奨, headed)」または「ヘッドレス (headless)」を選んでもらう
 - GUIブラウザ表示 (推奨, headed) を選んだ場合は、`browser-use --headed open <url>` で起動する
-- ヘッドレス (headless) を選んだ場合、またはヘッドレスへフォールバックした場合は、`browser-use open <url>` で起動する
+- ヘッドレス (headless) を選んだ場合、またはヘッドレスモードにフォールバックした場合は、`browser-use open <url>` で起動する
 
 ## トラブルシュート
 
 - ブラウザがおかしい時: `browser-use close` してから再度 `open`
 - 要素が見つからない時: `browser-use scroll down` の後に `browser-use state`
 - 動作を見たい時: `browser-use --headed open <url>`
-- `DISPLAY` 環境変数がない時: `--headed` は使わず、ヘッドレスモードで実行
+- `DISPLAY` 環境変数がない環境で `--headed` を使おうとした時: GUIブラウザは起動できないため、ヘッドレスモードで実行

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -53,7 +53,7 @@ browser-use close
 - スキル起動時、まず `DISPLAY` 環境変数の有無を確認する
 - `DISPLAY` がない場合: GUIブラウザは起動できない旨を通知し、ヘッドレスモードに自動フォールバックする
 - `DISPLAY` がある場合: ユーザーに「GUIブラウザ表示 (推奨, headed)」または「ヘッドレス (headless)」を選んでもらう
-- GUIブラウザ表示 (headed) を選んだ場合は、`browser-use --headed open <url>` で起動する
+- GUIブラウザ表示 (推奨, headed) を選んだ場合は、`browser-use --headed open <url>` で起動する
 - ヘッドレス (headless) を選んだ場合、またはヘッドレスへフォールバックした場合は、`browser-use open <url>` で起動する
 
 ## トラブルシュート

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -60,5 +60,4 @@ browser-use close
 
 - ブラウザがおかしい時: `browser-use close` してから再度 `open`
 - 要素が見つからない時: `browser-use scroll down` の後に `browser-use state`
-- 動作を見たい時: `browser-use --headed open <url>`
 - `DISPLAY` 環境変数がない環境で `--headed` を使おうとした時: GUIブラウザは起動できないため、ヘッドレスモードで実行


### PR DESCRIPTION
## Issues

- Close #102

## Why

browser-check needs an explicit startup flow for choosing GUI browser display or headless mode, and it should avoid attempting headed launch when DISPLAY is unavailable.

## Summary

This PR documents the browser-check startup mode selection flow. It adds DISPLAY detection, headed/headless user selection, and automatic headless fallback guidance.

## Changes

- Add a startup mode selection section to browser-check operational rules
- Document DISPLAY-based fallback to headless mode
- Add troubleshooting guidance for environments without DISPLAY

## Verification

- `rg -n "DISPLAY|headed|headless|起動モード|トラブルシュート" browser-check/SKILL.md` - passed
- `git diff --check` - passed
