### PR TITLE
refactor: skill descriptionsを日本語化・圧縮

### DIFF
--- a/.claude/skills/skills-readme-sync/SKILL.md
+++ b/.claude/skills/skills-readme-sync/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: skills-readme-sync
 description: >
-  Use this when adding, renaming, removing, or materially changing skills in this
-  repository and the README may need to be updated. It synchronizes the README's
-  Available Skills table with the current skill set.
+  このリポジトリでスキルを追加・改名・削除・大幅変更し、READMEの更新が必要なときに使う。
+  Available Skills表を現在のスキル構成へ同期する。
 ---
 
 # Skills README Sync

--- a/ai-identity-resolve/SKILL.md
+++ b/ai-identity-resolve/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: ai-identity-resolve
 description: >
-  Resolve AI agent identity metadata for review comments and PR replies. Use
-  when composing AI review helper metadata or when another skill needs the
-  current agent name and model name without guessing.
+  レビューコメントやPR返信に付けるAI識別メタデータを解決するときに使う。
+  現在のエージェント名とモデル名を推測せず取得する。
 ---
 
 # 概要

--- a/bun-dependency-update/SKILL.md
+++ b/bun-dependency-update/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: bun-dependency-update
 description: >
-  Use this when asked to update dependencies in a Bun application, whether the request is
-  a broad non-major refresh or a major-version upgrade for a specific package. It captures
-  the branching workflow for deciding between safe non-major Bun updates and an interactive
-  major-upgrade flow with upstream research, user confirmation, one-package-at-a-time changes,
-  and project validation.
+  Bunアプリの依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う。
+  upstream調査、ユーザー確認、1パッケージずつの更新、プロジェクト検証まで扱う。
 ---
 
 # Bun Dependency Updater

--- a/codex-skills-link-from-claude/SKILL.md
+++ b/codex-skills-link-from-claude/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: codex-skills-link-from-claude
 description: >
-  Use this when asked to make Claude Code skills available to Codex by creating a
-  `.codex/skills` symlink that points to `.claude/skills`. It captures the exact
-  symlink pattern that works in this repo and avoids the relative-path mistake that
-  breaks editor discovery.
+  Claude CodeのスキルをCodexでも使えるように依頼されたときに使う。
+  `.claude/skills` を指す `.codex/skills` symlinkを正しい相対パスで作成し、エディタの検出漏れを防ぐ。
 ---
 
 # Claude To Codex Skills Link

--- a/git-branch-create/SKILL.md
+++ b/git-branch-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-branch-create
-description: Branch naming and creation workflow
+description: Gitブランチ名の提案やブランチ作成を依頼されたときに使う。
 ---
 
 ## ワークフロー

--- a/git-commit-message/SKILL.md
+++ b/git-commit-message/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-message
-description: Commit message suggestion workflow
+description: Gitのコミットメッセージ提案を依頼されたときに使う。
 ---
 
 ## ワークフロー

--- a/git-worktree-create/SKILL.md
+++ b/git-worktree-create/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: git-worktree-create
 description: >
-  Create an isolated git worktree for coding-agent work, including base branch
-  resolution, branch naming, collision checks, and the handoff path for
-  implementation.
+  コーディングエージェント用の独立したgit worktreeを作成するときに使う。
+  基点ブランチの特定、ブランチ命名、衝突確認、実装先の引き継ぎまで扱う。
 ---
 
 # 概要

--- a/github-pr-comment-reply/SKILL.md
+++ b/github-pr-comment-reply/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: github-pr-comment-reply
 description: >
-  Use this when asked to reply to an existing GitHub Pull Request review comment
-  or PR conversation comment. Trigger this skill when the user provides a
-  comment URL or comment ID, or asks to find a comment on the current PR and
-  post a reply on GitHub.
+  GitHub PRのreview commentやconversation commentへの返信を依頼されたときに使う。
+  コメントURL・IDが指定された場合や、現在のPRから対象コメントを探してGitHubへ返信する場合に起動する。
 ---
 
 # 概要

--- a/github-pr-create/SKILL.md
+++ b/github-pr-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-create
-description: Use when asked to create or open a GitHub PR, including casual requests like "PRまでお願い", "PRまで", "pushしてPR", "PR作って", or "PR open". Handles PR body generation and gh-based PR creation.
+description: GitHub PRの作成を依頼されたときに使う。「PRまでお願い」「PRまで」「pushしてPR」「PR作って」「PR open」も対象。PR本文を生成し、ghでPRを作成する。
 ---
 
 ## 概要

--- a/github-pr-feedback-address/SKILL.md
+++ b/github-pr-feedback-address/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: github-pr-feedback-address
 description: >
