### PR TITLE
feat: add tmux agent payload messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 
 | Skill | Description |
 |-------|-------------|
+| [tmux-agent-messaging](tmux-agent-messaging/SKILL.md) | tmuxペイン上のAgent間でJSON Payloadを安全に非同期配送する |
 | [tmux-codex-split](tmux-codex-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで Codex CLI を起動する |
 | [tmux-opencode-split](tmux-opencode-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで OpenCode CLI を起動する |
 | [tmux-claude-split](tmux-claude-split/SKILL.md) | 現在の tmux ウィンドウを左右分割し、新しいペインで Claude Code CLI を起動する |

--- a/tmux-agent-messaging/SKILL.md
+++ b/tmux-agent-messaging/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: tmux-agent-messaging
+description: tmuxペイン上のAgent間で、長い指示や応答をJSON Payloadファイルとして安全に非同期配送する。別ペインのAgentへcommand・requestを送り、response・timeout・cleanupを扱う時に使う。
+---
+
+# tmux Agent Messaging
+
+`scripts/agent-message.sh` を使い、tmuxには本文ではなくPayloadの絶対パスだけを送る。`jq`がなければ自動インストールせず、ユーザーへ確認する。
+
+## 前提
+
+1. `TMUX`、`TMUX_PANE`、`jq`を確認する。
+2. Payloadの詳細が必要な時だけ`references/payload.schema.json`を読む。
+3. 通知されたPayloadは必ず`read`してから処理する。JSONを直接信頼しない。
+
+## 送信
+
+応答不要の指示は`command`、応答が必要な指示は`request`を使う。`--text`と`--text-file`は排他的に指定する。コンテキストは読み取り可能な絶対パスを`--context-file`で繰り返し渡す。
+
+```bash
+scripts/agent-message.sh command --to-pane '%2' --text-file /absolute/path/instruction.md
+scripts/agent-message.sh request --to-pane '%2' --text '調査してください' --timeout-seconds 1800
+```
+
+ネストした依頼では、現在処理中のrequestを指定して`traceId`を継承する。
+
+```bash
+scripts/agent-message.sh request --to-pane '%3' --parent-payload /tmp/tmux-agent-messaging/1000/trace-.../requests/msg-....json --text '追加調査'
+```
+
+request送信後は入力待ちへ戻る。1つの送信元ペインから同時に保持できる未完了requestは1件だけとする。
+
+## 受信と応答
+
+通知されたパスを`read`へ渡す。誤宛先、symlink、所有者違い、不正フィールドは拒否される。commandは正常に読んだ直後にPayloadが削除される。
+
+```bash
+scripts/agent-message.sh read /tmp/tmux-agent-messaging/1000/trace-.../commands/msg-....json
+```
+
+requestへの応答は元のPayloadを指定する。成功時は`completed`、失敗時は`failed`と`--error-code`を使う。
+
+```bash
+scripts/agent-message.sh respond --request /tmp/.../request.json --status completed --text-file /absolute/path/result.md
+scripts/agent-message.sh respond --request /tmp/.../request.json --status failed --error-code execution_failed --text '実行に失敗しました'
+```
+
+responseは直上の親ペインへだけ通知する。子孫からrootへ直接通知しない。親がresponseを`read`するとrequestとの対応確認と未完了状態の解除が行われる。失敗を受け取った中間Agentは、自身の親requestへ`failed`で応答し、ホップ単位で伝播する。
+
+## timeoutとcleanup
+
+requestは既定1800秒のwatchdogを起動する。timeout時は子ペインを停止せず、通常responseと同じ保存先をロックして`timeout` responseを確定し、親へ通知する。遅延responseは採用しない。
+
+rootは成功responseを読んで必要な成果物をworkspaceへ移した後、traceを削除する。失敗responseがある場合やresponseの`contextFiles`がtrace配下を参照する場合、cleanupは拒否される。
+
+```bash
+scripts/agent-message.sh cleanup --trace-id trace-...
+```
+
+timeout・失敗時はtraceを保持し、対象Agent、経過時間、`/tmp/tmux-agent-messaging/$UID/<traceId>/`をユーザーへ伝えて指示を待つ。

--- a/tmux-agent-messaging/SKILL.md
+++ b/tmux-agent-messaging/SKILL.md
@@ -5,7 +5,7 @@ description: tmuxペイン上のAgent間で、長い指示や応答をJSON Paylo
 
 # tmux Agent Messaging
 
-`scripts/agent-message.sh` を使い、tmuxには本文ではなくPayloadの絶対パスだけを送る。`jq`がなければ自動インストールせず、ユーザーへ確認する。
+この`SKILL.md`の配置ディレクトリを`<skill-dir>`として解決し、`<skill-dir>/scripts/agent-message.sh`を使う。現在の作業ディレクトリからの相対パスで解決しない。tmuxには本文ではなくPayloadの絶対パスだけを送る。`jq`がなければ自動インストールせず、ユーザーへ確認する。
 
 ## 前提
 
@@ -18,14 +18,14 @@ description: tmuxペイン上のAgent間で、長い指示や応答をJSON Paylo
 応答不要の指示は`command`、応答が必要な指示は`request`を使う。`--text`と`--text-file`は排他的に指定する。コンテキストは読み取り可能な絶対パスを`--context-file`で繰り返し渡す。
 
 ```bash
-scripts/agent-message.sh command --to-pane '%2' --text-file /absolute/path/instruction.md
-scripts/agent-message.sh request --to-pane '%2' --text '調査してください' --timeout-seconds 1800
+"<skill-dir>/scripts/agent-message.sh" command --to-pane '%2' --text-file /absolute/path/instruction.md
+"<skill-dir>/scripts/agent-message.sh" request --to-pane '%2' --text '調査してください' --timeout-seconds 1800
 ```
 
 ネストした依頼では、現在処理中のrequestを指定して`traceId`を継承する。
 
 ```bash
-scripts/agent-message.sh request --to-pane '%3' --parent-payload /tmp/tmux-agent-messaging/1000/trace-.../requests/msg-....json --text '追加調査'
+"<skill-dir>/scripts/agent-message.sh" request --to-pane '%3' --parent-payload /tmp/tmux-agent-messaging/1000/trace-.../requests/msg-....json --text '追加調査'
 ```
 
 request送信後は入力待ちへ戻る。1つの送信元ペインから同時に保持できる未完了requestは1件だけとする。
@@ -35,14 +35,14 @@ request送信後は入力待ちへ戻る。1つの送信元ペインから同時
 通知されたパスを`read`へ渡す。誤宛先、symlink、所有者違い、不正フィールドは拒否される。commandは正常に読んだ直後にPayloadが削除される。
 
 ```bash
-scripts/agent-message.sh read /tmp/tmux-agent-messaging/1000/trace-.../commands/msg-....json
+"<skill-dir>/scripts/agent-message.sh" read /tmp/tmux-agent-messaging/1000/trace-.../commands/msg-....json
 ```
 
 requestへの応答は元のPayloadを指定する。成功時は`completed`、失敗時は`failed`と`--error-code`を使う。
 
 ```bash
-scripts/agent-message.sh respond --request /tmp/.../request.json --status completed --text-file /absolute/path/result.md
-scripts/agent-message.sh respond --request /tmp/.../request.json --status failed --error-code execution_failed --text '実行に失敗しました'
+"<skill-dir>/scripts/agent-message.sh" respond --request /tmp/.../request.json --status completed --text-file /absolute/path/result.md
+"<skill-dir>/scripts/agent-message.sh" respond --request /tmp/.../request.json --status failed --error-code execution_failed --text '実行に失敗しました'
 ```
 
 responseは直上の親ペインへだけ通知する。子孫からrootへ直接通知しない。親がresponseを`read`するとrequestとの対応確認と未完了状態の解除が行われる。失敗を受け取った中間Agentは、自身の親requestへ`failed`で応答し、ホップ単位で伝播する。
@@ -54,7 +54,7 @@ requestは既定1800秒のwatchdogを起動する。timeout時は子ペインを
 rootは成功responseを読んで必要な成果物をworkspaceへ移した後、traceを削除する。失敗responseがある場合やresponseの`contextFiles`がtrace配下を参照する場合、cleanupは拒否される。
 
 ```bash
-scripts/agent-message.sh cleanup --trace-id trace-...
+"<skill-dir>/scripts/agent-message.sh" cleanup --trace-id trace-...
 ```
 
 timeout・失敗時はtraceを保持し、対象Agent、経過時間、`/tmp/tmux-agent-messaging/$UID/<traceId>/`をユーザーへ伝えて指示を待つ。

--- a/tmux-agent-messaging/agents/openai.yaml
+++ b/tmux-agent-messaging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "tmux Agent Messaging"
+  short_description: "tmux Agent間でJSON Payloadを安全に非同期配送する"
+  default_prompt: "Use $tmux-agent-messaging to send a JSON payload to another tmux agent pane."

--- a/tmux-agent-messaging/references/payload.schema.json
+++ b/tmux-agent-messaging/references/payload.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/u7chan/agent-skills/tmux-agent-messaging/payload.schema.json",
+  "title": "tmux Agent Message Payload",
+  "oneOf": [
+    { "$ref": "#/$defs/command" },
+    { "$ref": "#/$defs/request" },
+    { "$ref": "#/$defs/response" }
+  ],
+  "$defs": {
+    "common": {
+      "type": "object",
+      "required": ["id", "traceId", "action", "createdAt", "fromPaneId", "toPaneId", "text", "contextFiles"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^msg-[0-9a-f-]+$" },
+        "traceId": { "type": "string", "pattern": "^trace-[0-9a-f-]+$" },
+        "action": { "enum": ["command", "request", "response"] },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "fromPaneId": { "type": "string", "pattern": "^%[0-9]+$" },
+        "toPaneId": { "type": "string", "pattern": "^%[0-9]+$" },
+        "text": { "type": "string" },
+        "contextFiles": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^/" }
+        }
+      }
+    },
+    "command": {
+      "allOf": [
+        { "$ref": "#/$defs/common" },
+        {
+          "properties": { "action": { "const": "command" } }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "request": {
+      "allOf": [
+        { "$ref": "#/$defs/common" },
+        {
+          "required": ["responseFile", "timeoutSeconds"],
+          "properties": {
+            "action": { "const": "request" },
+            "responseFile": { "type": "string", "pattern": "^/tmp/tmux-agent-messaging/[0-9]+/trace-[0-9a-f-]+/responses/msg-[0-9a-f-]+\\.json$" },
+            "timeoutSeconds": { "type": "integer", "minimum": 1 }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "response": {
+      "allOf": [
+        { "$ref": "#/$defs/common" },
+        {
+          "required": ["inReplyTo", "status"],
+          "properties": {
+            "action": { "const": "response" },
+            "inReplyTo": { "type": "string", "pattern": "^msg-[0-9a-f-]+$" },
+            "status": { "enum": ["completed", "failed"] },
+            "error": {
+              "type": "object",
+              "required": ["code"],
+              "properties": { "code": { "type": "string", "minLength": 1 } },
+              "additionalProperties": false
+            }
+          }
+        }
+      ],
+      "if": { "properties": { "status": { "const": "failed" } } },
+      "then": { "required": ["error"] },
+      "else": { "not": { "required": ["error"] } },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/tmux-agent-messaging/scripts/agent-message.sh
+++ b/tmux-agent-messaging/scripts/agent-message.sh
@@ -144,7 +144,7 @@ trace_from_parent() {
 
 send_message() {
   local action="$1"; shift
-  local to='' text='' text_file='' parent='' timeout=1800 arg trace id dir payload_path response_file='' payload contexts_json
+  local to='' text='' text_file='' parent='' timeout=1800 arg trace id dir payload_path response_file='' payload contexts_json pending='' pending_lock=''
   local -a contexts=()
   while (($#)); do
     arg="$1"; shift
@@ -170,22 +170,25 @@ send_message() {
     payload_path="$dir/commands/$id.json"
     payload="$(jq -cn --arg id "$id" --arg trace "$trace" --arg now "$(now)" --arg from "$TMUX_PANE" --arg to "$to" --arg text "$text" --argjson contexts "$contexts_json" '{id:$id,traceId:$trace,action:"command",createdAt:$now,fromPaneId:$from,toPaneId:$to,text:$text,contextFiles:$contexts}')"
   else
-    local pending="$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    pending="$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    pending_lock="${pending}.lock"
     [[ ! -e "$pending" ]] || die "このペインには未完了requestがあります: $pending"
     payload_path="$dir/requests/$id.json"
     response_file="$dir/responses/$id.json"
     payload="$(jq -cn --arg id "$id" --arg trace "$trace" --arg now "$(now)" --arg from "$TMUX_PANE" --arg to "$to" --arg text "$text" --argjson contexts "$contexts_json" --arg response "$response_file" --argjson timeout "$timeout" '{id:$id,traceId:$trace,action:"request",createdAt:$now,fromPaneId:$from,toPaneId:$to,text:$text,contextFiles:$contexts,responseFile:$response,timeoutSeconds:$timeout}')"
+    mkdir "$pending_lock" 2>/dev/null || die "このペインには未完了requestがあります: $pending"
     if ! atomic_write "$pending" "$(jq -cn --arg request "$payload_path" --arg response "$response_file" --arg id "$id" --arg trace "$trace" '{requestFile:$request,responseFile:$response,requestId:$id,traceId:$trace}')"; then
+      rmdir "$pending_lock" 2>/dev/null || true
       die '未完了request状態を保存できません'
     fi
   fi
   if ! atomic_write "$payload_path" "$payload"; then
-    [[ "$action" == request ]] && rm -f "$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    if [[ "$action" == request ]]; then rm -f "$pending"; rmdir "$pending_lock" 2>/dev/null || true; fi
     die 'Payloadを保存できません'
   fi
   if ! notify_pane "$to" "$payload_path"; then
     rm -f "$payload_path"
-    [[ "$action" == request ]] && rm -f "$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    if [[ "$action" == request ]]; then rm -f "$pending"; rmdir "$pending_lock" 2>/dev/null || true; fi
     die 'Payloadの配送に失敗しました'
   fi
   if [[ "$action" == request ]]; then
@@ -196,18 +199,24 @@ send_message() {
 
 read_message() {
   (($# == 1)) || die 'usage: read <payload-path>'
-  local loaded path json action pending pending_json
+  local loaded path json action pending pending_lock pending_json
   loaded="$(load_payload "$1")"; path="${loaded%%$'\n'*}"; json="${loaded#*$'\n'}"; action="$(jq -r '.action' <<<"$json")"
   if [[ "$action" == response ]]; then
     pending="$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    pending_lock="${pending}.lock"
     [[ -f "$pending" && ! -L "$pending" && "$(stat -c '%u' "$pending")" == "$UID" ]] || die '対応する未完了requestがありません'
     pending_json="$(jq -c . "$pending")" || die '未完了request状態が不正です'
     jq -e 'keys == ["requestFile","requestId","responseFile","traceId"]' >/dev/null <<<"$pending_json" || die '未完了request状態に未定義フィールドがあります'
     jq -e --arg path "$path" --arg id "$(jq -r '.inReplyTo' <<<"$json")" '.responseFile == $path and .requestId == $id' >/dev/null <<<"$pending_json" || die 'responseが未完了requestと一致しません'
     rm -f "$pending"
+    rmdir "$pending_lock" 2>/dev/null || true
   fi
   printf '%s\n' "$json"
-  [[ "$action" == command ]] && rm -f "$path"
+  if [[ "$action" == command ]]; then
+    rm -f "$path"
+    rmdir "$(dirname "$path")" 2>/dev/null || true
+    rmdir "$(dirname "$(dirname "$path")")" 2>/dev/null || true
+  fi
   return 0
 }
 

--- a/tmux-agent-messaging/scripts/agent-message.sh
+++ b/tmux-agent-messaging/scripts/agent-message.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+readonly STORAGE_BASE="${TMUX_AGENT_MESSAGING_ROOT:-/tmp/tmux-agent-messaging/${UID}}"
+readonly SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+readonly NOTICE_PREFIX='$tmux-agent-messaging を使って次のPayloadを処理してください: '
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+require_command() { command -v "$1" >/dev/null 2>&1 || die "$1 が必要です。インストールしてよいかユーザーへ確認してください"; }
+require_tmux_env() { [[ -n "${TMUX:-}" && -n "${TMUX_PANE:-}" ]] || die 'TMUX と TMUX_PANE が必要です'; }
+
+init_storage() {
+  [[ ! -L "$STORAGE_BASE" ]] || die "保存ルートにsymlinkは使用できません: $STORAGE_BASE"
+  mkdir -p "$STORAGE_BASE/pending"
+  [[ "$(stat -c '%u' "$STORAGE_BASE")" == "$UID" ]] || die "保存ルートの所有者が現在ユーザーではありません: $STORAGE_BASE"
+  chmod 700 "$STORAGE_BASE" "$STORAGE_BASE/pending"
+}
+
+uuid() {
+  if command -v uuidgen >/dev/null 2>&1; then uuidgen | tr '[:upper:]' '[:lower:]';
+  elif [[ -r /proc/sys/kernel/random/uuid ]]; then tr '[:upper:]' '[:lower:]' < /proc/sys/kernel/random/uuid;
+  else die 'UUIDを生成できません'; fi
+}
+
+now() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+pane_key() { printf '%s' "${1#%}"; }
+
+assert_pane() {
+  local pane="$1" actual
+  [[ "$pane" =~ ^%[0-9]+$ ]] || die "不正なペインIDです: $pane"
+  actual="$(tmux display-message -p -t "$pane" '#{pane_id}' 2>/dev/null)" || die "送信先ペインが存在しません: $pane"
+  [[ "$actual" == "$pane" ]] || die "送信先ペインを確認できません: $pane"
+}
+
+notify_pane() {
+  local pane="$1" payload="$2"
+  tmux send-keys -t "$pane" -l "${NOTICE_PREFIX}${payload}" || return 1
+  tmux send-keys -t "$pane" Enter || return 1
+}
+
+safe_existing_payload() {
+  local path="$1" canonical base
+  [[ "$path" == /* && -f "$path" && ! -L "$path" ]] || die "Payloadはsymlinkではない通常ファイルである必要があります: $path"
+  [[ "$(stat -c '%u' "$path")" == "$UID" ]] || die "Payloadの所有者が現在ユーザーではありません: $path"
+  canonical="$(realpath -e "$path")"
+  base="$(realpath -e "$STORAGE_BASE")"
+  [[ "$canonical" == "$base"/trace-*/*/*.json ]] || die "Payloadが専用ルート配下にありません: $path"
+  printf '%s' "$canonical"
+}
+
+validate_context_files() {
+  local json="$1" path
+  while IFS= read -r path; do
+    [[ "$path" == /* && -f "$path" && -r "$path" ]] || die "contextFilesは読み取り可能な絶対パスに限ります: $path"
+  done < <(jq -r '.contextFiles[]' <<<"$json")
+}
+
+validate_payload_json() {
+  local json="$1" action allowed required status
+  jq -e 'type == "object"' >/dev/null <<<"$json" || die 'PayloadはJSON objectである必要があります'
+  action="$(jq -r '.action // empty' <<<"$json")"
+  case "$action" in
+    command) allowed='["id","traceId","action","createdAt","fromPaneId","toPaneId","text","contextFiles"]'; required="$allowed" ;;
+    request) allowed='["id","traceId","action","createdAt","fromPaneId","toPaneId","text","contextFiles","responseFile","timeoutSeconds"]'; required="$allowed" ;;
+    response) allowed='["id","traceId","action","createdAt","fromPaneId","toPaneId","text","contextFiles","inReplyTo","status","error"]'; required='["id","traceId","action","createdAt","fromPaneId","toPaneId","text","contextFiles","inReplyTo","status"]' ;;
+    *) die "不正なactionです: $action" ;;
+  esac
+  jq -e --argjson allowed "$allowed" --argjson required "$required" '
+    (keys_unsorted - $allowed | length) == 0 and
+    ($required - keys_unsorted | length) == 0 and
+    (.id | type == "string" and test("^msg-[0-9a-f-]+$")) and
+    (.traceId | type == "string" and test("^trace-[0-9a-f-]+$")) and
+    (.createdAt | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+    (.fromPaneId | type == "string" and test("^%[0-9]+$")) and
+    (.toPaneId | type == "string" and test("^%[0-9]+$")) and
+    (.text | type == "string") and
+    (.contextFiles | type == "array" and all(.[]; type == "string" and startswith("/")))
+  ' >/dev/null <<<"$json" || die 'Payloadの共通フィールドまたは未定義フィールドが不正です'
+  if [[ "$action" == request ]]; then
+    jq -e '.responseFile | type == "string" and startswith("/")' >/dev/null <<<"$json" || die 'responseFileが不正です'
+    jq -e '.timeoutSeconds | type == "number" and floor == . and . >= 1' >/dev/null <<<"$json" || die 'timeoutSecondsが不正です'
+  elif [[ "$action" == response ]]; then
+    jq -e '.inReplyTo | type == "string" and test("^msg-[0-9a-f-]+$")' >/dev/null <<<"$json" || die 'inReplyToが不正です'
+    status="$(jq -r '.status' <<<"$json")"
+    [[ "$status" == completed || "$status" == failed ]] || die 'statusが不正です'
+    if [[ "$status" == failed ]]; then
+      jq -e '.error | type == "object" and keys == ["code"] and (.code | type == "string" and length > 0)' >/dev/null <<<"$json" || die 'failed responseにはerror.codeが必要です'
+    else
+      jq -e 'has("error") | not' >/dev/null <<<"$json" || die 'completed responseにerrorは指定できません'
+    fi
+  fi
+  validate_context_files "$json"
+}
+
+load_payload() {
+  local path json expected_response
+  path="$(safe_existing_payload "$1")"
+  json="$(jq -c . "$path" 2>/dev/null)" || die "Payload JSONを解析できません: $path"
+  validate_payload_json "$json"
+  [[ "$(jq -r '.toPaneId' <<<"$json")" == "$TMUX_PANE" ]] || die "Payloadの宛先が現在のペインと一致しません"
+  if [[ "$(jq -r '.action' <<<"$json")" == request ]]; then
+    expected_response="$(dirname "$(dirname "$path")")/responses/$(jq -r '.id' <<<"$json").json"
+    [[ "$(jq -r '.responseFile' <<<"$json")" == "$expected_response" ]] || die 'responseFileがrequestのtrace配下にありません'
+  fi
+  printf '%s\n%s' "$path" "$json"
+}
+
+atomic_write() {
+  local target="$1" content="$2" tmp
+  mkdir -p "$(dirname "$target")"
+  chmod 700 "$(dirname "$target")" "$(dirname "$(dirname "$target")")"
+  tmp="$(dirname "$target")/.tmp.$(uuid)"
+  umask 077
+  printf '%s\n' "$content" > "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$target"
+}
+
+parse_text_args() {
+  local direct="$1" file="$2"
+  [[ -n "$direct" || -n "$file" ]] || die '--text または --text-file が必要です'
+  [[ -z "$direct" || -z "$file" ]] || die '--text と --text-file は同時指定できません'
+  if [[ -n "$file" ]]; then [[ "$file" == /* && -f "$file" && -r "$file" ]] || die '--text-fileは読み取り可能な絶対パスが必要です'; cat "$file"; else printf '%s' "$direct"; fi
+}
+
+context_json() {
+  local result='[]' path
+  for path in "$@"; do
+    [[ "$path" == /* && -f "$path" && -r "$path" ]] || die "contextFilesは読み取り可能な絶対パスに限ります: $path"
+    result="$(jq -c --arg path "$path" '. + [$path]' <<<"$result")"
+  done
+  printf '%s' "$result"
+}
+
+trace_from_parent() {
+  local parent="$1" loaded json
+  if [[ -z "$parent" ]]; then printf 'trace-%s' "$(uuid)"; return; fi
+  loaded="$(load_payload "$parent")"
+  json="${loaded#*$'\n'}"
+  [[ "$(jq -r '.action' <<<"$json")" == request ]] || die '--parent-payloadにはrequestを指定してください'
+  jq -r '.traceId' <<<"$json"
+}
+
+send_message() {
+  local action="$1"; shift
+  local to='' text='' text_file='' parent='' timeout=1800 arg trace id dir payload_path response_file='' payload contexts_json
+  local -a contexts=()
+  while (($#)); do
+    arg="$1"; shift
+    case "$arg" in
+      --to-pane) (($#)) || die "$arg に値が必要です"; to="$1"; shift ;;
+      --text) (($#)) || die "$arg に値が必要です"; text="$1"; shift ;;
+      --text-file) (($#)) || die "$arg に値が必要です"; text_file="$1"; shift ;;
+      --context-file) (($#)) || die "$arg に値が必要です"; contexts+=("$1"); shift ;;
+      --parent-payload) (($#)) || die "$arg に値が必要です"; parent="$1"; shift ;;
+      --timeout-seconds) (($#)) || die "$arg に値が必要です"; timeout="$1"; shift ;;
+      *) die "不明な引数です: $arg" ;;
+    esac
+  done
+  [[ -n "$to" ]] || die '--to-paneが必要です'
+  [[ "$timeout" =~ ^[1-9][0-9]*$ ]] || die '--timeout-secondsは1以上の整数です'
+  assert_pane "$to"
+  text="$(parse_text_args "$text" "$text_file")"
+  contexts_json="$(context_json "${contexts[@]}")"
+  trace="$(trace_from_parent "$parent")"
+  id="msg-$(uuid)"
+  dir="$STORAGE_BASE/$trace"
+  if [[ "$action" == command ]]; then
+    payload_path="$dir/commands/$id.json"
+    payload="$(jq -cn --arg id "$id" --arg trace "$trace" --arg now "$(now)" --arg from "$TMUX_PANE" --arg to "$to" --arg text "$text" --argjson contexts "$contexts_json" '{id:$id,traceId:$trace,action:"command",createdAt:$now,fromPaneId:$from,toPaneId:$to,text:$text,contextFiles:$contexts}')"
+  else
+    local pending="$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    [[ ! -e "$pending" ]] || die "このペインには未完了requestがあります: $pending"
+    payload_path="$dir/requests/$id.json"
+    response_file="$dir/responses/$id.json"
+    payload="$(jq -cn --arg id "$id" --arg trace "$trace" --arg now "$(now)" --arg from "$TMUX_PANE" --arg to "$to" --arg text "$text" --argjson contexts "$contexts_json" --arg response "$response_file" --argjson timeout "$timeout" '{id:$id,traceId:$trace,action:"request",createdAt:$now,fromPaneId:$from,toPaneId:$to,text:$text,contextFiles:$contexts,responseFile:$response,timeoutSeconds:$timeout}')"
+    if ! atomic_write "$pending" "$(jq -cn --arg request "$payload_path" --arg response "$response_file" --arg id "$id" --arg trace "$trace" '{requestFile:$request,responseFile:$response,requestId:$id,traceId:$trace}')"; then
+      die '未完了request状態を保存できません'
+    fi
+  fi
+  if ! atomic_write "$payload_path" "$payload"; then
+    [[ "$action" == request ]] && rm -f "$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    die 'Payloadを保存できません'
+  fi
+  if ! notify_pane "$to" "$payload_path"; then
+    rm -f "$payload_path"
+    [[ "$action" == request ]] && rm -f "$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    die 'Payloadの配送に失敗しました'
+  fi
+  if [[ "$action" == request ]]; then
+    ( sleep "$timeout"; "$SCRIPT_PATH" _timeout "$payload_path" ) >/dev/null 2>&1 &
+  fi
+  printf '%s\n' "$payload_path"
+}
+
+read_message() {
+  (($# == 1)) || die 'usage: read <payload-path>'
+  local loaded path json action pending pending_json
+  loaded="$(load_payload "$1")"; path="${loaded%%$'\n'*}"; json="${loaded#*$'\n'}"; action="$(jq -r '.action' <<<"$json")"
+  if [[ "$action" == response ]]; then
+    pending="$STORAGE_BASE/pending/$(pane_key "$TMUX_PANE").json"
+    [[ -f "$pending" && ! -L "$pending" && "$(stat -c '%u' "$pending")" == "$UID" ]] || die '対応する未完了requestがありません'
+    pending_json="$(jq -c . "$pending")" || die '未完了request状態が不正です'
+    jq -e 'keys == ["requestFile","requestId","responseFile","traceId"]' >/dev/null <<<"$pending_json" || die '未完了request状態に未定義フィールドがあります'
+    jq -e --arg path "$path" --arg id "$(jq -r '.inReplyTo' <<<"$json")" '.responseFile == $path and .requestId == $id' >/dev/null <<<"$pending_json" || die 'responseが未完了requestと一致しません'
+    rm -f "$pending"
+  fi
+  printf '%s\n' "$json"
+  [[ "$action" == command ]] && rm -f "$path"
+  return 0
+}
+
+respond() {
+  local request='' text='' text_file='' status='completed' error_code='' arg loaded request_path request_json response_file lock payload id contexts_json
+  local -a contexts=()
+  while (($#)); do
+    arg="$1"; shift
+    case "$arg" in
+      --request) (($#)) || die "$arg に値が必要です"; request="$1"; shift ;;
+      --text) (($#)) || die "$arg に値が必要です"; text="$1"; shift ;;
+      --text-file) (($#)) || die "$arg に値が必要です"; text_file="$1"; shift ;;
+      --status) (($#)) || die "$arg に値が必要です"; status="$1"; shift ;;
+      --error-code) (($#)) || die "$arg に値が必要です"; error_code="$1"; shift ;;
+      --context-file) (($#)) || die "$arg に値が必要です"; contexts+=("$1"); shift ;;
+      *) die "不明な引数です: $arg" ;;
+    esac
+  done
+  [[ -n "$request" ]] || die '--requestが必要です'
+  [[ "$status" == completed || "$status" == failed ]] || die '--statusはcompletedまたはfailedです'
+  [[ "$status" != failed || -n "$error_code" ]] || die 'failedには--error-codeが必要です'
+  [[ "$status" != completed || -z "$error_code" ]] || die 'completedに--error-codeは指定できません'
+  text="$(parse_text_args "$text" "$text_file")"
+  contexts_json="$(context_json "${contexts[@]}")"
+  loaded="$(load_payload "$request")"; request_path="${loaded%%$'\n'*}"; request_json="${loaded#*$'\n'}"
+  [[ "$(jq -r '.action' <<<"$request_json")" == request ]] || die '--requestにはrequest Payloadを指定してください'
+  response_file="$(jq -r '.responseFile' <<<"$request_json")"
+  [[ "$response_file" == "$(dirname "$(dirname "$request_path")")/responses/$(jq -r '.id' <<<"$request_json").json" ]] || die 'responseFileがrequestのtrace配下にありません'
+  mkdir -p "$(dirname "$response_file")"
+  chmod 700 "$(dirname "$response_file")"
+  lock="${response_file}.lock"
+  mkdir "$lock" 2>/dev/null || { [[ -f "$response_file" ]] && die 'responseは既に確定しています'; die 'responseロックを取得できません'; }
+  trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+  [[ ! -e "$response_file" ]] || die 'responseは既に確定しています'
+  id="msg-$(uuid)"
+  payload="$(jq -cn --arg id "$id" --arg trace "$(jq -r '.traceId' <<<"$request_json")" --arg now "$(now)" --arg from "$TMUX_PANE" --arg to "$(jq -r '.fromPaneId' <<<"$request_json")" --arg text "$text" --argjson contexts "$contexts_json" --arg reply "$(jq -r '.id' <<<"$request_json")" --arg status "$status" '{id:$id,traceId:$trace,action:"response",createdAt:$now,fromPaneId:$from,toPaneId:$to,text:$text,contextFiles:$contexts,inReplyTo:$reply,status:$status}')"
+  [[ "$status" != failed ]] || payload="$(jq -c --arg code "$error_code" '. + {error:{code:$code}}' <<<"$payload")"
+  atomic_write "$response_file" "$payload"
+  if ! notify_pane "$(jq -r '.fromPaneId' <<<"$request_json")" "$response_file"; then
+    rmdir "$lock" 2>/dev/null || true
+    die "responseは保存しましたが親ペインへの通知に失敗しました: $response_file"
+  fi
+  rmdir "$lock"
+  trap - EXIT
+  printf '%s\n' "$response_file"
+}
+
+timeout_request() {
+  (($# == 1)) || exit 1
+  local request="$1" request_json response lock payload
+  [[ -f "$request" && ! -L "$request" ]] || exit 0
+  request_json="$(jq -c . "$request" 2>/dev/null)" || exit 0
+  response="$(jq -r '.responseFile // empty' <<<"$request_json")"; [[ -n "$response" ]] || exit 0
+  [[ ! -e "$response" ]] || exit 0
+  mkdir -p "$(dirname "$response")"; chmod 700 "$(dirname "$response")"
+  lock="${response}.lock"; mkdir "$lock" 2>/dev/null || exit 0
+  trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+  [[ ! -e "$response" ]] || exit 0
+  payload="$(jq -cn --arg id "msg-$(uuid)" --arg trace "$(jq -r '.traceId' <<<"$request_json")" --arg now "$(now)" --arg from "$(jq -r '.toPaneId' <<<"$request_json")" --arg to "$(jq -r '.fromPaneId' <<<"$request_json")" --arg reply "$(jq -r '.id' <<<"$request_json")" '{id:$id,traceId:$trace,action:"response",createdAt:$now,fromPaneId:$from,toPaneId:$to,text:"制限時間内に応答がありませんでした",contextFiles:[],inReplyTo:$reply,status:"failed",error:{code:"timeout"}}')"
+  atomic_write "$response" "$payload"
+  notify_pane "$(jq -r '.fromPaneId' <<<"$request_json")" "$response" || exit 1
+}
+
+cleanup_trace() {
+  local trace='' arg dir file context pending
+  while (($#)); do arg="$1"; shift; case "$arg" in --trace-id) (($#)) || die "$arg に値が必要です"; trace="$1"; shift;; *) die "不明な引数です: $arg";; esac; done
+  [[ "$trace" =~ ^trace-[0-9a-f-]+$ ]] || die '--trace-idが不正です'
+  dir="$STORAGE_BASE/$trace"; [[ -d "$dir" && ! -L "$dir" ]] || die "traceが存在しません: $trace"
+  while IFS= read -r -d '' file; do
+    jq -e '.action == "response" and .status == "failed"' >/dev/null "$file" && die '失敗responseを含むtraceは保持してください'
+    while IFS= read -r context; do [[ "$context" != "$dir"/* ]] || die 'responseのcontextFilesがtrace配下を参照しています。成果物をworkspaceへ移してください'; done < <(jq -r 'select(.action == "response") | .contextFiles[]?' "$file")
+  done < <(find "$dir" -type f -name '*.json' -print0)
+  for pending in "$STORAGE_BASE"/pending/*.json; do
+    [[ -e "$pending" ]] || continue
+    jq -e --arg trace "$trace" '.traceId == $trace' "$pending" >/dev/null && die '未完了requestがあるためcleanupできません'
+  done
+  rm -rf -- "$dir"
+}
+
+main() {
+  require_command jq
+  init_storage
+  case "${1:-}" in
+    command|request) require_tmux_env; local action="$1"; shift; send_message "$action" "$@" ;;
+    read) require_tmux_env; shift; read_message "$@" ;;
+    respond) require_tmux_env; shift; respond "$@" ;;
+    cleanup) shift; cleanup_trace "$@" ;;
+    _timeout) shift; timeout_request "$@" ;;
+    *) die 'usage: agent-message.sh {command|request|read|respond|cleanup} ...' ;;
+  esac
+}
+
+main "$@"

--- a/tmux-agent-messaging/scripts/test-agent-message-tmux.sh
+++ b/tmux-agent-messaging/scripts/test-agent-message-tmux.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v tmux >/dev/null 2>&1 || { printf 'SKIP: tmux is not installed.\n'; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf 'ERROR: jq is required.\n' >&2; exit 1; }
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/agent-message.sh"
+server="agent-message-test-$$"
+root="$(mktemp -d)"
+trap 'tmux -L "$server" kill-server 2>/dev/null || true; rm -rf "$root"' EXIT
+
+tmux -L "$server" new-session -d -s test -c "$PWD"
+parent="$(tmux -L "$server" display-message -p -t test:0.0 '#{pane_id}')"
+child="$(tmux -L "$server" split-window -d -P -F '#{pane_id}' -t "$parent" -c "$PWD")"
+pid="$(tmux -L "$server" display-message -p '#{pid}')"
+tmux_env="/tmp/tmux-${UID}/${server},${pid},0"
+
+request_path="$(TMUX="$tmux_env" TMUX_PANE="$parent" TMUX_AGENT_MESSAGING_ROOT="$root" "$helper" request --to-pane "$child" --text 'integration' --timeout-seconds 30)"
+sleep 0.2
+child_capture="$(tmux -L "$server" capture-pane -p -J -t "$child" -S -100)"
+grep -F "$(basename "$request_path")" <<<"$child_capture" >/dev/null || { printf 'Child pane did not receive request path:\n%s\n' "$child_capture" >&2; exit 1; }
+
+response_path="$(TMUX="$tmux_env" TMUX_PANE="$child" TMUX_AGENT_MESSAGING_ROOT="$root" "$helper" respond --request "$request_path" --text 'done')"
+sleep 0.2
+parent_capture="$(tmux -L "$server" capture-pane -p -J -t "$parent" -S -100)"
+grep -F "$(basename "$response_path")" <<<"$parent_capture" >/dev/null || { printf 'Parent pane did not receive response path:\n%s\n' "$parent_capture" >&2; exit 1; }
+TMUX="$tmux_env" TMUX_PANE="$parent" TMUX_AGENT_MESSAGING_ROOT="$root" "$helper" read "$response_path" | jq -e '.status == "completed"' >/dev/null
+
+printf 'Isolated tmux integration test passed.\n'

--- a/tmux-agent-messaging/scripts/test-agent-message.sh
+++ b/tmux-agent-messaging/scripts/test-agent-message.sh
@@ -21,6 +21,14 @@ case "$1" in
 esac
 EOF
 chmod +x "$tmp/bin/tmux"
+cat > "$tmp/bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+last="${!#}"
+if [[ -n "${FAKE_MV_DELAY_PENDING:-}" && "$last" == */pending/*.json ]]; then sleep 0.2; fi
+exec /usr/bin/mv "$@"
+EOF
+chmod +x "$tmp/bin/mv"
 
 export PATH="$tmp/bin:$PATH"
 export FAKE_TMUX_LOG="$tmp/tmux.log"
@@ -37,7 +45,8 @@ assert_jq() { jq -e "$2" "$1" >/dev/null || fail "$3"; }
 if $helper command --to-pane '%2' --text 'bad context' --context-file relative.txt >/dev/null 2>&1; then fail 'relative context rejection'; fi
 
 long_text="$(printf '長い本文%.0s' {1..1000})"
-command_path="$($helper command --to-pane '%2' --text "$long_text" --context-file "$context")"
+command_path="$(cd "$tmp" && "$helper" command --to-pane '%2' --text "$long_text" --context-file "$context")"
+command_trace_dir="$(dirname "$(dirname "$command_path")")"
 assert_jq "$command_path" '.action == "command" and (.text | length > 1000)' 'command payload'
 [[ "$(stat -c '%a' "$(dirname "$(dirname "$command_path")")")" == 700 ]] || fail 'trace directory permissions'
 [[ "$(stat -c '%a' "$command_path")" == 600 ]] || fail 'payload permissions'
@@ -48,6 +57,7 @@ export TMUX_PANE='%2'
 command_json="$($helper read "$command_path")"
 [[ "$(jq -r '.text' <<<"$command_json")" == "$long_text" ]] || fail 'command read'
 [[ ! -e "$command_path" ]] || fail 'command cleanup after read'
+[[ ! -d "$command_trace_dir" ]] || fail 'empty command trace cleanup'
 
 export TMUX_PANE='%1'
 request_path="$($helper request --to-pane '%2' --text '調査' --timeout-seconds 30)"
@@ -66,6 +76,24 @@ response_json="$($helper read "$response_path")"
 trace="$(jq -r '.traceId' "$request_path")"
 $helper cleanup --trace-id "$trace"
 [[ ! -d "$TMUX_AGENT_MESSAGING_ROOT/$trace" ]] || fail 'successful cleanup'
+
+# Concurrent requests atomically reserve the one pending slot.
+export FAKE_MV_DELAY_PENDING=1
+set +e
+$helper request --to-pane '%2' --text 'request-a' --timeout-seconds 30 > "$tmp/request-a.out" 2>/dev/null & request_a=$!
+$helper request --to-pane '%2' --text 'request-b' --timeout-seconds 30 > "$tmp/request-b.out" 2>/dev/null & request_b=$!
+wait "$request_a"; request_a_status=$?
+wait "$request_b"; request_b_status=$?
+set -e
+unset FAKE_MV_DELAY_PENDING
+((request_a_status + request_b_status == 1)) || fail 'pending request reservation race'
+if ((request_a_status == 0)); then request_path="$(<"$tmp/request-a.out")"; else request_path="$(<"$tmp/request-b.out")"; fi
+export TMUX_PANE='%2'
+response_path="$($helper respond --request "$request_path" --text 'request race done')"
+export TMUX_PANE='%1'
+$helper read "$response_path" >/dev/null
+trace="$(jq -r '.traceId' "$request_path")"
+$helper cleanup --trace-id "$trace"
 
 # A payload addressed to another pane is rejected.
 wrong_target="$($helper command --to-pane '%2' --text 'wrong target')"

--- a/tmux-agent-messaging/scripts/test-agent-message.sh
+++ b/tmux-agent-messaging/scripts/test-agent-message.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/agent-message.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+cat > "$tmp/bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  display-message)
+    while (($#)); do [[ "$1" == -t ]] && { shift; printf '%s\n' "$1"; exit; }; shift; done
+    ;;
+  send-keys)
+    printf '%s\n' "$*" >> "${FAKE_TMUX_LOG:?}"
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$tmp/bin/tmux"
+
+export PATH="$tmp/bin:$PATH"
+export FAKE_TMUX_LOG="$tmp/tmux.log"
+export TMUX='fake'
+export TMUX_AGENT_MESSAGING_ROOT="$tmp/store"
+export TMUX_PANE='%1'
+touch "$FAKE_TMUX_LOG"
+context="$tmp/context.txt"
+printf 'context\n' > "$context"
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+assert_jq() { jq -e "$2" "$1" >/dev/null || fail "$3"; }
+
+if $helper command --to-pane '%2' --text 'bad context' --context-file relative.txt >/dev/null 2>&1; then fail 'relative context rejection'; fi
+
+long_text="$(printf '長い本文%.0s' {1..1000})"
+command_path="$($helper command --to-pane '%2' --text "$long_text" --context-file "$context")"
+assert_jq "$command_path" '.action == "command" and (.text | length > 1000)' 'command payload'
+[[ "$(stat -c '%a' "$(dirname "$(dirname "$command_path")")")" == 700 ]] || fail 'trace directory permissions'
+[[ "$(stat -c '%a' "$command_path")" == 600 ]] || fail 'payload permissions'
+grep -F "$command_path" "$FAKE_TMUX_LOG" >/dev/null || fail 'command notification'
+! grep -F "$long_text" "$FAKE_TMUX_LOG" >/dev/null || fail 'tmux must not receive message text'
+
+export TMUX_PANE='%2'
+command_json="$($helper read "$command_path")"
+[[ "$(jq -r '.text' <<<"$command_json")" == "$long_text" ]] || fail 'command read'
+[[ ! -e "$command_path" ]] || fail 'command cleanup after read'
+
+export TMUX_PANE='%1'
+request_path="$($helper request --to-pane '%2' --text '調査' --timeout-seconds 30)"
+if $helper request --to-pane '%2' --text '重複' --timeout-seconds 30 >/dev/null 2>&1; then fail 'one pending request per pane'; fi
+
+export TMUX_PANE='%2'
+request_json="$($helper read "$request_path")"
+[[ "$(jq -r '.action' <<<"$request_json")" == request ]] || fail 'request read'
+response_path="$($helper respond --request "$request_path" --status completed --text '完了' --context-file "$context")"
+assert_jq "$response_path" '.status == "completed" and .contextFiles[0] != null' 'completed response'
+if $helper respond --request "$request_path" --status completed --text '遅延' >/dev/null 2>&1; then fail 'response overwrite'; fi
+
+export TMUX_PANE='%1'
+response_json="$($helper read "$response_path")"
+[[ "$(jq -r '.inReplyTo' <<<"$response_json")" == "$(jq -r '.id' "$request_path")" ]] || fail 'response pairing'
+trace="$(jq -r '.traceId' "$request_path")"
+$helper cleanup --trace-id "$trace"
+[[ ! -d "$TMUX_AGENT_MESSAGING_ROOT/$trace" ]] || fail 'successful cleanup'
+
+# A payload addressed to another pane is rejected.
+wrong_target="$($helper command --to-pane '%2' --text 'wrong target')"
+export TMUX_PANE='%3'
+if $helper read "$wrong_target" >/dev/null 2>&1; then fail 'wrong target rejection'; fi
+export TMUX_PANE='%2'
+$helper read "$wrong_target" >/dev/null
+export TMUX_PANE='%1'
+
+# Nested requests inherit traceId and respond one hop at a time.
+request_path="$($helper request --to-pane '%2' --text 'root request' --timeout-seconds 30)"
+root_trace="$(jq -r '.traceId' "$request_path")"
+export TMUX_PANE='%2'
+$helper read "$request_path" >/dev/null
+nested_request="$($helper request --to-pane '%3' --parent-payload "$request_path" --text 'nested request' --timeout-seconds 30)"
+[[ "$(jq -r '.traceId' "$nested_request")" == "$root_trace" ]] || fail 'nested trace inheritance'
+export TMUX_PANE='%3'
+$helper read "$nested_request" >/dev/null
+nested_response="$($helper respond --request "$nested_request" --text 'nested done')"
+export TMUX_PANE='%2'
+$helper read "$nested_response" >/dev/null
+root_response="$($helper respond --request "$request_path" --text 'root done')"
+export TMUX_PANE='%1'
+$helper read "$root_response" >/dev/null
+$helper cleanup --trace-id "$root_trace"
+
+# Concurrent responders share one lock; exactly one response is accepted.
+request_path="$($helper request --to-pane '%2' --text 'race' --timeout-seconds 30)"
+export TMUX_PANE='%2'
+set +e
+$helper respond --request "$request_path" --text 'race-a' > "$tmp/race-a.out" 2>/dev/null & race_a=$!
+$helper respond --request "$request_path" --text 'race-b' > "$tmp/race-b.out" 2>/dev/null & race_b=$!
+wait "$race_a"; race_a_status=$?
+wait "$race_b"; race_b_status=$?
+set -e
+((race_a_status + race_b_status == 1)) || fail 'response lock race'
+response_path="$(jq -r '.responseFile' "$request_path")"
+export TMUX_PANE='%1'
+$helper read "$response_path" >/dev/null
+trace="$(jq -r '.traceId' "$request_path")"
+$helper cleanup --trace-id "$trace"
+
+request_path="$($helper request --to-pane '%2' --text 'timeout' --timeout-seconds 1)"
+sleep 2
+response_path="$(jq -r '.responseFile' "$request_path")"
+assert_jq "$response_path" '.status == "failed" and .error.code == "timeout"' 'timeout response'
+export TMUX_PANE='%2'
+if $helper respond --request "$request_path" --text 'late response' >/dev/null 2>&1; then fail 'late response rejection'; fi
+export TMUX_PANE='%1'
+$helper read "$response_path" >/dev/null
+trace="$(jq -r '.traceId' "$request_path")"
+if $helper cleanup --trace-id "$trace" >/dev/null 2>&1; then fail 'failed trace retention'; fi
+
+export TMUX_PANE='%9'
+bad="$TMUX_AGENT_MESSAGING_ROOT/$trace/responses/bad.json"
+jq '. + {unknown:true}' "$response_path" > "$bad"
+chmod 600 "$bad"
+if $helper read "$bad" >/dev/null 2>&1; then fail 'unknown field rejection'; fi
+ln -s "$response_path" "$TMUX_AGENT_MESSAGING_ROOT/$trace/responses/link.json"
+if $helper read "$TMUX_AGENT_MESSAGING_ROOT/$trace/responses/link.json" >/dev/null 2>&1; then fail 'symlink rejection'; fi
+
+printf 'All agent-message tests passed.\n'

--- a/tmux-claude-split/SKILL.md
+++ b/tmux-claude-split/SKILL.md
@@ -25,6 +25,14 @@ description: tmux を分割して新しいペインで Claude Code CLI を起動
 
 4. `tmux capture-pane -p -t '<new-pane-id>' -S -20` で Claude Code の起動を確認する。
 
+## Agent間メッセージング
+
+起動後のClaude Codeへ長い指示、複数行の本文、コンテキストファイル、応答が必要な依頼を渡す時は、`../tmux-agent-messaging/SKILL.md`を読み、共通ヘルパーで新規ペインへPayloadパスだけを通知する。短いCLI起動コマンド以外の本文を`tmux send-keys`へ直接渡さない。
+
+- 応答不要なら`command --to-pane '<new-pane-id>'`を使う。
+- 応答が必要なら`request --to-pane '<new-pane-id>'`を使い、送信後は入力待ちへ戻る。
+- 子ペインから通知されたresponseは共通ヘルパーの`read`で検証する。
+
 ## 指定の扱い
 
 - 対象ペインやセッションが指定された場合は、`$TMUX_PANE` より指定を優先する。

--- a/tmux-codex-split/SKILL.md
+++ b/tmux-codex-split/SKILL.md
@@ -25,6 +25,14 @@ description: tmux を分割して新しいペインで Codex CLI を起動する
 
 4. `tmux capture-pane -p -t '<new-pane-id>' -S -20` で Codex の起動を確認する。
 
+## Agent間メッセージング
+
+起動後のCodexへ長い指示、複数行の本文、コンテキストファイル、応答が必要な依頼を渡す時は、`../tmux-agent-messaging/SKILL.md`を読み、共通ヘルパーで新規ペインへPayloadパスだけを通知する。短いCLI起動コマンド以外の本文を`tmux send-keys`へ直接渡さない。
+
+- 応答不要なら`command --to-pane '<new-pane-id>'`を使う。
+- 応答が必要なら`request --to-pane '<new-pane-id>'`を使い、送信後は入力待ちへ戻る。
+- 子ペインから通知されたresponseは共通ヘルパーの`read`で検証する。
+
 ## 指定の扱い
 
 - 対象ペインやセッションが指定された場合は、`$TMUX_PANE` より指定を優先する。

--- a/tmux-opencode-split/SKILL.md
+++ b/tmux-opencode-split/SKILL.md
@@ -25,6 +25,14 @@ description: tmux を分割して新しいペインで OpenCode CLI を起動す
 
 4. `tmux capture-pane -p -t '<new-pane-id>' -S -20` で OpenCode の起動を確認する。
 
+## Agent間メッセージング
+
+起動後のOpenCodeへ長い指示、複数行の本文、コンテキストファイル、応答が必要な依頼を渡す時は、`../tmux-agent-messaging/SKILL.md`を読み、共通ヘルパーで新規ペインへPayloadパスだけを通知する。短いCLI起動コマンド以外の本文を`tmux send-keys`へ直接渡さない。
+
+- 応答不要なら`command --to-pane '<new-pane-id>'`を使う。
+- 応答が必要なら`request --to-pane '<new-pane-id>'`を使い、送信後は入力待ちへ戻る。
+- 子ペインから通知されたresponseは共通ヘルパーの`read`で検証する。
+
 ## 指定の扱い
 
 - 対象ペインやセッションが指定された場合は、`$TMUX_PANE` より指定を優先する。


### PR DESCRIPTION
## Issues

- Close #136

## Why

tmux経由で長い指示や応答を直接送ると、入力サイズ、改行、エスケープの扱いが不安定になるため、Agent間で共通利用できるファイルベースの通信契約が必要でした。

## Summary

JSON Payloadを一時ファイルへ原子的に保存し、tmuxではPayloadパスだけを通知する`tmux-agent-messaging`スキルを追加します。request/response、timeout、競合制御、検証、cleanupを共通ヘルパーへ集約し、既存3種類のsplitスキルから参照できるようにします。

## Changes

- `command`、`request`、`read`、`respond`、`cleanup`を提供するBashヘルパーを追加
- action別JSON Schemaと、宛先・所有者・symlink・context path・未定義フィールドの検証を追加
- watchdog、1ペイン1request制約、atomic response、応答競合ロック、失敗trace保持を実装
- ネストしたrequestの`traceId`継承とホップ単位のresponseを実装
- 単体テストと隔離tmuxサーバーによる結合テストを追加
- Codex、Claude Code、OpenCodeのsplitスキルとREADMEを同期

## Verification

- `bash tmux-agent-messaging/scripts/test-agent-message.sh` - passed
- `bash tmux-agent-messaging/scripts/test-agent-message-tmux.sh` - passed
- `python3 /home/u7dev/.codex/skills/.system/skill-creator/scripts/quick_validate.py tmux-agent-messaging` - passed
- `bash scripts/validate-skills.sh` - passed
- `bash -n tmux-agent-messaging/scripts/*.sh` - passed
- Draft 2020-12 validatorによるSchemaとaction別サンプル検証 - passed
- `git diff --check` - passed
