### PR TITLE
docs(github-issue): simplify issue templates

### DIFF
--- a/github-issue-create-from-plan/SKILL.md
+++ b/github-issue-create-from-plan/SKILL.md
@@ -73,9 +73,7 @@ description: >
 ## 4. 待機条件
 
 - plan モードでは、ユーザーが `OK` と返すまでは Issue を作成しない。
-- plan モードで `OK` を受け取った場合は、切替後の edit または auto モードとして Issue 作成へ進む。
 - edit または auto モードでは、`OK` を待たずに Issue を作成する。
-- plan モードで `OK` 以外の修正依頼が来たら、プラン更新を優先する。
 
 ## 5. テンプレートを選ぶ
 
@@ -100,9 +98,12 @@ Issue の規模に応じて、`references/` 配下のテンプレートを **ど
   - 実装判断やレビュー判断に必要な具体値、ファイル例、API 例
 - 保持対象は要約で消さず、Issue 本文の適切なセクションに原文に近い形で移す。
 - 保持対象が実装判断に必要か迷う場合は残す。
-- Standard の場合は、保持対象を主に `Design Details / 設計詳細` に置く。補足的な例は `Notes / 補足` に置いてよい。
-- Light の場合でも、保持対象があるなら `Examples / サンプル` セクションを追加して残す。保持対象が多い、または設計判断を含む場合は Standard に切り替える。
+- Standard の場合は、保持対象を主に `Design Details` に置く。補足的な例は `Notes` に置いてよい。
+- Light の場合でも、保持対象があるなら `Examples` セクションを追加して残す。保持対象が多い、または設計判断を含む場合は Standard に切り替える。
 - Issue タイトルは内容が一目で分かる具体的な文にする。
+- 選択したテンプレートの見出し構成と順序に従い、本文は日本語で記述する。
+- `Related Issues / PRs` を本文の先頭に置き、関連がなければ `None` と書く。
+- 背景、目的、変更概要は別々のセクションへ細分化せず、`Summary` にまとめる。
 - モノレポ運用で対象アプリやパッケージが明確な場合、Issue タイトルの先頭に Prefix を付ける。
 - Prefix 形式は `[example-app] title example` のように `[scope] summary` を使う。
 - 単一リポジトリ、または対象スコープが1つに定まらない場合は Prefix を付けない。
@@ -110,7 +111,7 @@ Issue の規模に応じて、`references/` 配下のテンプレートを **ど
 - Label は確認できた候補の中から、Issue 内容に最も合うものだけを選んで付与する。
 - 適切な Label が存在しない場合は、存在しない Label 名を新規に仮定して付けない。
 - ただし、既存 Label では運用上どうしても不足し、新規作成が妥当な場合は候補 Label 名と用途をユーザーに一度提案してから作成する。
-- ユーザーが README や `AGENTS.md` の更新を要求している場合は、本文の `### Documentation / ドキュメント` セクションに明記する。
+- ユーザーが README や `AGENTS.md` の更新を要求している場合は、本文の `### Documentation` セクションに明記する。
 - `gh issue create` を使い、必要なら対象リポジトリを `--repo` で明示する。
 - Label を付ける場合は、事前に確認した既存 Label 名だけを `--label` で明示する。
 - 新規 Label が必要な場合は、ユーザー合意前に Label を作成しない。
@@ -126,7 +127,10 @@ Issue の規模に応じて、`references/` 配下のテンプレートを **ど
     FILE=$(mktemp)
     trap 'rm -f "$FILE"' EXIT
     cat > "$FILE" << 'EOF'
-    ## Overview / 概要
+    ## Related Issues / PRs
+    None
+
+    ## Summary
     ...
     EOF
 

--- a/github-issue-create-from-plan/references/issue-template-light.md
+++ b/github-issue-create-from-plan/references/issue-template-light.md
@@ -1,17 +1,24 @@
-# Issue Template (Light) / 軽量Issueテンプレート
+# Issue Template (Light)
 
 軽微な修正向けの最小テンプレート。
 
 ## 本文テンプレート
 
-    ## Overview / 概要
-    <!-- Summarize in about 1–2 lines -->
+    ## Related Issues / PRs
 
-    ## Tasks / タスク
+    <!--
+    Link related issues or PRs.
+    Write "None" if there are no related items.
+    -->
+
+    ## Summary
+    <!-- Summarize the current context and expected outcome in about 1–3 lines -->
+
+    ## Tasks
 
     - [ ] Modify ○○
 
-    ## Examples / サンプル
+    ## Examples
 
     <!--
     Include this section only when the confirmed plan contains examples,
@@ -20,16 +27,16 @@
     Place code blocks, tables, Mermaid, or concrete examples here.
     -->
 
-    ## Testing / テスト
+    ## Testing
 
