### PR TITLE
feat: add tmux Codex split skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@
 |-------|-------------|
 | [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
 
+### ターミナル操作
+
+| Skill | Description |
+|-------|-------------|
+| [tmux-codex-split](tmux-codex-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで Codex CLI を起動する |
+
 ### ブラウザ操作 / 検証
 
 | Skill | Description |

--- a/tmux-codex-split/SKILL.md
+++ b/tmux-codex-split/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: tmux-codex-split
+description: tmux を分割して新しいペインで Codex CLI を起動する。「隣のペインで Codex」「tmux で Codex」などの依頼で使う。
+---
+
+# tmux Codex Split
+
+## 基本動作
+
+ユーザーから指定がなければ、現在実行中の tmux ペインを基準に同じウィンドウを左右分割し、新しい右ペインで `codex` を起動する。
+
+1. `TMUX` と `TMUX_PANE` が設定されていることを確認する。未設定なら、tmux 外から対象を推測して操作せずユーザーへ伝える。
+2. 次のコマンドで現在のペインを左右分割し、新規ペイン ID を取得する。
+
+   ```bash
+   tmux split-window -h -t "$TMUX_PANE" -c "#{pane_current_path}" -P -F '#{pane_id}'
+   ```
+
+3. 取得したペイン ID を `<new-pane-id>` として、文字入力と Enter を分けて送る（`send-keys -l` はリテラル文字しか送らず、Enter キーなど特殊キー名を解釈しないため）。
+
+   ```bash
+   tmux send-keys -t '<new-pane-id>' -l 'codex'
+   tmux send-keys -t '<new-pane-id>' Enter
+   ```
+
+4. `tmux capture-pane -p -t '<new-pane-id>' -S -20` で Codex の起動を確認する。
+
+## 指定の扱い
+
+- 対象ペインやセッションが指定された場合は、`$TMUX_PANE` より指定を優先する。
+- 「上下」指定なら `split-window -v` を使う。指定なしは `-h`（左右）とする。
+- 作業ディレクトリが指定された場合は `-c` にそのパスを渡す。指定なしは元ペインの `#{pane_current_path}` を引き継ぐ。
+- Codex のオプションや別コマンドが指定された場合は、`codex` の代わりに指定文字列を送る。
+- 既存ペインや別セッションを「隣」と推測して使わない。基本動作では必ず現在のウィンドウに新規ペインを作る。
+
+## 安全上の注意
+
+- 分割に失敗した場合は `send-keys` を実行しない。
+- ペイン ID は `split-window -P -F '#{pane_id}'` の出力をそのまま使い、位置番号を推測しない。
+- 起動確認でエラーが見えた場合は、成功したと報告しない。

--- a/tmux-codex-split/agents/openai.yaml
+++ b/tmux-codex-split/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "tmux Codex Split"
+  short_description: "現在の tmux を左右分割して Codex を起動"
+  default_prompt: "Use $tmux-codex-split to split the current tmux window horizontally and start Codex in the new pane."


### PR DESCRIPTION
## Why

tmux 上で Codex 用の隣接ペインを一貫した手順で作成できるようにするため。

## Summary

現在の tmux ウィンドウを左右分割し、新しいペインで Codex CLI を起動するスキルを追加します。対象や分割方向などが明示された場合にも対応します。

## Changes

- `tmux-codex-split` スキルと UI メタデータを追加
- 現在のペインを基準とした安全な分割・起動・確認手順を定義
- README の Available Skills にターミナル操作グループを追加

## Checklist

- [x] スキル単体の構造検証
- [x] リポジトリ全体のスキル検証
- [x] `git diff --check`
