### PR TITLE
docs: README のスキル一覧を整理

### DIFF
--- a/.claude/skills/skills-readme-sync/SKILL.md
+++ b/.claude/skills/skills-readme-sync/SKILL.md
@@ -60,10 +60,9 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 - 性質バッジを Description セルの先頭に付ける場合は次の書式に揃える
   - 書式: `**<バッジ>** — <用途の短い説明>`
   - 用途が定まっているバッジ:
-    - `**experimental**`: 安定度がまだ揺れているスキル。安定したら注記を外す
     - `**本リポジトリ専用**`: 他リポジトリで使うことを想定していない、この `agent-skills` リポジトリ自身のメンテに紐付くスキル (例: `skills-readme-sync`)
   - 列は増やさない (該当スキルが少数のため、列追加は表が広がるだけ)
-  - 複数バッジが必要になったら `**experimental** / **本リポジトリ専用**` のように `/` で区切る
+- 実験的なスキルは Description の `experimental` バッジではなく、`Experimental` グループに置く
 
 ### Step 3: README の一覧を同期する
 
@@ -79,18 +78,23 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 
 | グループ | 含めるスキルの目安 |
 |---------|------------------|
-| Git / GitHub 操作 | `git-*` `github-*` などリポジトリ・PR・Issue を扱うもの |
-| 実装フロー | Issue 着手から PR 準備までの進行管理を担うもの (`start-implementation` 等) |
+| Git ローカル操作 | `git-*` のうち branch / worktree / commit などローカル Git 操作を扱うもの |
+| GitHub Issue / PR | `github-issue-*` `github-pr-*` など Issue / PR の作成・レビュー・返信を扱うもの |
+| 実装 / 成果物生成 | Issue 着手から PR 準備までの進行管理や、Markdown/HTML 成果物生成を担うもの |
+| 要件定義 / 設計対話 | 設計、要件、意思決定の対話やドキュメント照合を担うもの |
+| 品質 / テスト設計 | QA 観点やテストケース設計を担うもの |
 | 依存パッケージ更新 | `*-dependency-update` 系 (npm / bun / uv など) |
-| UI / フロントエンド | 画面構成・スタイリング・ブラウザ確認に関するもの |
-| アセット変換 | 画像→SVG など、生成・変換系のもの |
-| スキル管理 / セットアップ | スキル自体の作成・同期・連携設定に関するもの |
+| UI / フロントエンド | 画面構成・スタイリングに関するもの |
+| ブラウザ操作 / 検証 | browser-use や Chrome remote debugging などブラウザ操作・接続確認に関するもの |
+| Experimental | 安定度や運用方針がまだ揺れている実験的なもの |
+| スキル作成 / メンテナンス | スキル自体の作成・同期・連携設定に関するもの |
 
 ルール:
 - 既存グループに馴染むスキルは新規グループを作らずそこに入れる
 - 該当スキルが 0 件になったグループは見出しごと削除する
 - グループ内のソート順は、**関連の強い順** または **作業フローの順** を優先し、難しい場合のみ名前順 ASC を使う
-  - 例: Git / GitHub 操作 → branch → commit → issue → PR (create → review → comment-reply) のような流れ順
+  - 例: Git ローカル操作 → branch → worktree → commit のような流れ順
+  - 例: GitHub Issue / PR → issue → PR (create → feedback-address → review → comment-reply) のような流れ順
   - 例: 依存パッケージ更新 → 言語/ランタイムのアルファベット順 (bun → npm → uv)
 - 新しい性質のスキルが増えてどのグループにも収まらない場合のみ、新グループを追加して理由をコミットメッセージに残す
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,27 @@
 
 ## Available Skills
 
-スキルは役割ごとにグルーピングしてあります。グループ内の並びは関連の強さや作業フローの順です。
+スキルは利用目的ごとにグルーピングしてあります。グループ内の並びは関連の強さや作業フローの順です。
 
-### Git / GitHub 操作
+### Git ローカル操作
 
 | Skill | Description |
 |-------|-------------|
 | [git-branch-create](git-branch-create/SKILL.md) | ブランチ名を提案し、ブランチを作成する |
 | [git-worktree-create](git-worktree-create/SKILL.md) | 独立した git worktree を作成し、並列作業用の作業領域を用意する |
 | [git-commit-message](git-commit-message/SKILL.md) | コミットメッセージを提案する |
