### PR TITLE
feat: add agents/openai.yaml metadata for all 26 remaining skills

### DIFF
--- a/.claude/skills/skills-readme-sync/agents/openai.yaml
+++ b/.claude/skills/skills-readme-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skills README Sync"
+  short_description: "スキル追加・変更後にREADMEのAvailable Skills表を同期する"
+  default_prompt: "Use $skills-readme-sync to update the README Available Skills table after skill changes."

--- a/ai-identity-resolve/agents/openai.yaml
+++ b/ai-identity-resolve/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Identity Resolve"
+  short_description: "レビューコメントやPR返信に付けるAI識別メタデータを解決する"
+  default_prompt: "Use $ai-identity-resolve to resolve AI identity metadata for review comments or PR replies."

--- a/browser-use/agents/openai.yaml
+++ b/browser-use/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Browser Use"
+  short_description: "browser-use CLIの独自ブラウザでlocalhost画面を確認する"
+  default_prompt: "Use $browser-use to check localhost screens with the browser-use CLI custom browser."

--- a/bun-dependency-update/agents/openai.yaml
+++ b/bun-dependency-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bun Dependency Update"
+  short_description: "Bunアプリの依存関係を1パッケージずつ安全に更新する"
+  default_prompt: "Use $bun-dependency-update to update Bun project dependencies one by one with upstream checks."

--- a/codex-skills-link-from-claude/agents/openai.yaml
+++ b/codex-skills-link-from-claude/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex Skills Link from Claude"
+  short_description: "Claude CodeスキルをCodexで使うためのsymlinkを作成する"
+  default_prompt: "Use $codex-skills-link-from-claude to create a .codex/skills symlink pointing to .claude/skills."

--- a/git-branch-create/agents/openai.yaml
+++ b/git-branch-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Branch Create"
+  short_description: "Gitのブランチ名を自動生成し作業ブランチを作成する"
+  default_prompt: "Use $git-branch-create to propose and create a git branch name for your task."

--- a/git-commit-message/agents/openai.yaml
+++ b/git-commit-message/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Commit Message"
+  short_description: "GitのコミットメッセージをConventional Commits形式で提案する"
+  default_prompt: "Use $git-commit-message to generate a conventional commit message suggestion."

--- a/git-worktree-create/agents/openai.yaml
+++ b/git-worktree-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Worktree Create"
+  short_description: "コーディングエージェント用の独立したgit worktreeを作成する"
+  default_prompt: "Use $git-worktree-create to create an isolated git worktree for a coding agent."

--- a/github-implement-pr/agents/openai.yaml
+++ b/github-implement-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Implement PR"
+  short_description: "GitHub Issue対応からPR作成・Codexレビュー依頼まで一括実行する"
+  default_prompt: "Use $github-implement-pr to implement a GitHub issue, create a PR, and request a Codex review."

--- a/github-issue-create-from-plan/agents/openai.yaml
+++ b/github-issue-create-from-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Issue Create from Plan"
+  short_description: "設計プランからGitHub Issueを作成し必要に応じてHTMLも生成する"
+  default_prompt: "Use $github-issue-create-from-plan to create a GitHub issue from a finalized design plan."

--- a/github-pr-comment-reply/agents/openai.yaml
+++ b/github-pr-comment-reply/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Comment Reply"
+  short_description: "GitHub PRのレビューコメントや会話コメントへ返信する"
+  default_prompt: "Use $github-pr-comment-reply to reply to review comments or conversation comments on a GitHub PR."

--- a/github-pr-create/agents/openai.yaml
+++ b/github-pr-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Create"
+  short_description: "PR本文を生成してghでGitHub Pull Requestを作成する"
+  default_prompt: "Use $github-pr-create to generate a PR description and create a GitHub pull request."

--- a/github-pr-feedback-address/agents/openai.yaml
+++ b/github-pr-feedback-address/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Feedback Address"
+  short_description: "GitHub PRの未解決フィードバックを検証・修正・返信する"
+  default_prompt: "Use $github-pr-feedback-address to address unresolved feedback on a GitHub PR."

--- a/github-pr-review/agents/openai.yaml
+++ b/github-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Review"
+  short_description: "指定されたGitHub PRをレビューしてPR上にコメントを投稿する"
+  default_prompt: "Use $github-pr-review to review a GitHub PR and post review comments."