-  Use this when asked to address feedback on an existing GitHub Pull Request, including casual requests like "PRのFBおねがい", "PRのコメントみて", "レビューコメント対応して", "FB対応して", or requests made after a PR has been opened and review comments are expected. Finds the current PR from the provided PR URL/number or current branch, inspects unresolved review feedback, implements fixes, validates, commits, pushes, and replies to the addressed feedback comments.
+  既存のGitHub PRへのfeedback対応を依頼されたときに使う。「PRのFBおねがい」「PRのコメントみて」
+  「レビューコメント対応して」「FB対応して」も対象。未解決feedbackの検証、修正、テスト、commit、push、返信まで行う。
 ---
 
 # 概要

--- a/github-pr-review/SKILL.md
+++ b/github-pr-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: github-pr-review
 description: >
-  Use this when asked to review a specific GitHub Pull Request and leave review comments on the PR itself.
-  Trigger this skill when the user provides a PR number or URL, says casual review requests like "レビューして", "PRレビューして", or "このPR見て", or explicitly asks you to review and comment on a GitHub PR instead of only summarizing findings in chat. Also trigger when the user asks to recheck feedback previously posted by this skill.
+  指定されたGitHub PRのレビューや再チェックを行い、PR上へコメントするときに使う。
+  PR URL・番号の指定や、「レビューして」「PRレビューして」「このPR見て」など、GitHubへの投稿を求める依頼で起動する。
 ---
 
 # 概要

--- a/npm-dependency-update/SKILL.md
+++ b/npm-dependency-update/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: npm-dependency-update
 description: >
-  Use this when asked to update dependencies in an npm application, whether the request is
-  a broad non-major refresh or a major-version upgrade for a specific package. It captures
-  the branching workflow for deciding between safe npm updates within the current major
-  series and an interactive major-upgrade flow with upstream research, user confirmation,
-  one-package-at-a-time changes, and project validation.
+  npmアプリの依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う。
+  upstream調査、ユーザー確認、1パッケージずつの更新、プロジェクト検証まで扱う。
 ---
 
 # npm Dependency Updater

--- a/skill-author/SKILL.md
+++ b/skill-author/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: skill-author
 description: >
-  Used when creating or improving SKILL.md files.
-  Triggered by "create a skill", "write a SKILL.md", "turn this workflow into a skill",
-  or when reviewing/improving existing skills.
+  SKILL.mdの新規作成・改善・レビュー、または既存ワークフローのスキル化を依頼されたときに使う。
+  「create a skill」「write a SKILL.md」「turn this workflow into a skill」なども対象。
 ---
 
 # 概要

--- a/tailwind-ui-compose/SKILL.md
+++ b/tailwind-ui-compose/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: tailwind-ui-compose
 description: >
-  Composition-first UI design and Tailwind implementation guidance for screens,
-  pages, and app surfaces that need clear hierarchy, restrained decoration, and
-  responsive structure. Use when Codex is asked to design a new UI, restyle an
-  existing screen, propose layout direction, or generate JSX/TSX with Tailwind
-  while avoiding card-heavy, shadow-heavy, component-first output.
+  Tailwindで画面を新規設計・リスタイルするとき、レイアウト提案やJSX/TSX生成を依頼されたときに使う。
+  明確な階層、控えめな装飾、レスポンシブ構成を重視したcomposition-firstのUI設計を扱う。
 ---
 
 # Design UI Compose

--- a/uv-dependency-update/SKILL.md
+++ b/uv-dependency-update/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: uv-dependency-update
 description: >
-  Use this when asked to update dependencies in a uv-managed Python project, whether the
-  request is a broad non-major refresh or a major-version upgrade for a specific package.
-  It captures the branching workflow for deciding between safe uv updates within the current
-  major series and an interactive major-upgrade flow with upstream research, user confirmation,
-  one-package-at-a-time changes, and project validation.
+  uv管理のPythonプロジェクトで依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う。
+  upstream調査、ユーザー確認、1パッケージずつの更新、プロジェクト検証まで扱う。
 ---
 
 # uv Dependency Updater


### PR DESCRIPTION
## Issues

- Close #139
- Refs #138

## Why

スキル発火判定に常時使われるfrontmatter descriptionが英語・日本語で混在し、一部は実行手順まで含んで長くなっていました。日本語中心の利用環境で発火条件と保守性を明確にするため、言語と長さを整理します。

## Summary

英語主体だった15スキルのdescriptionを日本語主体へ変更しました。300文字超だった6件は、機能・使用タイミング・代表トリガーを維持しながら300文字以内へ圧縮しています。

## Changes

- descriptionを日本語主体へ統一
- Codex、GitHub、Bun、npm、Tailwindなどの技術用語は原表記を維持
- `PRまで`、`create a skill` などの代表トリガーを維持
- 全31スキルのdescriptionが300文字以内であることを確認
- READMEは既存の日本語説明と用途が一致しているため変更なし

## Verification

- `bash scripts/validate-skills.sh` - passed（31 SKILL.md）
- `git diff --check` - passed
- 全descriptionの300文字以内・日本語含有チェック - passed
