### PR TITLE
Add tmux split skills for OpenCode and Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
 | Skill | Description |
 |-------|-------------|
 | [tmux-codex-split](tmux-codex-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで Codex CLI を起動する |
+| [tmux-opencode-split](tmux-opencode-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで OpenCode CLI を起動する |
+| [tmux-claude-split](tmux-claude-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで Claude Code CLI を起動する |
 
 ### ブラウザ操作 / 検証
 

--- a/tmux-claude-split/SKILL.md
+++ b/tmux-claude-split/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: tmux-claude-split
+description: tmux を分割して新しいペインで Claude Code CLI を起動する。「隣のペインで Claude Code」「tmux で Claude」などの依頼で使う。
+---
+
+# tmux Claude Code Split
+
+## 基本動作
+
+ユーザーから指定がなければ、現在実行中の tmux ペインを基準に同じウィンドウを左右分割し、新しい右ペインで `claude` を起動する。
+
+1. `TMUX` と `TMUX_PANE` が設定されていることを確認する。未設定なら、tmux 外から対象を推測して操作せずユーザーへ伝える。
+2. 次のコマンドで現在のペインを左右分割し、新規ペイン ID を取得する。
+
+   ```bash
+   tmux split-window -h -t "$TMUX_PANE" -c "#{pane_current_path}" -P -F '#{pane_id}'
+   ```
+
+3. 取得したペイン ID を `<new-pane-id>` として、文字入力と Enter を分けて送る（`send-keys -l` はリテラル文字しか送らず、Enter キーなど特殊キー名を解釈しないため）。
+
+   ```bash
+   tmux send-keys -t '<new-pane-id>' -l 'claude'
+   tmux send-keys -t '<new-pane-id>' Enter
+   ```
+
+4. `tmux capture-pane -p -t '<new-pane-id>' -S -20` で Claude Code の起動を確認する。
+
+## 指定の扱い
+
+- 対象ペインやセッションが指定された場合は、`$TMUX_PANE` より指定を優先する。
+- 「上下」指定なら `split-window -v` を使う。指定なしは `-h`（左右）とする。
+- 作業ディレクトリが指定された場合は `-c` にそのパスを渡す。指定なしは元ペインの `#{pane_current_path}` を引き継ぐ。
+- Claude Code のオプションや別コマンドが指定された場合は、`claude` の代わりに指定文字列を送る。
+- 既存ペインや別セッションを「隣」と推測して使わない。基本動作では必ず現在のウィンドウに新規ペインを作る。
+
+## 安全上の注意
+
+- 分割に失敗した場合は `send-keys` を実行しない。
+- ペイン ID は `split-window -P -F '#{pane_id}'` の出力をそのまま使い、位置番号を推測しない。
+- 起動確認でエラーが見えた場合は、成功したと報告しない。

--- a/tmux-claude-split/agents/openai.yaml
+++ b/tmux-claude-split/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "tmux Claude Code Split"
+  short_description: "現在の tmux を分割して Claude Code を起動"
+  default_prompt: "Use $tmux-claude-split to split the current tmux window horizontally and start Claude Code in the new pane."

--- a/tmux-opencode-split/SKILL.md
+++ b/tmux-opencode-split/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: tmux-opencode-split
+description: tmux を分割して新しいペインで OpenCode CLI を起動する。「隣のペインで OpenCode」「tmux で OpenCode」などの依頼で使う。
+---
+
+# tmux OpenCode Split
+
+## 基本動作
+
+ユーザーから指定がなければ、現在実行中の tmux ペインを基準に同じウィンドウを左右分割し、新しい右ペインで `opencode` を起動する。
+
+1. `TMUX` と `TMUX_PANE` が設定されていることを確認する。未設定なら、tmux 外から対象を推測して操作せずユーザーへ伝える。
+2. 次のコマンドで現在のペインを左右分割し、新規ペイン ID を取得する。
+
+   ```bash
+   tmux split-window -h -t "$TMUX_PANE" -c "#{pane_current_path}" -P -F '#{pane_id}'
+   ```
+
+3. 取得したペイン ID を `<new-pane-id>` として、文字入力と Enter を分けて送る（`send-keys -l` はリテラル文字しか送らず、Enter キーなど特殊キー名を解釈しないため）。
+
+   ```bash
+   tmux send-keys -t '<new-pane-id>' -l 'opencode'
+   tmux send-keys -t '<new-pane-id>' Enter
+   ```
+
+4. `tmux capture-pane -p -t '<new-pane-id>' -S -20` で OpenCode の起動を確認する。
+
+## 指定の扱い
+
+- 対象ペインやセッションが指定された場合は、`$TMUX_PANE` より指定を優先する。
+- 「上下」指定なら `split-window -v` を使う。指定なしは `-h`（左右）とする。
+- 作業ディレクトリが指定された場合は `-c` にそのパスを渡す。指定なしは元ペインの `#{pane_current_path}` を引き継ぐ。
+- OpenCode のオプションや別コマンドが指定された場合は、`opencode` の代わりに指定文字列を送る。
+- 既存ペインや別セッションを「隣」と推測して使わない。基本動作では必ず現在のウィンドウに新規ペインを作る。
+
+## 安全上の注意
+
+- 分割に失敗した場合は `send-keys` を実行しない。
+- ペイン ID は `split-window -P -F '#{pane_id}'` の出力をそのまま使い、位置番号を推測しない。
+- 起動確認でエラーが見えた場合は、成功したと報告しない。

--- a/tmux-opencode-split/agents/openai.yaml
+++ b/tmux-opencode-split/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "tmux OpenCode Split"
+  short_description: "現在の tmux を分割して OpenCode を起動"
+  default_prompt: "Use $tmux-opencode-split to split the current tmux window horizontally and start OpenCode in the new pane."


### PR DESCRIPTION
## Issues

- なし

## Why

tmux で起動する CLI ごとにトリガーと起動コマンドを明確にし、誤起動を避けながら個別に保守できるようにするためです。

## Summary

OpenCode と Claude Code を新しい tmux ペインで起動する専用スキルを追加します。既存の Codex 版と同じ分割操作と安全策を維持しつつ、スキルを物理的に分離します。

## Changes

- `tmux-opencode-split` を追加
- `tmux-claude-split` を追加
- README のターミナル操作一覧を更新

## Checklist

- [x] 両スキルを `quick_validate.py` で検証
- [x] `git diff --check` で差分を検証
- [x] README のリンクとスキル名を確認