--- a/grill-with-docs/agents/openai.yaml
+++ b/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Grill with Docs"
+  short_description: "既存ドキュメントと照合しながら設計を厳しく壁打ち検証する"
+  default_prompt: "Use $grill-with-docs to rigorously stress-test a design against existing documentation."

--- a/grilling/agents/openai.yaml
+++ b/grilling/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Grilling"
+  short_description: "計画や設計を実装前に徹底的に壁打ちして前提を明確にする"
+  default_prompt: "Use $grilling to thoroughly grill a plan or design and clarify decisions before implementation."

--- a/html-artifact-format/agents/openai.yaml
+++ b/html-artifact-format/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HTML Artifact Format"
+  short_description: "AI向けMarkdown成果物を人間向け単一HTMLに変換して視覚化する"
+  default_prompt: "Use $html-artifact-format to convert AI-oriented Markdown artifacts into human-readable HTML with visual elements."

--- a/image-to-svg/agents/openai.yaml
+++ b/image-to-svg/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Image to SVG"
+  short_description: "PNG/JPEG画像を編集可能なベクターSVGに変換する"
+  default_prompt: "Use $image-to-svg to convert a raster image (PNG/JPEG) into an editable vector SVG."

--- a/japanese-text-proofread/agents/openai.yaml
+++ b/japanese-text-proofread/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Japanese Text Proofread"
+  short_description: "日本語Markdown文書の誤字脱字・表記ゆれ・句読点を校正する"
+  default_prompt: "Use $japanese-text-proofread to proofread Japanese text for typos, inconsistencies, and punctuation errors."

--- a/npm-dependency-update/agents/openai.yaml
+++ b/npm-dependency-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "npm Dependency Update"
+  short_description: "npmアプリの依存関係を1パッケージずつ安全に更新する"
+  default_prompt: "Use $npm-dependency-update to update npm project dependencies one by one with upstream checks."

--- a/qa-test-design/agents/openai.yaml
+++ b/qa-test-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "QA Test Design"
+  short_description: "QA観点出し・テスト設計・テストケース洗い出しを体系的に行う"
+  default_prompt: "Use $qa-test-design to systematically design test cases and QA perspectives."

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -91,6 +91,57 @@ else
   done < "$tmp_dir/readme.stale"
 fi
 
+# Validate agents/openai.yaml metadata for each skill
+MIN_DESC_LEN=25
+MAX_DESC_LEN=64
+
+while IFS= read -r skill_file; do
+  skill_dir="$(dirname "$skill_file")"
+  yaml_file="$skill_dir/agents/openai.yaml"
+
+  # Extract skill name from SKILL.md frontmatter
+  skill_name="$(sed -n '/^---$/,/^---$/ { /^name:/ { s/^name:[[:space:]]*//p; q; } }' "$skill_file")"
+  if [[ -z "$skill_name" ]]; then
+    report_failure "$skill_file: could not extract name from frontmatter"
+    continue
+  fi
+
+  # Check agents/openai.yaml exists
+  if [[ ! -f "$yaml_file" ]]; then
+    report_failure "$skill_dir: agents/openai.yaml is missing"
+    continue
+  fi
+
+  # Check display_name
+  display_name="$(sed -n 's/^[[:space:]]*display_name:[[:space:]]*"\(.*\)"/\1/p' "$yaml_file")"
+  if [[ -z "$display_name" ]]; then
+    report_failure "$yaml_file: display_name is missing or empty"
+  fi
+
+  # Check short_description
+  short_desc="$(sed -n 's/^[[:space:]]*short_description:[[:space:]]*"\(.*\)"/\1/p' "$yaml_file")"
+  if [[ -z "$short_desc" ]]; then
+    report_failure "$yaml_file: short_description is missing or empty"
+  else
+    desc_len="$(echo -n "$short_desc" | wc -m)"
+    if (( desc_len < MIN_DESC_LEN )); then
+      report_failure "$yaml_file: short_description is $desc_len chars (min $MIN_DESC_LEN)"
+    elif (( desc_len > MAX_DESC_LEN )); then
+      report_failure "$yaml_file: short_description is $desc_len chars (max $MAX_DESC_LEN)"
+    fi
+  fi
+
+  # Check default_prompt
+  default_prompt="$(sed -n 's/^[[:space:]]*default_prompt:[[:space:]]*"\(.*\)"/\1/p' "$yaml_file")"
+  if [[ -z "$default_prompt" ]]; then
+    report_failure "$yaml_file: default_prompt is missing or empty"
+  else
+    if ! echo "$default_prompt" | grep -qF "\$$skill_name"; then
+      report_failure "$yaml_file: default_prompt does not reference \$$skill_name"
+    fi
+  fi
+done < "$tmp_dir/skills.actual"
+
 if (( failures > 0 )); then
   printf 'Skill validation failed with %s error(s).\n' "$failures" >&2
   exit 1

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -123,7 +123,7 @@ while IFS= read -r skill_file; do
   if [[ -z "$short_desc" ]]; then
     report_failure "$yaml_file: short_description is missing or empty"
   else
