### PR TITLE
wsl-chrome-attach: add portproxy gateway candidate

### DIFF
--- a/wsl-chrome-attach/SKILL.md
+++ b/wsl-chrome-attach/SKILL.md
@@ -89,6 +89,8 @@ python3 <skill-dir>/scripts/diagnose_chrome_debug.py
 - WSL の default gateway
 - `/etc/resolv.conf` の `nameserver`
 
+既定 port `9333` で診断する場合は、WSL NAT mode と Windows portproxy の実用構成向けに `http://<default-gateway>:9334` も自動で候補に含める。これは `0.0.0.0:9334 -> 127.0.0.1:9333` の portproxy が残っている環境を検出するための候補であり、成功した場合だけ `--browserUrl=http://<default-gateway>:9334` として使う。
+
 ### 4. 成功 URL を MCP 設定に使う
 
 診断成功時に表示される `--browserUrl=...` を `chrome-devtools-mcp` に渡す。
@@ -174,7 +176,9 @@ WSL 側で default gateway を確認する。
 ip route | grep default
 ```
 
-例: default gateway が `172.28.160.1` なら、診断スクリプトに candidate として渡す。
+既定 port `9333` の通常診断では、診断スクリプトが `http://<default-gateway>:9334` も自動で試す。成功した場合は、その URL が `--browserUrl` として表示される。
+
+明示的に portproxy 側だけを確認したい場合や、候補を固定して優先したい場合は candidate として渡す。
 
 ```bash
 python3 <skill-dir>/scripts/diagnose_chrome_debug.py \
@@ -211,9 +215,8 @@ netsh interface portproxy delete v4tov4 `
 1. `Chrome Debug` ショートカットで専用 profile の Chrome を起動する。
 2. Windows 側で `http://127.0.0.1:9333/json/version` が成功することを確認する。
 3. 管理者 PowerShell で `netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=9334 connectaddress=127.0.0.1 connectport=9333` を実行する。
-4. WSL 側で `ip route | grep default` を確認する。
-5. WSL 側で `python3 <skill-dir>/scripts/diagnose_chrome_debug.py --candidate http://<default-gateway>:9334 --port 9334` を実行する。
-6. 成功した `http://<default-gateway>:9334` を `chrome-devtools-mcp` の `--browserUrl` に渡す。
+4. WSL 側で `python3 <skill-dir>/scripts/diagnose_chrome_debug.py` を実行する。
+5. 成功した `http://<default-gateway>:9334` を `chrome-devtools-mcp` の `--browserUrl` に渡す。
 
 `portproxy` 設定は Windows 側に残る。2回目以降は、多くの場合 `Chrome Debug` ショートカットで専用 profile の Chrome を起動するだけで、WSL 側から同じ `http://<default-gateway>:9334` に再接続できる。接続できない時だけ `netsh interface portproxy show all` と診断スクリプトで状態を確認する。
 

--- a/wsl-chrome-attach/scripts/diagnose_chrome_debug.py
+++ b/wsl-chrome-attach/scripts/diagnose_chrome_debug.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 
 DEFAULT_PORT = 9333
+DEFAULT_PORTPROXY_PORT = 9334
 
 
 @dataclass(frozen=True)
@@ -114,8 +115,18 @@ def build_candidates(port: int, explicit: list[str]) -> list[Candidate]:
     for nameserver in read_resolv_nameservers():
         raw.append((f"http://{nameserver}:{port}", "/etc/resolv.conf nameserver"))
 
-    for gateway in read_default_gateways():
+    default_gateways = read_default_gateways()
+    for gateway in default_gateways:
         raw.append((f"http://{gateway}:{port}", "default gateway"))
+
+    if port == DEFAULT_PORT:
+        for gateway in default_gateways:
+            raw.append(
+                (
+                    f"http://{gateway}:{DEFAULT_PORTPROXY_PORT}",
+                    "default gateway portproxy",
+                )
+            )
 
     candidates: list[Candidate] = []
     seen: set[str] = set()
@@ -214,6 +225,22 @@ def print_failure_help(port: int) -> None:
     print("If PowerShell succeeds but WSL fails:")
     print("  - Check WSL networking mode, Windows Firewall, and Chrome listen scope.")
     print("  - Avoid --remote-debugging-address=0.0.0.0 unless the exposure risk is understood.")