-    ### Validation Policy / 検証方針
+    ### Validation Policy
     If the project has linters or tests configured, make sure that the linter and tests pass.
 
-    ### Documentation / ドキュメント
+    ### Documentation
 
     <!-- Update README.md or AGENTS.md if needed. Write "None" if not applicable. -->
 
-    ## Acceptance Criteria / 完了条件
+    ## Acceptance Criteria
 
     - [ ] Expected behavior is implemented
     - [ ] If a linter command is configured, it completes successfully
@@ -38,8 +45,10 @@
 
 ## 注意事項
 
-- `Overview / 概要`、`Tasks / タスク`、`Acceptance Criteria / 完了条件`、`Testing / テスト` は省略しない。
-- 軽量テンプレートでは `Background / 背景`、`Implementation Approach / 実装方針`、`Design Details / 設計詳細`、`Out of Scope / スコープ外`、`Test Perspectives / テスト観点`、`Related Issues/PRs / 関連Issue・PR`、`Notes / 補足` は使わない。
-- `Examples / サンプル` は、Plan 原文にサンプル例、コードブロック、表、Mermaid、具体的な入出力例がある場合だけ使う。
+- テンプレートの見出し構成と順序に従い、本文は日本語で記述する。
+- `Related Issues / PRs` は本文の先頭に置き、関連がなければ `None` と書く。
+- `Related Issues / PRs`、`Summary`、`Tasks`、`Acceptance Criteria`、`Testing` は省略しない。
+- 軽量テンプレートでは `Implementation Approach`、`Design Details`、`Out of Scope`、`Test Perspectives`、`Notes` は使わない。
+- `Examples` は、Plan 原文にサンプル例、コードブロック、表、Mermaid、具体的な入出力例がある場合だけ使う。
 - サンプル量が多い、または設計判断を含む場合は Standard テンプレートへ切り替える。
-- ユーザーが README や `AGENTS.md` の更新を求めている場合は `### Documentation / ドキュメント` に明記する。不要なら `None` と書く。
+- ユーザーが README や `AGENTS.md` の更新を求めている場合は `### Documentation` に明記する。不要なら `None` と書く。

--- a/github-issue-create-from-plan/references/issue-template-standard.md
+++ b/github-issue-create-from-plan/references/issue-template-standard.md
@@ -1,4 +1,4 @@
-# Issue Template (Standard) / 標準Issueテンプレート
+# Issue Template (Standard)
 
 設計判断や横断的な影響を伴う通常の Issue 向けのフルテンプレート。
 
@@ -6,34 +6,34 @@
 
 設計に関する記述は箇条書きだけで終わらせない。次の表から対象に合う表現を 1 つ以上選んで含める。
 
-| Design target / 対象 | Preferred representation / 推奨表現 |
+| Design target | Preferred representation |
 | --- | --- |
-| Flow or state transition / フロー・状態遷移 | Mermaid `flowchart` or `stateDiagram-v2` |
-| User/API interaction / ユーザー操作・API連携 | Mermaid `sequenceDiagram` |
-| Database relationship / DB関係 | Mermaid `erDiagram` |
-| Data shape / データ構造 | TypeScript, JSON, SQL, or schema code block |
-| Core logic / 主要ロジック | Source-like pseudocode or small code snippet |
+| Flow or state transition | Mermaid `flowchart` or `stateDiagram-v2` |
+| User/API interaction | Mermaid `sequenceDiagram` |
+| Database relationship | Mermaid `erDiagram` |
+| Data shape | TypeScript, JSON, SQL, or schema code block |
+| Core logic | Source-like pseudocode or small code snippet |
 
-Plan 原文にサンプル例、コードブロック、表、Mermaid、具体的な入出力例がある場合は、要約で消さずに原文に近い形で残す。主な配置先は `Design Details / 設計詳細` とし、補足的な例だけ `Notes / 補足` に置く。
+Plan 原文にサンプル例、コードブロック、表、Mermaid、具体的な入出力例がある場合は、要約で消さずに原文に近い形で残す。主な配置先は `Design Details` とし、補足的な例だけ `Notes` に置く。
 
 ## 本文テンプレート
 
-    ## Overview / 概要
-    <!-- Summarize in about 1–2 lines -->
-
-    ## Objective / 目的
-    <!-- What will be gained by completing this task -->
-
-    ## Background / 背景
-
-    ## Related Issues/PRs / 関連Issue・PR
+    ## Related Issues / PRs
 
     <!--
     Link related issues, PRs, discussions, or external specs.
     If there are no related items, write "None" instead of leaving this ambiguous.
     -->
 