-    desc_len="$(echo -n "$short_desc" | wc -m)"
+    desc_len=$(python3 -c "import sys; print(len(sys.argv[1]))" "$short_desc")
     if (( desc_len < MIN_DESC_LEN )); then
       report_failure "$yaml_file: short_description is $desc_len chars (min $MIN_DESC_LEN)"
     elif (( desc_len > MAX_DESC_LEN )); then
@@ -136,7 +136,7 @@ while IFS= read -r skill_file; do
   if [[ -z "$default_prompt" ]]; then
     report_failure "$yaml_file: default_prompt is missing or empty"
   else
-    if ! echo "$default_prompt" | grep -qF "\$$skill_name"; then
+    if ! echo "$default_prompt" | grep -qE "\\\$$skill_name([^a-z0-9-]|\$)"; then
       report_failure "$yaml_file: default_prompt does not reference \$$skill_name"
     fi
   fi

--- a/skill-author/agents/openai.yaml
+++ b/skill-author/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skill Author"
+  short_description: "SKILL.mdの新規作成・改善・レビューを体系的に行う"
+  default_prompt: "Use $skill-author to create, improve, or review a SKILL.md file."

--- a/tailwind-ui-compose/agents/openai.yaml
+++ b/tailwind-ui-compose/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tailwind UI Compose"
+  short_description: "Tailwind CSSでレイアウト設計・UIコンポーネントのJSXを生成する"
+  default_prompt: "Use $tailwind-ui-compose to design layout and generate JSX components with Tailwind CSS."

--- a/uv-dependency-update/agents/openai.yaml
+++ b/uv-dependency-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "uv Dependency Update"
+  short_description: "uv管理のPython依存関係を1パッケージずつ安全に更新する"
+  default_prompt: "Use $uv-dependency-update to update uv-managed Python dependencies one by one."

--- a/wsl-chrome-attach-use/agents/openai.yaml
+++ b/wsl-chrome-attach-use/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "WSL Chrome Attach Use"
+  short_description: "attach済みWindows Chromeをchrome-devtools-mcp経由で操作する"
+  default_prompt: "Use $wsl-chrome-attach-use to operate an attached Windows Chrome via chrome-devtools-mcp."

--- a/wsl-chrome-attach/agents/openai.yaml
+++ b/wsl-chrome-attach/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "WSL Chrome Attach"
+  short_description: "WSL2からWindows側のChromeへremote debug接続を診断・確立する"
+  default_prompt: "Use $wsl-chrome-attach to diagnose and establish a remote debugging connection to Windows Chrome from WSL2."


### PR DESCRIPTION
## Issues

- Close #138

## Why

31スキルのうち26件に `agents/openai.yaml` が未整備だった。Codex/OpenAI UIでスキル一覧・チップ表示・呼び出し時の表示と開始文を統一するため、全スキルにメタデータを追加する。

## Summary

不足していた26スキルに `agents/openai.yaml` を追加し、全31スキルで `display_name`、`short_description`、`default_prompt` が一貫した形式で揃った。また `scripts/validate-skills.sh` にメタデータ検証を追加し、新規スキル追加時の整備漏れを検出できるようにした。

## Changes

- 26スキルに `agents/openai.yaml` を新規追加（全31スキル完備）
- `scripts/validate-skills.sh` に以下のメタデータ検証を追加
  - `agents/openai.yaml` ファイルの存在確認
  - `display_name`、`short_description`、`default_prompt` 必須3項目の存在確認
  - `short_description` が25〜64文字に収まることの検証
  - `default_prompt` が正しい `$skill-name` を参照していることの検証

## Verification

- `bash scripts/validate-skills.sh` - passed（全31スキルのメタデータが検証を通過）