+    if port == DEFAULT_PORT:
+        gateways = read_default_gateways()
+        print()
+        print("For WSL NAT mode with Windows portproxy:")
+        if gateways:
+            print("  - This diagnostic also tried these common portproxy candidates:")
+            for gateway in gateways:
+                print(f"    http://{gateway}:{DEFAULT_PORTPROXY_PORT}")
+        else:
+            print("  - Check the WSL default gateway, then test <default-gateway>:9334.")
+        print("  - Verify the Windows listener with:")
+        print("    netsh interface portproxy show all")
+        print(
+            "  - Expected mapping: "
+            f"0.0.0.0:{DEFAULT_PORTPROXY_PORT} -> 127.0.0.1:{DEFAULT_PORT}"
+        )
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/wsl-chrome-attach/tests/test_diagnose_chrome_debug.py
+++ b/wsl-chrome-attach/tests/test_diagnose_chrome_debug.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "diagnose_chrome_debug.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("diagnose_chrome_debug", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["diagnose_chrome_debug"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class DiagnoseChromeDebugTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.diag = load_module()
+
+    def candidates_for(self, port: int) -> list[tuple[str, str]]:
+        with (
+            mock.patch.object(self.diag, "read_resolv_nameservers", return_value=[]),
+            mock.patch.object(
+                self.diag, "read_default_gateways", return_value=["172.25.128.1"]
+            ),
+        ):
+            return [
+                (candidate.url, candidate.source)
+                for candidate in self.diag.build_candidates(port, [])
+            ]
+
+    def test_default_port_includes_default_gateway_portproxy_candidate(self) -> None:
+        candidates = self.candidates_for(self.diag.DEFAULT_PORT)
+
+        self.assertIn(
+            ("http://172.25.128.1:9334", "default gateway portproxy"),
+            candidates,
+        )
+
+    def test_portproxy_port_does_not_add_duplicate_candidate(self) -> None:
+        candidates = self.candidates_for(self.diag.DEFAULT_PORTPROXY_PORT)
+        urls = [url for url, _ in candidates]
+
+        self.assertIn(
+            ("http://172.25.128.1:9334", "default gateway"),
+            candidates,
+        )
+        self.assertNotIn(
+            ("http://172.25.128.1:9334", "default gateway portproxy"),
+            candidates,
+        )
+        self.assertEqual(urls.count("http://172.25.128.1:9334"), 1)
+
+    def test_explicit_candidate_keeps_priority_before_built_in_candidates(self) -> None:
+        with (
+            mock.patch.object(self.diag, "read_resolv_nameservers", return_value=[]),
+            mock.patch.object(
+                self.diag, "read_default_gateways", return_value=["172.25.128.1"]
+            ),
+        ):
+            candidates = self.diag.build_candidates(
+                self.diag.DEFAULT_PORT,
+                ["http://example.test:9444"],
+            )
+
+        self.assertEqual(candidates[0].url, "http://example.test:9444")
+        self.assertEqual(candidates[0].source, "--candidate")
+
+    def test_failure_help_mentions_portproxy_for_default_port(self) -> None:
+        with mock.patch.object(
+            self.diag, "read_default_gateways", return_value=["172.25.128.1"]
+        ):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                self.diag.print_failure_help(self.diag.DEFAULT_PORT)
+
+        text = output.getvalue()
+        self.assertIn("For WSL NAT mode with Windows portproxy:", text)
+        self.assertIn("http://172.25.128.1:9334", text)
+        self.assertIn("0.0.0.0:9334 -> 127.0.0.1:9333", text)
+
+    def test_failure_help_omits_portproxy_for_non_default_port(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.diag.print_failure_help(9222)
+
+        self.assertNotIn("For WSL NAT mode with Windows portproxy:", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issues

- Close #106

## Why

WSL NAT mode では、Windows 側 Chrome の `127.0.0.1:9333` が WSL 側の `127.0.0.1:9333` から直接見えないことがあります。既存ドキュメントでは Windows portproxy による `0.0.0.0:9334 -> 127.0.0.1:9333` の実用フローを案内しているため、通常診断でもこの構成を自然に検出できるようにします。

## Summary

既定 port `9333` の診断時に、WSL default gateway の `9334` を portproxy 候補として自動追加します。成功時は既存の成功 URL 表示により `--browserUrl=http://<default-gateway>:9334` を案内します。

## Changes

- `diagnose_chrome_debug.py` に `DEFAULT_PORTPROXY_PORT` と `default gateway portproxy` 候補を追加
- `--port 9334` 明示時には既存の default gateway 候補だけを使い、不要な重複を避ける
- 失敗時ヘルプに WSL NAT mode + Windows portproxy の確認手順を追記
- `wsl-chrome-attach/SKILL.md` の portproxy 手順を自動診断前提に更新

## Verification

- `python3 -m py_compile wsl-chrome-attach/scripts/diagnose_chrome_debug.py` - passed
- candidate generation check with mocked default gateway - passed
- `git diff --check` - passed
- `python3 wsl-chrome-attach/scripts/diagnose_chrome_debug.py --timeout 0.1` - passed, detected `http://172.25.128.1:9334` as `default gateway portproxy`