+
+### GitHub Issue / PR
+
+| Skill | Description |
+|-------|-------------|
 | [github-issue-create-from-plan](github-issue-create-from-plan/SKILL.md) | 設計プラン合意後に GitHub Issue を作成する |
 | [github-pr-create](github-pr-create/SKILL.md) | PR 本文生成を含めて GitHub に PR を作成する |
 | [github-pr-feedback-address](github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う |
 | [github-pr-review](github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う |
 | [github-pr-comment-reply](github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する |
 
-### 実装フロー
+### 実装 / 成果物生成
 
 | Skill | Description |
 |-------|-------------|
@@ -52,17 +57,22 @@
 | Skill | Description |
 |-------|-------------|
 | [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
+
+### ブラウザ操作 / 検証
+
+| Skill | Description |
+|-------|-------------|
 | [browser-use](browser-use/SKILL.md) | browser-use CLI の独自ブラウザで localhost などの画面確認を進める |
 | [wsl-chrome-attach](wsl-chrome-attach/SKILL.md) | WSL2 上のエージェントから Windows Chrome の remote debugging へ接続診断する |
 | [wsl-chrome-attach-use](wsl-chrome-attach-use/SKILL.md) | attach 済み Windows Chrome を chrome-devtools-mcp 経由で操作する |
 
-### アセット変換
+### Experimental
 
 | Skill | Description |
 |-------|-------------|
-| [image-to-svg](image-to-svg/SKILL.md) | **experimental** — 画像（PNG/JPEG）を編集可能な SVG に変換する |
+| [image-to-svg](image-to-svg/SKILL.md) | 画像（PNG/JPEG）を編集可能な SVG に変換する |
 
-### スキル管理 / セットアップ
+### スキル作成 / メンテナンス
 
 | Skill | Description |
 |-------|-------------|
@@ -80,6 +90,8 @@
 
 これにより、一覧を見た時に「どこで」「何に対して」「何をする」スキルかを判断しやすくします。
 
+README のグルーピングはスキル名の prefix ではなく、利用目的を優先して決めます。
+
 ## Skill Maintenance
 
 `SKILL.md` は原則として180行以内に収め、必須ルール・禁止事項・主要ワークフローは先頭150行以内に置きます。
@@ -95,39 +107,7 @@ bash scripts/validate-skills.sh
 
 ## Setup
 
-### Claude Code を使用する場合
-
-```sh
-git clone git@github.com:u7chan/agent-skills.git
-cd agent-skills
-mkdir -p "$HOME/.claude/skills"
-ln -sf "$(pwd)" "$HOME/.claude/skills"
-```
-
-> [!NOTE]
-> `$HOME/.claude/skills` ディレクトリが既に存在する場合は、上記コマンドをそのまま実行してください。
-
-### Codex を使用する場合
-
-```sh
-git clone git@github.com:u7chan/agent-skills.git
-cd agent-skills
-mkdir -p "$HOME/.codex"
-ln -sfn "$(pwd)" "$HOME/.codex/skills"
-```
-
-> [!NOTE]
-> `"$HOME/.codex/skills"` が既に存在する場合は、上記コマンドをそのまま実行してください。
-
-### シンボリックリンクを解除する場合
-
-```sh
-rm "$HOME/.claude/skills"
-rm "$HOME/.codex/skills"
-```
-
-> [!NOTE]
-> Claude Code 以外のエージェントでは、設定ディレクトリのパスが異なる場合があります。
+セットアップ手順は [SETUP.md](SETUP.md) を参照してください。
 
 ## Usage
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,35 @@
+# Setup
+
+## Claude Code を使用する場合
+
+```sh
+git clone git@github.com:u7chan/agent-skills.git
+cd agent-skills
+mkdir -p "$HOME/.claude/skills"
+ln -sf "$(pwd)" "$HOME/.claude/skills"
+```
+
+> [!NOTE]
+> `$HOME/.claude/skills` ディレクトリが既に存在する場合は、上記コマンドをそのまま実行してください。
+
+## Codex を使用する場合
+
+```sh
+git clone git@github.com:u7chan/agent-skills.git
+cd agent-skills
+mkdir -p "$HOME/.codex"
+ln -sfn "$(pwd)" "$HOME/.codex/skills"
+```
+
+> [!NOTE]
+> `"$HOME/.codex/skills"` が既に存在する場合は、上記コマンドをそのまま実行してください。
+
+## シンボリックリンクを解除する場合
+
+```sh
+rm "$HOME/.claude/skills"
+rm "$HOME/.codex/skills"
+```
+
+> [!NOTE]
+> Claude Code 以外のエージェントでは、設定ディレクトリのパスが異なる場合があります。


### PR DESCRIPTION
## Issues

- Refs none

## Why

README をスキル一覧の Index として読みやすく保つため、セットアップ手順を分離し、スキルの分類を利用目的ベースに整理します。

## Summary

README の Available Skills を人が作業目的から探しやすいグルーピングへ整理しました。セットアップ手順は README から `SETUP.md` へ移し、README にはリンクだけを残しています。

## Changes

- Git と GitHub、UI とブラウザ操作をそれぞれ別グループへ分割
- `image-to-svg` を `Experimental` グループへ移動し、説明文の experimental 表記を整理
- `スキル作成 / メンテナンス` グループへ名称変更し、`skills-readme-sync` の本リポジトリ専用表記は維持
- README の命名規則に「グルーピングは利用目的優先」と追記
- セットアップ手順を `SETUP.md` に分離

## Checklist

- [x] `bash scripts/validate-skills.sh`
- [x] `git diff --check`
