### PR TITLE
chore: use ubuntu-slim for skill validation

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-skills:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
       - name: Validate skills


### PR DESCRIPTION
## Why

The skill validation workflow only checks out the repository and runs a lightweight Bash validation script. It does not need Docker, elevated privileges, or a full Ubuntu runner image.

## Summary

Switch the `validate-skills` job from `ubuntu-latest` to `ubuntu-slim` so it uses GitHub Actions' lightweight runner for this short validation task.

## Changes

- Update `.github/workflows/validate-skills.yml` to use `ubuntu-slim`.

## Checklist

- [x] テスト: `bash scripts/validate-skills.sh`
