### PR TITLE
docs: split browser attach workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,9 @@
 | Skill | Description |
 |-------|-------------|
 | [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
-| [browser-use](browser-use/SKILL.md) | `browser-use` CLI の独自ブラウザで localhost などの画面確認を進める |
+| [browser-use](browser-use/SKILL.md) | browser-use CLI の独自ブラウザで localhost などの画面確認を進める |
 | [wsl-chrome-attach](wsl-chrome-attach/SKILL.md) | WSL2 上のエージェントから Windows Chrome の remote debugging へ接続診断する |
-| [wsl-chrome-attach-use](wsl-chrome-attach-use/SKILL.md) | attach 済み Windows Chrome を `chrome-devtools-mcp` 経由で操作する |
-
-> [!NOTE]
-> `browser-check` は `browser-use` に改名しました。互換エイリアスは残していないため、既存の `$browser-check` 呼び出しは `$browser-use` に置き換えてください。
+| [wsl-chrome-attach-use](wsl-chrome-attach-use/SKILL.md) | attach 済み Windows Chrome を chrome-devtools-mcp 経由で操作する |
 
 ### アセット変換
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@
 | Skill | Description |
 |-------|-------------|
 | [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
-| [browser-check](browser-check/SKILL.md) | `browser-use` で localhost の画面確認ワークフローを進める |
+| [browser-use](browser-use/SKILL.md) | `browser-use` CLI の独自ブラウザで localhost などの画面確認を進める |
 | [wsl-chrome-attach](wsl-chrome-attach/SKILL.md) | WSL2 上のエージェントから Windows Chrome の remote debugging へ接続診断する |
+| [wsl-chrome-attach-use](wsl-chrome-attach-use/SKILL.md) | attach 済み Windows Chrome を `chrome-devtools-mcp` 経由で操作する |
+
+> [!NOTE]
+> `browser-check` は `browser-use` に改名しました。互換エイリアスは残していないため、既存の `$browser-check` 呼び出しは `$browser-use` に置き換えてください。
 
 ### アセット変換
 

--- a/browser-use/SKILL.md
+++ b/browser-use/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: browser-check
-description: localhost の画面確認を browser-use で進めるワークフロー。
+name: browser-use
+description: browser-use CLI の独自ブラウザで localhost などの画面確認を進めるワークフロー。
 ---
 
-# Browser Check
+# Browser Use
 
-`browser-use` を、`localhost` の画面確認用に最小構成で使う。
+`browser-use` CLI が起動する独自ブラウザで、`localhost` などの画面確認を進める。
+
+このスキルは `browser-use` CLI 専用であり、ユーザー管理の既存ブラウザや MCP 経由の操作は扱わない。
 
 ## ワークフロー
 
@@ -16,8 +18,6 @@ description: localhost の画面確認を browser-use で進めるワークフ�
 ### 2. 起動モードを選択する
 
 まず `DISPLAY` 環境変数の有無を確認する。
-
-WSL2 上のエージェントから、認証や設定を済ませた Windows 側 Chrome に attach してから確認したい場合は、先に `wsl-chrome-attach` で `chrome-devtools-mcp` の `browserUrl` を確定する。
 
 - `DISPLAY` がない場合: GUI ブラウザは起動できないため、ヘッドレスモードで進める
 - `DISPLAY` がある場合: 画面の見た目や操作感を確認する目的なら headed、状態確認だけで足りる目的なら headless を選ぶ

--- a/browser-use/SKILL.md
+++ b/browser-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-use
-description: browser-use CLI の独自ブラウザで localhost などの画面確認を進めるワークフロー。
+description: browser-use CLI の独自ブラウザで localhost などの画面確認を進める
 ---
 
 # Browser Use

--- a/wsl-chrome-attach-use/SKILL.md
+++ b/wsl-chrome-attach-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wsl-chrome-attach-use
-description: wsl-chrome-attach 後に chrome-devtools-mcp 経由で Windows Chrome を操作するワークフロー。
+description: attach 済み Windows Chrome を chrome-devtools-mcp 経由で操作する
 ---
 
 # WSL Chrome Attach Use
@@ -13,7 +13,7 @@ description: wsl-chrome-attach 後に chrome-devtools-mcp 経由で Windows Chro
 
 - `wsl-chrome-attach` の診断が成功している。
 - 診断成功時に表示された `--browserUrl=...` が `chrome-devtools-mcp` の起動引数に設定されている。
-- MCP 設定後にエージェントを再起動し、このセッションで `navigate_page`、`take_screenshot`、`click`、`fill`、`press_key`、`wait_for` などの Chrome DevTools MCP ツールが利用可能になっている。
+- MCP 設定後にエージェントを再起動し、このセッションで Chrome DevTools MCP ツールが利用可能になっている。クライアントによっては `chrome-devtools_navigate_page` のようにサーバー名 prefix 付きで表示されるため、`navigate_page`、`take_screenshot`、`click`、`fill`、`press_key`、`wait_for` に対応するツールが見えていることを確認する。
 - Chrome はユーザー管理の専用 profile で起動したままにする。
 
 ## ワークフロー
@@ -22,7 +22,7 @@ description: wsl-chrome-attach 後に chrome-devtools-mcp 経由で Windows Chro
 
 このセッションで Chrome DevTools MCP ツールが見えているか確認する。
 
-利用可能な MCP ツール一覧に `navigate_page`、`take_screenshot`、`take_snapshot` などがない場合は、まだ操作を始めない。`wsl-chrome-attach` の診断結果を使って MCP 設定を見直し、エージェントを再起動してから再実行する。
+利用可能な MCP ツール一覧に `navigate_page`、`take_screenshot`、`take_snapshot` などに対応するツールがない場合は、まだ操作を始めない。`chrome-devtools_navigate_page` のような prefix 付き表示も同じ操作として扱う。対応するツールが見つからない時は、`wsl-chrome-attach` の診断結果を使って MCP 設定を見直し、エージェントを再起動してから再実行する。
 
 ### 2. 対象 URL を決める
 

--- a/wsl-chrome-attach-use/SKILL.md
+++ b/wsl-chrome-attach-use/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: wsl-chrome-attach-use
+description: wsl-chrome-attach 後に chrome-devtools-mcp 経由で Windows Chrome を操作するワークフロー。
+---
+
+# WSL Chrome Attach Use
+
+`wsl-chrome-attach` で接続診断済みの Windows Chrome を、`chrome-devtools-mcp` のツールで操作する。
+
+このスキルは attach 済みの Chrome を使う。`browser-use` CLI の独自ブラウザ起動は扱わない。
+
+## 前提条件
+
+- `wsl-chrome-attach` の診断が成功している。
+- 診断成功時に表示された `--browserUrl=...` が `chrome-devtools-mcp` の起動引数に設定されている。
+- MCP 設定後にエージェントを再起動し、このセッションで `navigate_page`、`take_screenshot`、`click`、`fill`、`press_key`、`wait_for` などの Chrome DevTools MCP ツールが利用可能になっている。
+- Chrome はユーザー管理の専用 profile で起動したままにする。
+
+## ワークフロー
+
+### 1. MCP ツールの可視性を確認する
+
+このセッションで Chrome DevTools MCP ツールが見えているか確認する。
+
+利用可能な MCP ツール一覧に `navigate_page`、`take_screenshot`、`take_snapshot` などがない場合は、まだ操作を始めない。`wsl-chrome-attach` の診断結果を使って MCP 設定を見直し、エージェントを再起動してから再実行する。
+
+### 2. 対象 URL を決める
+
+ユーザー指定の URL がある場合はそれを使う。指定がない場合は、対象アプリの dev server や README を確認して `localhost` または `127.0.0.1` の URL を特定する。
+
+### 3. ページへ遷移する
+
+`navigate_page` で対象 URL を開く。既存タブを使う場合でも、最初に明示的に遷移して操作対象を固定する。
+
+### 4. 初期状態を確認する
+
+`take_snapshot` でアクセシビリティツリーと要素参照を確認する。見た目の確認が必要な場合は `take_screenshot` も取る。
+
+### 5. 要素参照で操作する
+
+`take_snapshot` に表示された要素参照を使って、クリックや入力を 1 操作ずつ進める。画面遷移や DOM 更新の後は、再度 `take_snapshot` を取って参照を確認し直す。
+
+よく使う操作:
+
+- `click`: ボタン、リンク、チェックボックスなどを押す
+- `fill`: 入力欄へテキストを入れる
+- `press_key`: Enter、Tab、Escape などのキーを送る
+- `wait_for`: 表示テキストや状態変化を待つ
+
+### 6. 結果を待って確認する
+
+保存・送信・遷移などの完了条件を `wait_for` で待つ。その後 `take_snapshot` や `take_screenshot` で結果を確認する。
+
+### 7. 片付ける
+
+確認が終わっても、ユーザー管理の Chrome は勝手に閉じない。必要なら操作に使ったタブだけを閉じる。remote debugging 付き Chrome の終了はユーザーの判断に委ねる。
+
+## 判断基準
+
+- attach 済み Chrome を使いたい場合だけこのスキルを使う。
+- MCP ツールがこのセッションで見えていない場合は、操作ではなく設定確認へ戻る。
+- 認証済み profile や既存セッションが必要な確認では、`browser-use` ではなくこのスキルを使う。
+- 画面遷移後や入力後は、要素参照が変わる前提で再確認する。
+
+## トラブルシュート
+
+- MCP ツールが使えない時: `wsl-chrome-attach` の成功 URL を `chrome-devtools-mcp` の `--browserUrl` に設定し、エージェントを再起動する。
+- 要素が見つからない時: スクロール後に `take_snapshot` を取り直す。必要に応じて `take_screenshot` で実画面も確認する。
+- `Session not found` や接続失敗が出る時: Chrome が起動中か、portproxy が有効か、`wsl-chrome-attach` の診断が成功するかを確認する。
+- 認証状態が期待と違う時: Windows 側 Chrome が専用 profile で起動しているか確認する。

--- a/wsl-chrome-attach/SKILL.md
+++ b/wsl-chrome-attach/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: wsl-chrome-attach
-description: WSL2 上の Codex や Claude Code などのコーディングエージェントから、Windows 側で remote debugging を有効にした Chrome へ接続診断し、chrome-devtools-mcp / Browser Use CLI に渡す browserUrl を特定する。認証や設定を人間が済ませた専用 Chrome profile を AI 操作へバトンタッチしたい時に使う。
+description: WSL2 上の Codex や Claude Code などのコーディングエージェントから、Windows 側で remote debugging を有効にした Chrome へ接続診断し、chrome-devtools-mcp に渡す browserUrl を特定する。認証や設定を人間が済ませた専用 Chrome profile を AI 操作へバトンタッチしたい時に使う。
 ---
 
 # WSL Chrome Attach
 
 WSL2 上のエージェントから Windows 側 Chrome の Chrome DevTools Protocol (CDP) endpoint に到達できるか確認し、MCP 設定に使う `--browserUrl=...` を決める。
 
-このスキルは attach までを扱う。attach 後のクリック、入力、スクリーンショット確認は `browser-check` を使う。
+このスキルは attach までを扱う。attach 後のクリック、入力、スクリーンショット確認は `wsl-chrome-attach-use` を使う。
 
 ## 必須注意
 
@@ -110,6 +110,8 @@ python3 <skill-dir>/scripts/diagnose_chrome_debug.py
 ```
 
 `--browserUrl` の値は診断スクリプトの成功結果に合わせる。WSL networking mode によって `127.0.0.1`、`localhost`、Windows host IP のどれが通るかは変わる。
+
+MCP 設定を反映するには、利用中のエージェントを再起動して MCP サーバーを読み込ませる。再起動後、`wsl-chrome-attach-use` を使い、このセッションで `navigate_page`、`take_screenshot`、`click`、`fill` などの Chrome DevTools MCP ツールが見えていることを確認してから操作する。
 
 ## 失敗時の切り分け
 
@@ -217,6 +219,7 @@ netsh interface portproxy delete v4tov4 `
 3. 管理者 PowerShell で `netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=9334 connectaddress=127.0.0.1 connectport=9333` を実行する。
 4. WSL 側で `python3 <skill-dir>/scripts/diagnose_chrome_debug.py` を実行する。
 5. 成功した `http://<default-gateway>:9334` を `chrome-devtools-mcp` の `--browserUrl` に渡す。
+6. エージェントを再起動して MCP 設定を読み込み、`wsl-chrome-attach-use` で attach 済み Chrome を操作する。
 
 `portproxy` 設定は Windows 側に残る。2回目以降は、多くの場合 `Chrome Debug` ショートカットで専用 profile の Chrome を起動するだけで、WSL 側から同じ `http://<default-gateway>:9334` に再接続できる。接続できない時だけ `netsh interface portproxy show all` と診断スクリプトで状態を確認する。
 

--- a/wsl-chrome-attach/scripts/diagnose_chrome_debug.py
+++ b/wsl-chrome-attach/scripts/diagnose_chrome_debug.py
@@ -298,6 +298,12 @@ def main(argv: list[str]) -> int:
     print()
     print("MCP JSON example:")
     print(mcp_json(browser_url))
+    print()
+    print("Next step:")
+    print(
+        "  Add the browserUrl to chrome-devtools-mcp, restart the agent, "
+        "then use the wsl-chrome-attach-use skill."
+    )
 
     return 0
 

--- a/wsl-chrome-attach/tests/test_diagnose_chrome_debug.py
+++ b/wsl-chrome-attach/tests/test_diagnose_chrome_debug.py
@@ -96,6 +96,30 @@ class DiagnoseChromeDebugTests(unittest.TestCase):
 
         self.assertNotIn("For WSL NAT mode with Windows portproxy:", output.getvalue())
 
+    def test_success_output_mentions_next_skill(self) -> None:
+        candidate = self.diag.Candidate("http://127.0.0.1:9333", "test")
+        result = self.diag.Result(
+            candidate,
+            ok=True,
+            data={
+                "Browser": "Chrome/Test",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9333/devtools/browser/test",
+            },
+        )
+
+        with (
+            mock.patch.object(self.diag, "build_candidates", return_value=[candidate]),
+            mock.patch.object(self.diag, "fetch_versions", return_value=[result]),
+        ):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                exit_code = self.diag.main([])
+
+        self.assertEqual(exit_code, 0)
+        text = output.getvalue()
+        self.assertIn("Next step:", text)
+        self.assertIn("wsl-chrome-attach-use skill", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Issues

- Close #111

## Why

The browser-check skill mixed two separate browser workflows: browser-use CLI with its own browser, and WSL Chrome attach through chrome-devtools-mcp. Issue feedback also called out stale references in the attach skill and the need to settle the rename behavior.

## Summary

This PR splits those responsibilities into browser-use, wsl-chrome-attach, and the new wsl-chrome-attach-use skill. It also updates the diagnostic success output so the next MCP-based workflow is visible after attach succeeds.

## Changes

- Rename browser-check to browser-use and scope it to browser-use CLI only.
- Add wsl-chrome-attach-use for Chrome DevTools MCP operation after attach.
- Update wsl-chrome-attach front matter, body, and NAT flow to point to the new use skill.
- Add next-step output to the Chrome debug diagnostic script and cover it with unittest.
- Sync README with the updated skill names and descriptions.

## Verification

- `python3 -m unittest wsl-chrome-attach/tests/test_diagnose_chrome_debug.py` - passed
- `python3 -m unittest discover -s wsl-chrome-attach/tests` - passed
