### PR TITLE
docs: update browser-check workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 | Skill | Description |
 |-------|-------------|
 | [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
-| [browser-check](browser-check/SKILL.md) | `browser-use` で localhost の画面確認を最小構成で進める |
+| [browser-check](browser-check/SKILL.md) | `browser-use` で localhost の画面確認ワークフローを進める |
 
 ### アセット変換
 

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -61,7 +61,7 @@ browser-use state
 > 補足: 遷移や保存が即座に完了し、次の `state` で結果が確認できる場合は `wait` を省略しても構いません。
 
 ```bash
-browser-use wait selector "button[type=submit]"
+browser-use wait selector ".success-message"
 browser-use wait text "Saved"
 browser-use state
 browser-use screenshot

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -44,6 +44,8 @@ browser-use get title
 
 `state` に表示された要素番号を使って、クリックや入力を 1 コマンドずつ実行する。画面遷移や DOM 更新の後は、再度 `state` を取って番号を確認し直す。
 
+> 注意: `open` 直後に取得した `state` の番号が、すぐに無効になることがあります。「Element index not found」と出た場合は、まず `browser-use state` を再度実行して番号を確認し直してください。
+
 ```bash
 browser-use click 5
 browser-use input 3 "hello"
@@ -55,6 +57,8 @@ browser-use state
 ### 5. 結果を待って確認する
 
 保存・送信・遷移などの完了条件を、セレクタまたは表示テキストで待つ。その後 `state` や `screenshot` で結果を確認する。
+
+> 補足: 遷移や保存が即座に完了し、次の `state` で結果が確認できる場合は `wait` を省略しても構いません。
 
 ```bash
 browser-use wait selector "button[type=submit]"
@@ -82,5 +86,5 @@ browser-use close
 ## トラブルシュート
 
 - ブラウザがおかしい時: `browser-use close` してから再度 `open`
-- 要素が見つからない時: `browser-use scroll down` の後に `browser-use state`
+- 要素が見つからない時: まず `browser-use state` を再度実行して番号を確認し直す。スクロールで見えていない可能性がある場合は `browser-use scroll down` の後に `browser-use state`
 - `DISPLAY` 環境変数がない環境で `--headed` を使おうとした時: GUIブラウザは起動できないため、ヘッドレスモードで実行

--- a/browser-check/SKILL.md
+++ b/browser-check/SKILL.md
@@ -1,60 +1,83 @@
 ---
 name: browser-check
-description: AI browser checks for localhost UI testing.
+description: localhost の画面確認を browser-use で進めるワークフロー。
 ---
 
 # Browser Check
 
 `browser-use` を、`localhost` の画面確認用に最小構成で使う。
 
-## 基本
+## ワークフロー
+
+### 1. 対象URLを決める
+
+ユーザー指定の URL がある場合はそれを使う。指定がない場合は、対象アプリの dev server や README を確認して `localhost` または `127.0.0.1` の URL を特定する。
+
+### 2. 起動モードを選択する
+
+まず `DISPLAY` 環境変数の有無を確認する。
+
+- `DISPLAY` がない場合: GUI ブラウザは起動できないため、ヘッドレスモードで進める
+- `DISPLAY` がある場合: 画面の見た目や操作感を確認する目的なら headed、状態確認だけで足りる目的なら headless を選ぶ
+
+起動コマンド:
 
 ```bash
-browser-use open http://localhost:3000
-browser-use state
-browser-use click 5
-browser-use input 3 "hello"
-browser-use screenshot
-browser-use close
-```
-
-`state` で要素番号を確認してから操作する。画面遷移後は必要に応じて再度 `state` を取る。
-
-## よく使うコマンド
-
-```bash
-browser-use open http://localhost:3000
+# headed
 browser-use --headed open http://localhost:3000
 
+# headless
+browser-use open http://localhost:3000
+```
+
+### 3. 初期状態を確認する
+
+`state` で現在のページ構造と要素番号を確認する。見た目の確認が必要な場合は `screenshot` も取る。
+
+```bash
 browser-use state
 browser-use screenshot
+browser-use get title
+```
 
+### 4. 要素番号で操作する
+
+`state` に表示された要素番号を使って、クリックや入力を 1 コマンドずつ実行する。画面遷移や DOM 更新の後は、再度 `state` を取って番号を確認し直す。
+
+```bash
 browser-use click 5
 browser-use input 3 "hello"
 browser-use keys "Enter"
 browser-use scroll down
+browser-use state
+```
 
-browser-use get title
+### 5. 結果を待って確認する
+
+保存・送信・遷移などの完了条件を、セレクタまたは表示テキストで待つ。その後 `state` や `screenshot` で結果を確認する。
+
+```bash
 browser-use wait selector "button[type=submit]"
 browser-use wait text "Saved"
+browser-use state
+browser-use screenshot
+```
 
+### 6. 終了する
+
+確認が終わったらブラウザを閉じる。
+
+```bash
 browser-use close
 ```
 
-## 運用ルール
+## 判断基準
 
 - `localhost` や `127.0.0.1` の確認用途を優先する
 - まず `state` を見てから要素番号で操作する
 - 見た目や挙動を確認したい時は `--headed` を使う
 - 複雑な自動化より、1 コマンドずつ確実に進める
-
-## 起動モード選択
-
-- スキル起動時、まず `DISPLAY` 環境変数の有無を確認する
-- `DISPLAY` がない場合: GUIブラウザは起動できない旨を通知し、ヘッドレスモードに自動フォールバックする
-- `DISPLAY` がある場合: ユーザーに「GUIブラウザ表示 (推奨, headed)」または「ヘッドレス (headless)」を選んでもらう
-- GUIブラウザ表示 (推奨, headed) を選んだ場合は、`browser-use --headed open <url>` で起動する
-- ヘッドレス (headless) を選んだ場合、またはヘッドレスモードにフォールバックした場合は、`browser-use open <url>` で起動する
+- 画面遷移後や入力後は、要素番号が変わる前提で再確認する
 
 ## トラブルシュート
 


### PR DESCRIPTION
## Issues

- Refs none

## Why

`browser-check` の説明が英語のままで、本文もコマンド逆引き寄りになっていたため、スキルとして使う時の判断順に沿って読める形へ整理します。

## Summary

`browser-check` の description を日本語化し、localhost 画面確認の流れをワークフローとして再構成します。README のスキル一覧説明も変更内容に合わせて更新します。

## Changes

- `browser-check/SKILL.md` の description を日本語化
- 起動モード選択を含む確認手順をワークフロー形式に再構成
- `README.md` の `browser-check` 説明を同期

## Checklist

- [x] 差分の空白チェック (`git diff --check`)
- [ ] フォーマット
- [ ] リント / 型チェック
- [ ] テスト

## Details

フォーマット、リント、テストは、このリポジトリ内に実行対象の設定ファイルやスクリプトが見当たらなかったため未実施です。