-    ## Implementation Approach / 実装方針
+    ## Summary
+
+    <!--
+    Summarize the current context, expected outcome, and why this work is needed.
+    Keep these points together instead of splitting them into Overview, Objective,
+    and Background sections.
+    -->
+
+    ## Implementation Approach
 
     <!--
     Describe the high-level approach here:
@@ -43,7 +43,7 @@ Plan 原文にサンプル例、コードブロック、表、Mermaid、具体�
     Keep concrete schemas, API contracts, edge-case handling, and detailed logic in Design Details.
     -->
 
-    ## Design Details / 設計詳細
+    ## Design Details
 
     <!--
     Describe concrete design specifications here:
@@ -72,29 +72,29 @@ Plan 原文にサンプル例、コードブロック、表、Mermaid、具体�
     };
     ```
 
-    ## Tasks / タスク
+    ## Tasks
 
     - [ ] Add to ○○
     - [ ] Modify ○○
 
-    ## Out of Scope / スコープ外
+    ## Out of Scope
 
     <!--
     Explicitly list work that this issue will not cover.
     This prevents implicit expectations from expanding the review scope.
     -->
 
-    ## Testing / テスト
+    ## Testing
 
-    ### Validation Policy / 検証方針
+    ### Validation Policy
     If the implementation task is large, it may be divided into multiple steps.
     In such cases, if the project has linters or tests configured, make sure that the linter and tests pass at each step.
 
-    ### Documentation / ドキュメント
+    ### Documentation
 
     <!-- Be sure to update README.md or AGENTS.md if they exist -->
 
-    ## Acceptance Criteria / 完了条件
+    ## Acceptance Criteria
 
     <!--
     Define what must be true for this issue to be considered Done.
@@ -106,21 +106,23 @@ Plan 原文にサンプル例、コードブロック、表、Mermaid、具体�
     - [ ] If a test command is configured, it completes successfully
     - [ ] If a formatter command is configured, it completes successfully
 
-    ## Test Perspectives / テスト観点
+    ## Test Perspectives
 
-    | Area / 観点 | What to Verify / 確認内容 | Method / 確認方法 |
+    | Area | What to Verify | Method |
     | --- | --- | --- |
-    | Normal path / 正常系 | Primary user flow and expected result | Unit, integration, or manual verification |
-    | Edge cases / 境界条件 | Empty, missing, invalid, or maximum/minimum inputs | Focused test cases or manual reproduction |
-    | Regression / 回帰 | Existing behavior that must not change | Existing tests or targeted smoke checks |
-    | Operations / 運用 | Logs, errors, permissions, docs, or migration impact | Command output, UI check, or documentation review |
+    | Normal path | Primary user flow and expected result | Unit, integration, or manual verification |
+    | Edge cases | Empty, missing, invalid, or maximum/minimum inputs | Focused test cases or manual reproduction |
+    | Regression | Existing behavior that must not change | Existing tests or targeted smoke checks |
+    | Operations | Logs, errors, permissions, docs, or migration impact | Command output, UI check, or documentation review |
 
-    ## Notes / 補足
+    ## Notes
 
 ## 注意事項
 
-- ユーザーが README や `AGENTS.md` の更新を求めている場合は `### Documentation / ドキュメント` に明記する。
-- `Related Issues/PRs / 関連Issue・PR` は関連がなければ `None` と書く。
+- テンプレートの見出し構成と順序に従い、本文は日本語で記述する。
+- `Related Issues / PRs` は本文の先頭に置き、関連がなければ `None` と書く。
+- 背景、目的、変更概要は `Summary` にまとめ、個別セクションへ分割しない。
+- ユーザーが README や `AGENTS.md` の更新を求めている場合は `### Documentation` に明記する。
 - 設計記述は表に従い、Mermaid・コードブロック・擬似コードのいずれかを必ず含める。
 - Plan 原文のサンプル例、コードブロック、表、Mermaid、具体的な入出力例は削らず、実装判断に必要か迷う場合は残す。
 - 本文テンプレート内の Mermaid や TypeScript はプレースホルダーなので、実際の Issue では Plan 原文の具体例で置き換える。


### PR DESCRIPTION
## Issues

None

## Why

Issue テンプレートの日英併記と細分化された概要セクションを整理し、生成される Issue を読みやすくするため。

## Summary

Issue テンプレートの見出しを英語に統一し、本文は日本語で記述するルールへ整理します。関連 Issue / PR を先頭へ移動し、Overview・Objective・Background は Summary に統合します。

## Changes

- Standard / Light テンプレートの見出しを英語に統一
- `Related Issues / PRs` を本文先頭へ移動
- 概要・目的・背景を `Summary` に統合
- plan / edit / auto モードの待機条件を簡素化
- スキル本体のテンプレート参照ルールと生成例を更新

## Checklist

- [x] フォーマット差分チェック
- [x] 全スキル検証
- [x] テンプレート参照の整合性確認
