### PR TITLE
feat: add Herdr agent delegation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | Skill | Description |
 |-------|-------------|
 | [github-implement-pr](github-implement-pr/SKILL.md) | Issue 確認から実装、検証、PR 作成までを一連で進める |
+| [herdr-agent-delegate](herdr-agent-delegate/SKILL.md) | Herdr 上の CLI Agent へタスクを委譲し、起動・待機・結果回収まで行う |
 | [html-artifact-format](html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLを判断し、視覚化要素入りの単一HTMLを生成する |
 
 ### 要件定義 / 設計対話

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: herdr-agent-delegate
+description: Herdr上でCodex、Claude Code、OpenCode、その他のCLI Agentへタスクを委譲し、同一TabへのGrid状起動、明示したidle Agentの再利用、依頼送信、完了待機、結果回収まで行う。「別Agentに任せて」「Codex/Claude/OpenCodeを起動して調査」「複数Agentへ並列委譲」「子Agentの結果を回収」など、Herdr内のAgent委譲で使う。
+---
+
+# Herdr Agent Delegate
+
+このスキルのディレクトリを `<skill-dir>` として絶対パスで解決する。詳細なCLI差分が必要なら `references/agent-cli.md`、タスクファイルの安全条件やネスト規則が必要なら `references/task-protocol.md` を読む。
+
+## 1. プリフライト
+
+1. `HERDR_ENV=1` と空でない `HERDR_PANE_ID` を確認する。満たさない場合はHerdr外から対象を推測せず終了する。
+2. `command -v herdr` と利用するAgent CLIを確認する。自動インストールしない。
+3. `herdr pane current --current` を実行し、現在の `pane_id`、`tab_id`、`cwd`、Agent種別を取得する。記憶したIDを使い回さない。
+4. ユーザー指定がなければ現在のAgent種別とcwdを引き継ぐ。現在のAgent種別も不明なら起動対象を確認する。起動オプションは明示されたものだけを使う。
+
+## 2. タスク交換を作る
+
+依頼本文を読み取り可能な一時Markdownへ保存し、本文をコマンド引数へ直接埋め込まず次を実行する。追加コンテキストは読み取り可能な絶対パスで繰り返し指定する。
+
+```bash
+<skill-dir>/scripts/task_exchange.py create \
+  --task-file <request.md> \
+  --context-file <absolute-context-path>
+```
+
+JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する。これはCLI結果であり、Agent間Payloadではない。
+`task.md` へのコピーを確認後、入力用に作った `request.md` は削除する。
+
+## 3. 宛先を解決する
+
+明示的な宛先がある場合だけ既存Agentの再利用を試す。
+
+1. `herdr agent get <target>` で毎回解決する。
+2. 解決した `pane_id` が自分自身なら拒否する。
+3. `agent_status` が `idle` の時だけ再利用する。`working`、`blocked`、`done`、`unknown` には送信せず状態を報告する。
+
+明示的な宛先がない場合、または対象が存在しない場合は同一Tabへ新規Agentを作る。存在するがidleでない明示宛先を無断で新規Agentへ置き換えない。
+
+## 4. 新規AgentをGrid状に起動する
+
+親と「今回この親が起動した子」のpane IDだけを候補にする。無関係な既存paneや再利用Agentは候補へ入れない。
+
+1. `herdr pane layout --current` のJSONを一時ファイルへ保存する。
+2. 次を実行し、出力された分割対象・方向を使う。子を増やすたび `--child` を追加する。
+
+```bash
+<skill-dir>/scripts/choose_layout.py \
+  --layout-file <layout.json> \
+  --parent "$HERDR_PANE_ID" \
+  --child <child-pane-id>
+```
+
+3. 約50%で分割し、レスポンスの `result.pane.pane_id` を新しいIDとして取得する。
+
+```bash
+herdr pane split <target-pane-id> \
+  --direction <right-or-down> --ratio 0.5 --cwd <cwd> --no-focus
+herdr pane run <new-pane-id> '<agent-command>'
+```
+
+4. semantic state対応Agentは `agent-status idle`、その他は画面出力と `pane read` で起動を確認する。確認できない場合は依頼を送らない。
+5. 分割判断に使ったlayout一時ファイルを削除する。
+
+## 5. 依頼を送る
+
+Agentへは短い通知だけを送る。
+
+```text
+次の委譲タスクを処理してください: <task_path>
+ファイル全文を読み、Completion contractに従って結果を確定してください。
+```
+
+対応Agentには `herdr agent send <target> <notice>`、その他には `herdr pane send-text <pane-id> <notice>` を使い、送信後のEnterは `herdr pane send-keys <pane-id> Enter` で分ける。送信直後にsemantic stateが `working` へ遷移するか、画面が処理開始を示すことを確認する。
+
+## 6. 完了を待つ
+
+Codex、Claude Code、OpenCodeなど `agent get` でAgentとして解決できる対象はsemantic待機を使う。
+
+```bash
+<skill-dir>/scripts/wait_for_completion.py \
+  --target <pane-id> --reply-path <reply-path> semantic
+```
+
+未対応CLIはタスク固有markerを待つ。
+
+```bash
+<skill-dir>/scripts/wait_for_completion.py \
+  --target <pane-id> --reply-path <reply-path> marker --marker <marker>
+```
+
+既定timeoutは1時間。長時間待機をバックグラウンド実行できる環境では待機を張って制御を返し、終了後に続行する。`blocked`、`timeout`、`reply_missing` は成功扱いしない。
+
+## 7. 回収する
+
+完了時だけ次を実行する。通常ファイル、所有者、保存ルート、非空を検証して内容を出力し、成功後にtask directoryを削除する。
+
+```bash
+<skill-dir>/scripts/task_exchange.py collect --task-dir <task-dir>
+```
+
+失敗時はcollectや手動削除をせず、`herdr agent get` と `herdr agent read --source recent-unwrapped --lines 80` で診断する。対象、状態、経過、保持した `task_dir` を報告する。
+
+## ネストと並列委譲
+
+- 各Agentは直下の子だけを管理する。孫は子へ返し、子が統合して親へ返す。
+- 子がさらに委譲する時は新しいtask directoryとmarkerを作る。親のものを共有しない。
+- 複数子は独立したtask directoryで起動してから個別に待つ。結果の混在を避ける。
+- 子や孫からrootへ直接通知しない。失敗も直上へ要約してホップ単位で伝播する。
+
+## 禁止事項
+
+- JSON Payload、グローバルtrace、独自watchdogを追加しない。
+- `working` Agentへ割り込まない。ユーザーが明示しても、このスキルでは中断操作を扱わない。
+- pane IDを推測・永続化しない。操作直前に再取得する。
+- 失敗・blocked・timeout時のtask directoryを削除しない。

--- a/herdr-agent-delegate/agents/openai.yaml
+++ b/herdr-agent-delegate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Herdr Agent Delegate"
+  short_description: "Herdr上のCLI Agentへタスクを安全に委譲して結果を回収"
+  default_prompt: "Use $herdr-agent-delegate to delegate this task to a CLI agent in the current Herdr tab and collect the result."

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -1,0 +1,31 @@
+# Agent CLI運用差分
+
+## 起動コマンド
+
+| Agent | 起動コマンド | 完了待機 |
+| --- | --- | --- |
+| Codex | `codex` | semantic state |
+| Claude Code | `claude` | semantic state |
+| OpenCode | `opencode` | semantic state |
+| その他 | ユーザー指定のコマンド | output marker。`agent get` が安定して識別できる場合だけsemantic state |
+
+ユーザーが指定した引数は該当コマンドへ渡す。指定されていない引数を補わない。シェル展開が必要な文字列を組み立てず、コマンドは `herdr pane run` の1引数として渡す。
+
+## 起動確認
+
+1. `herdr pane split` のJSONから新規 `pane_id` を読む。
+2. `herdr pane run <pane-id> '<command>'` を実行する。
+3. 対応Agentでは `herdr wait agent-status <pane-id> --status idle --timeout 30000` を使う。
+4. 未対応CLIでは期待するプロンプトを `herdr wait output` で待ち、`herdr pane read --source recent-unwrapped --lines 40` でも確認する。
+5. trust、login、初期設定などのダイアログがあれば自動承認しない。内容をユーザーへ報告する。
+
+## IDと送信
+
+- pane IDはcloseなどで変化しうる。`agent list`、`agent get`、`pane current`、create/splitレスポンスから都度読む。
+- `agent send` と `pane send-text` はEnterを送らない。`pane send-keys <pane-id> Enter` を別に実行する。
+- シェルへコマンドを送る時だけ `pane run` を使う。Agentの入力欄へ依頼を送る時はtextとEnterを分離する。
+- `agent_status=done` は再利用可能なidleではない。新しい依頼を送らない。
+
+## semantic待機の判定
+
+`agent get` が対象をAgentとして解決し、処理開始後に `working`、完了時に `idle` または `done` を返す場合にsemantic待機を使う。`unknown` のまま安定しないCLIはmarker待機へ切り替える。marker一致だけでは成功とせず、必ず同じtask directoryの `reply.md` も検証する。

--- a/herdr-agent-delegate/references/task-protocol.md
+++ b/herdr-agent-delegate/references/task-protocol.md
@@ -6,6 +6,7 @@
 /tmp/herdr-agent-delegate/<uid>/<tag>/
 ├── task.md
 ├── marker
+├── result.md
 ├── reply.tmp.md
 └── reply.md
 ```
@@ -16,8 +17,8 @@
 ## 子Agentの完了
 
 1. `task.md` 全文を読む。
-2. 結果をMarkdownの通常ファイルへ書く。
-3. `task.md` 記載の `task_exchange.py complete` を実行する。
+2. 結果を `task.md` 記載の `result.md` へ書く。
+3. `task.md` 記載の `task_exchange.py complete` をそのまま実行する。
 4. helperは内容を `reply.tmp.md` へ安全に書き、同一ディレクトリ内で `reply.md` へatomic renameする。
 5. helperが出力した一意なmarkerを表示する。
 

--- a/herdr-agent-delegate/references/task-protocol.md
+++ b/herdr-agent-delegate/references/task-protocol.md
@@ -1,0 +1,48 @@
+# Markdownタスク交換プロトコル
+
+## 保存形式
+
+```text
+/tmp/herdr-agent-delegate/<uid>/<tag>/
+├── task.md
+├── marker
+├── reply.tmp.md
+└── reply.md
+```
+
+`task_exchange.py create` がユーザーごとの保存ルート、tag、`task.md`、markerを作る。Agent間では `task.md` の絶対パスだけを通知する。CLIが返すJSONは呼び出し元が各パスを取得するための結果であり、保存・配送するPayloadではない。
+入力用に別途作った依頼Markdownは `task.md` へのコピー確認後に呼び出し元が削除する。
+
+## 子Agentの完了
+
+1. `task.md` 全文を読む。
+2. 結果をMarkdownの通常ファイルへ書く。
+3. `task.md` 記載の `task_exchange.py complete` を実行する。
+4. helperは内容を `reply.tmp.md` へ安全に書き、同一ディレクトリ内で `reply.md` へatomic renameする。
+5. helperが出力した一意なmarkerを表示する。
+
+既に `reply.md` が存在する場合は上書きしない。親paneへの直接通知は不要で、親のsemantic/marker待機が完了を検知する。
+
+## 親Agentの回収
+
+`task_exchange.py collect` は次を確認する。
+
+- task directoryが絶対パスで専用保存ルートの直下にある
+- task directoryとreplyがsymlinkではない
+- 現在ユーザーが所有する通常ファイルである
+- `reply.md` が空でない
+
+検証成功後はreplyを標準出力へ返し、task directoryを削除する。`--keep` は成功結果を調査用に残す必要がある場合だけ使う。
+
+reply欠損、不正ファイル、blocked、timeout、Agent終了時はcollectしない。task directoryを保持し、`task.md`、Agent出力、状態を診断材料にする。
+
+## ネスト
+
+委譲ごとに新しいtagを作り、相関は直上の親子間だけで扱う。
+
+```text
+Parent --task A--> Child --task B--> Grandchild
+Parent <--reply A-- Child <--reply B-- Grandchild
+```
+
+Childはreply Bを回収・統合してからreply Aを確定する。Grandchildが失敗した場合、Childはtask Bを保持し、その状態と保存先をreply Aまたは失敗報告へ含める。rootから全子孫を横断するtraceは作らない。

--- a/herdr-agent-delegate/scripts/choose_layout.py
+++ b/herdr-agent-delegate/scripts/choose_layout.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Choose the next herdr pane split so delegated agents form a grid."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def choose(layout: dict, parent: str, children: list[str], cell_aspect: float) -> dict:
+    panes = layout.get("result", {}).get("layout", {}).get("panes", [])
+    by_id = {pane.get("pane_id"): pane.get("rect", {}) for pane in panes}
+    candidates = [pane_id for pane_id in [parent, *children] if pane_id in by_id]
+    if parent not in by_id:
+        raise ValueError(f"parent pane is not in the current layout: {parent}")
+    if not candidates:
+        raise ValueError("no candidate panes are in the current layout")
+
+    child_rank = {pane_id: index + 1 for index, pane_id in enumerate(children)}
+
+    def score(pane_id: str) -> tuple[int, int]:
+        rect = by_id[pane_id]
+        area = int(rect.get("width", 0)) * int(rect.get("height", 0))
+        return area, child_rank.get(pane_id, 0)
+
+    target = max(candidates, key=score)
+    rect = by_id[target]
+    physical_width = float(rect["width"]) * cell_aspect
+    direction = "right" if physical_width >= float(rect["height"]) else "down"
+    return {"target_pane_id": target, "direction": direction, "ratio": 0.5}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--layout-file", help="herdr pane layout JSON; default: stdin")
+    parser.add_argument("--parent", required=True)
+    parser.add_argument("--child", action="append", default=[])
+    parser.add_argument("--cell-aspect", type=float, default=0.5)
+    args = parser.parse_args()
+    if args.cell_aspect <= 0:
+        parser.error("--cell-aspect must be greater than zero")
+
+    try:
+        if args.layout_file:
+            with open(args.layout_file, encoding="utf-8") as stream:
+                layout = json.load(stream)
+        else:
+            layout = json.load(sys.stdin)
+        print(json.dumps(choose(layout, args.parent, args.child, args.cell_aspect)))
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/herdr-agent-delegate/scripts/task_exchange.py
+++ b/herdr-agent-delegate/scripts/task_exchange.py
@@ -12,9 +12,10 @@ import stat
 import sys
 import time
 from pathlib import Path
+from typing import NoReturn
 
 
-def die(message: str) -> "NoReturn":
+def die(message: str) -> NoReturn:
     print(f"ERROR: {message}", file=sys.stderr)
     raise SystemExit(1)
 
@@ -93,6 +94,7 @@ def create_exchange(args: argparse.Namespace) -> None:
     marker = f"HERDR_DELEGATE_DONE_{tag.upper().replace('-', '_')}"
     reply_tmp = task_dir / "reply.tmp.md"
     reply = task_dir / "reply.md"
+    result = task_dir / "result.md"
     script = Path(__file__).resolve()
 
     context_lines = "\n".join(f"- `{path}`" for path in contexts) or "- なし"
@@ -110,9 +112,9 @@ def create_exchange(args: argparse.Namespace) -> None:
 ## Completion contract
 
 1. この依頼だけを実行し、結果をMarkdownで作成する。
-2. 結果を一度別の通常ファイルへ書き、次のコマンドで確定する。
+2. 結果を `{result}` へ書き、次のコマンドをそのまま実行して確定する。
 
-   `{script} complete --task-dir {task_dir} --reply-file <result-file>`
+   `{script} complete --task-dir {task_dir} --reply-file {result}`
 
 3. コマンドが出力する一意な完了markerを改変せず表示して完了する。
 4. 結果は直上の親にだけ返す。ネスト委譲時もrootへ直接通知しない。
@@ -136,10 +138,18 @@ def complete_exchange(args: argparse.Namespace) -> None:
     marker_path = safe_regular_file(task_dir / "marker", require_nonempty=True)
     reply_tmp = task_dir / "reply.tmp.md"
     reply = task_dir / "reply.md"
-    if reply.exists() or reply.is_symlink():
-        die(f"reply is already finalized: {reply}")
-    atomic_write(reply_tmp, source.read_text(encoding="utf-8"))
-    os.replace(reply_tmp, reply)
+    lock = task_dir / ".complete.lock"
+    try:
+        lock.mkdir(mode=0o700)
+    except FileExistsError:
+        die(f"another process is finalizing this reply: {reply}")
+    try:
+        if reply.exists() or reply.is_symlink():
+            die(f"reply is already finalized: {reply}")
+        atomic_write(reply_tmp, source.read_text(encoding="utf-8"))
+        os.replace(reply_tmp, reply)
+    finally:
+        lock.rmdir()
     print(marker_path.read_text(encoding="utf-8").strip())
 
 

--- a/herdr-agent-delegate/scripts/task_exchange.py
+++ b/herdr-agent-delegate/scripts/task_exchange.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Create and collect Markdown task exchanges for herdr agent delegation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import stat
+import sys
+import time
+from pathlib import Path
+
+
+def die(message: str) -> "NoReturn":
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def storage_root() -> Path:
+    configured = os.environ.get("HERDR_AGENT_DELEGATE_ROOT")
+    return Path(configured) if configured else Path("/tmp/herdr-agent-delegate") / str(os.getuid())
+
+
+def ensure_directory(path: Path, *, create: bool = False) -> Path:
+    if create:
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        die(f"directory does not exist: {path}")
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        die(f"directory must not be a symlink: {path}")
+    if info.st_uid != os.getuid():
+        die(f"directory is not owned by the current user: {path}")
+    path.chmod(0o700)
+    return path.resolve(strict=True)
+
+
+def safe_task_dir(raw_path: str) -> Path:
+    root = ensure_directory(storage_root(), create=True)
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        die("task directory must be an absolute path")
+    resolved = ensure_directory(candidate)
+    if resolved.parent != root:
+        die(f"task directory is outside the storage root: {candidate}")
+    return resolved
+
+
+def safe_regular_file(path: Path, *, require_nonempty: bool = False) -> Path:
+    if not path.is_absolute():
+        die(f"file must be an absolute path: {path}")
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        die(f"file does not exist: {path}")
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        die(f"file must be a regular file, not a symlink: {path}")
+    if info.st_uid != os.getuid():
+        die(f"file is not owned by the current user: {path}")
+    if require_nonempty and info.st_size == 0:
+        die(f"file is empty: {path}")
+    return path.resolve(strict=True)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(6)}.tmp")
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def new_tag() -> str:
+    return f"{int(time.time()):x}-{secrets.token_hex(6)}"
+
+
+def create_exchange(args: argparse.Namespace) -> None:
+    root = ensure_directory(storage_root(), create=True)
+    source = safe_regular_file(Path(args.task_file), require_nonempty=True)
+    contexts = [safe_regular_file(Path(item)) for item in args.context_file]
+    tag = new_tag()
+    task_dir = root / tag
+    task_dir.mkdir(mode=0o700)
+    marker = f"HERDR_DELEGATE_DONE_{tag.upper().replace('-', '_')}"
+    reply_tmp = task_dir / "reply.tmp.md"
+    reply = task_dir / "reply.md"
+    script = Path(__file__).resolve()
+
+    context_lines = "\n".join(f"- `{path}`" for path in contexts) or "- なし"
+    task_text = source.read_text(encoding="utf-8")
+    document = f"""# Delegated task
+
+## Task
+
+{task_text.rstrip()}
+
+## Additional context files
+
+{context_lines}
+
+## Completion contract
+
+1. この依頼だけを実行し、結果をMarkdownで作成する。
+2. 結果を一度別の通常ファイルへ書き、次のコマンドで確定する。
+
+   `{script} complete --task-dir {task_dir} --reply-file <result-file>`
+
+3. コマンドが出力する一意な完了markerを改変せず表示して完了する。
+4. 結果は直上の親にだけ返す。ネスト委譲時もrootへ直接通知しない。
+
+確定先は `{reply}`、書き込み中の一時先は `{reply_tmp}` である。
+"""
+    atomic_write(task_dir / "task.md", document)
+    atomic_write(task_dir / "marker", marker + "\n")
+    print(json.dumps({
+        "tag": tag,
+        "task_dir": str(task_dir),
+        "task_path": str(task_dir / "task.md"),
+        "reply_path": str(reply),
+        "marker": marker,
+    }, ensure_ascii=False))
+
+
+def complete_exchange(args: argparse.Namespace) -> None:
+    task_dir = safe_task_dir(args.task_dir)
+    source = safe_regular_file(Path(args.reply_file), require_nonempty=True)
+    marker_path = safe_regular_file(task_dir / "marker", require_nonempty=True)
+    reply_tmp = task_dir / "reply.tmp.md"
+    reply = task_dir / "reply.md"
+    if reply.exists() or reply.is_symlink():
+        die(f"reply is already finalized: {reply}")
+    atomic_write(reply_tmp, source.read_text(encoding="utf-8"))
+    os.replace(reply_tmp, reply)
+    print(marker_path.read_text(encoding="utf-8").strip())
+
+
+def collect_exchange(args: argparse.Namespace) -> None:
+    task_dir = safe_task_dir(args.task_dir)
+    reply = safe_regular_file(task_dir / "reply.md", require_nonempty=True)
+    content = reply.read_text(encoding="utf-8")
+    print(content, end="" if content.endswith("\n") else "\n")
+    if not args.keep:
+        shutil.rmtree(task_dir)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="create a Markdown task exchange")
+    create.add_argument("--task-file", required=True)
+    create.add_argument("--context-file", action="append", default=[])
+    create.set_defaults(handler=create_exchange)
+
+    complete = subparsers.add_parser("complete", help="atomically finalize a child reply")
+    complete.add_argument("--task-dir", required=True)
+    complete.add_argument("--reply-file", required=True)
+    complete.set_defaults(handler=complete_exchange)
+
+    collect = subparsers.add_parser("collect", help="validate and print a finalized reply")
+    collect.add_argument("--task-dir", required=True)
+    collect.add_argument("--keep", action="store_true")
+    collect.set_defaults(handler=collect_exchange)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/herdr-agent-delegate/scripts/wait_for_completion.py
+++ b/herdr-agent-delegate/scripts/wait_for_completion.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Wait for a delegated agent through herdr semantic state or an output marker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def run_herdr(arguments: list[str], timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["herdr", *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def agent_status(target: str) -> str:
+    result = run_herdr(["agent", "get", target], timeout=10)
+    if result.returncode != 0:
+        return "unavailable"
+    try:
+        payload = json.loads(result.stdout)
+        return str(payload["result"]["agent"]["agent_status"])
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return "unavailable"
+
+
+def valid_reply(path: Path) -> bool:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return False
+    return (
+        path.is_absolute()
+        and stat.S_ISREG(info.st_mode)
+        and not stat.S_ISLNK(info.st_mode)
+        and info.st_uid == os.getuid()
+        and info.st_size > 0
+    )
+
+
+def emit(status: str, target: str, started: float, agent_state: str | None = None) -> None:
+    result: dict[str, object] = {
+        "status": status,
+        "target": target,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+    }
+    if agent_state is not None:
+        result["agent_status"] = agent_state
+    print(json.dumps(result))
+
+
+def wait_semantic(args: argparse.Namespace) -> int:
+    started = time.monotonic()
+    deadline = started + args.timeout / 1000
+    seen_working = False
+    reply = Path(args.reply_path)
+
+    while time.monotonic() < deadline:
+        state = agent_status(args.target)
+        seen_working = seen_working or state == "working"
+        if state == "blocked":
+            emit("blocked", args.target, started, state)
+            return 2
+        if valid_reply(reply) and (seen_working or state in {"idle", "done"}):
+            emit("completed", args.target, started, state)
+            return 0
+        if state == "done":
+            emit("reply_missing", args.target, started, state)
+            return 4
+        remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
+        poll_ms = min(args.poll_interval, remaining_ms)
+        awaited_state = "idle" if seen_working else "working"
+        run_herdr(
+            ["wait", "agent-status", args.target, "--status", awaited_state, "--timeout", str(poll_ms)],
+            timeout=poll_ms / 1000 + 5,
+        )
+
+    emit("timeout", args.target, started, agent_status(args.target))
+    return 3
+
+
+def wait_marker(args: argparse.Namespace) -> int:
+    started = time.monotonic()
+    result = run_herdr([
+        "wait", "output", args.target,
+        "--match", args.marker,
+        "--source", "recent-unwrapped",
+        "--timeout", str(args.timeout),
+    ], timeout=args.timeout / 1000 + 5)
+    if result.returncode != 0:
+        emit("timeout", args.target, started)
+        return 3
+    if not valid_reply(Path(args.reply_path)):
+        emit("reply_missing", args.target, started)
+        return 4
+    emit("completed", args.target, started)
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--reply-path", required=True)
+    parser.add_argument("--timeout", type=int, default=3_600_000)
+    parser.add_argument("--poll-interval", type=int, default=1_000)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    subparsers.add_parser("semantic")
+    marker = subparsers.add_parser("marker")
+    marker.add_argument("--marker", required=True)
+    args = parser.parse_args()
+    if args.timeout <= 0 or args.poll_interval <= 0:
+        parser.error("timeouts must be greater than zero")
+    exit_code = wait_semantic(args) if args.mode == "semantic" else wait_marker(args)
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/herdr-agent-delegate/scripts/wait_for_completion.py
+++ b/herdr-agent-delegate/scripts/wait_for_completion.py
@@ -59,6 +59,20 @@ def emit(status: str, target: str, started: float, agent_state: str | None = Non
     print(json.dumps(result))
 
 
+def wait_for_state(target: str, state: str, poll_ms: int) -> subprocess.CompletedProcess[str]:
+    started = time.monotonic()
+    result = run_herdr(
+        ["wait", "agent-status", target, "--status", state, "--timeout", str(poll_ms)],
+        timeout=poll_ms / 1000 + 5,
+    )
+    if result.returncode != 0:
+        elapsed = time.monotonic() - started
+        remaining = poll_ms / 1000 - elapsed
+        if remaining > 0:
+            time.sleep(remaining)
+    return result
+
+
 def wait_semantic(args: argparse.Namespace) -> int:
     started = time.monotonic()
     deadline = started + args.timeout / 1000
@@ -74,16 +88,13 @@ def wait_semantic(args: argparse.Namespace) -> int:
         if valid_reply(reply) and (seen_working or state in {"idle", "done"}):
             emit("completed", args.target, started, state)
             return 0
-        if state == "done":
+        if state == "done" or (seen_working and state == "idle"):
             emit("reply_missing", args.target, started, state)
             return 4
         remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
         poll_ms = min(args.poll_interval, remaining_ms)
         awaited_state = "idle" if seen_working else "working"
-        run_herdr(
-            ["wait", "agent-status", args.target, "--status", awaited_state, "--timeout", str(poll_ms)],
-            timeout=poll_ms / 1000 + 5,
-        )
+        wait_for_state(args.target, awaited_state, poll_ms)
 
     emit("timeout", args.target, started, agent_status(args.target))
     return 3

--- a/herdr-agent-delegate/tests/test_choose_layout.py
+++ b/herdr-agent-delegate/tests/test_choose_layout.py
@@ -1,0 +1,42 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "choose_layout.py"
+SPEC = importlib.util.spec_from_file_location("choose_layout", MODULE_PATH)
+choose_layout = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(choose_layout)
+
+
+def layout(*panes):
+    return {"result": {"layout": {"panes": [
+        {"pane_id": pane_id, "rect": {"width": width, "height": height}}
+        for pane_id, width, height in panes
+    ]}}}
+
+
+class ChooseLayoutTest(unittest.TestCase):
+    def test_first_split_uses_wide_parent(self):
+        result = choose_layout.choose(layout(("w1:p1", 120, 40)), "w1:p1", [], 0.5)
+        self.assertEqual(result, {"target_pane_id": "w1:p1", "direction": "right", "ratio": 0.5})
+
+    def test_second_split_prefers_equal_area_child_and_goes_down(self):
+        value = layout(("w1:p1", 60, 40), ("w1:p2", 60, 40), ("w1:p9", 200, 50))
+        result = choose_layout.choose(value, "w1:p1", ["w1:p2"], 0.5)
+        self.assertEqual(result["target_pane_id"], "w1:p2")
+        self.assertEqual(result["direction"], "down")
+
+    def test_unrelated_larger_pane_is_ignored(self):
+        value = layout(("w1:p1", 50, 30), ("w1:p2", 50, 30), ("w1:p9", 200, 80))
+        result = choose_layout.choose(value, "w1:p1", ["w1:p2"], 0.5)
+        self.assertNotEqual(result["target_pane_id"], "w1:p9")
+
+    def test_missing_parent_fails(self):
+        with self.assertRaises(ValueError):
+            choose_layout.choose(layout(("w1:p2", 80, 30)), "w1:p1", [], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-agent-delegate/tests/test_task_exchange.py
+++ b/herdr-agent-delegate/tests/test_task_exchange.py
@@ -1,0 +1,72 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "task_exchange.py"
+
+
+class TaskExchangeTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name) / "exchange"
+        self.env = {**os.environ, "HERDR_AGENT_DELEGATE_ROOT": str(self.root)}
+        self.input = Path(self.temporary.name) / "input.md"
+        self.input.write_text("調査して結果を返す。\n", encoding="utf-8")
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def run_script(self, *arguments, check=True):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *arguments],
+            env=self.env,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+    def create(self):
+        result = self.run_script("create", "--task-file", str(self.input))
+        return json.loads(result.stdout)
+
+    def test_create_complete_collect_and_cleanup(self):
+        exchange = self.create()
+        task_dir = Path(exchange["task_dir"])
+        task_text = Path(exchange["task_path"]).read_text(encoding="utf-8")
+        self.assertIn("調査して結果を返す。", task_text)
+        self.assertNotIn(exchange["marker"], task_text)
+        self.assertEqual(task_dir.stat().st_mode & 0o777, 0o700)
+
+        result_file = Path(self.temporary.name) / "result.md"
+        result_file.write_text("# Result\n\n完了\n", encoding="utf-8")
+        completed = self.run_script(
+            "complete", "--task-dir", str(task_dir), "--reply-file", str(result_file)
+        )
+        self.assertEqual(completed.stdout.strip(), exchange["marker"])
+
+        collected = self.run_script("collect", "--task-dir", str(task_dir))
+        self.assertEqual(collected.stdout, "# Result\n\n完了\n")
+        self.assertFalse(task_dir.exists())
+
+    def test_missing_reply_is_retained(self):
+        exchange = self.create()
+        failed = self.run_script("collect", "--task-dir", exchange["task_dir"], check=False)
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertTrue(Path(exchange["task_dir"]).exists())
+
+    def test_symlink_reply_is_rejected_and_retained(self):
+        exchange = self.create()
+        task_dir = Path(exchange["task_dir"])
+        (task_dir / "reply.md").symlink_to(self.input)
+        failed = self.run_script("collect", "--task-dir", str(task_dir), check=False)
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertTrue(task_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-agent-delegate/tests/test_task_exchange.py
+++ b/herdr-agent-delegate/tests/test_task_exchange.py
@@ -40,6 +40,8 @@ class TaskExchangeTest(unittest.TestCase):
         task_text = Path(exchange["task_path"]).read_text(encoding="utf-8")
         self.assertIn("調査して結果を返す。", task_text)
         self.assertNotIn(exchange["marker"], task_text)
+        self.assertIn(f"--reply-file {task_dir / 'result.md'}", task_text)
+        self.assertNotIn("<result-file>", task_text)
         self.assertEqual(task_dir.stat().st_mode & 0o777, 0o700)
 
         result_file = Path(self.temporary.name) / "result.md"
@@ -66,6 +68,39 @@ class TaskExchangeTest(unittest.TestCase):
         failed = self.run_script("collect", "--task-dir", str(task_dir), check=False)
         self.assertNotEqual(failed.returncode, 0)
         self.assertTrue(task_dir.exists())
+
+    def test_only_one_concurrent_complete_succeeds(self):
+        exchange = self.create()
+        task_dir = Path(exchange["task_dir"])
+        result_files = []
+        for index in range(2):
+            result_file = Path(self.temporary.name) / f"result-{index}.md"
+            result_file.write_text(f"result {index}\n", encoding="utf-8")
+            result_files.append(result_file)
+
+        processes = [
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "complete",
+                    "--task-dir",
+                    str(task_dir),
+                    "--reply-file",
+                    str(result_file),
+                ],
+                env=self.env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for result_file in result_files
+        ]
+        results = [process.communicate() for process in processes]
+
+        self.assertEqual(sorted(process.returncode for process in processes), [0, 1])
+        self.assertIn((task_dir / "reply.md").read_text(encoding="utf-8"), {"result 0\n", "result 1\n"})
+        self.assertEqual(sum(exchange["marker"] in stdout for stdout, _ in results), 1)
 
 
 if __name__ == "__main__":

--- a/herdr-agent-delegate/tests/test_wait_for_completion.py
+++ b/herdr-agent-delegate/tests/test_wait_for_completion.py
@@ -1,0 +1,69 @@
+import importlib.util
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "wait_for_completion.py"
+SPEC = importlib.util.spec_from_file_location("wait_for_completion", MODULE_PATH)
+waiter = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(waiter)
+
+
+class Result:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+        self.stdout = ""
+        self.stderr = ""
+
+
+class WaitForCompletionTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.reply = Path(self.temporary.name) / "reply.md"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def args(self, **values):
+        defaults = {
+            "target": "w1:p2",
+            "reply_path": str(self.reply),
+            "timeout": 1_000,
+            "poll_interval": 10,
+            "marker": "DONE_123",
+        }
+        defaults.update(values)
+        return Namespace(**defaults)
+
+    def test_semantic_wait_completes_after_working(self):
+        self.reply.write_text("done\n", encoding="utf-8")
+        with patch.object(waiter, "agent_status", side_effect=["working"]), patch.object(
+            waiter, "run_herdr", return_value=Result()
+        ):
+            self.assertEqual(waiter.wait_semantic(self.args()), 0)
+
+    def test_semantic_wait_reports_blocked(self):
+        with patch.object(waiter, "agent_status", return_value="blocked"):
+            self.assertEqual(waiter.wait_semantic(self.args()), 2)
+
+    def test_semantic_wait_does_not_accept_reply_while_blocked(self):
+        self.reply.write_text("partial\n", encoding="utf-8")
+        with patch.object(waiter, "agent_status", return_value="blocked"):
+            self.assertEqual(waiter.wait_semantic(self.args()), 2)
+
+    def test_marker_requires_reply_after_match(self):
+        with patch.object(waiter, "run_herdr", return_value=Result()):
+            self.assertEqual(waiter.wait_marker(self.args()), 4)
+
+    def test_marker_completes_with_reply(self):
+        self.reply.write_text("done\n", encoding="utf-8")
+        with patch.object(waiter, "run_herdr", return_value=Result()):
+            self.assertEqual(waiter.wait_marker(self.args()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-agent-delegate/tests/test_wait_for_completion.py
+++ b/herdr-agent-delegate/tests/test_wait_for_completion.py
@@ -55,6 +55,21 @@ class WaitForCompletionTest(unittest.TestCase):
         with patch.object(waiter, "agent_status", return_value="blocked"):
             self.assertEqual(waiter.wait_semantic(self.args()), 2)
 
+    def test_semantic_wait_reports_missing_reply_after_working_to_idle(self):
+        with patch.object(waiter, "agent_status", side_effect=["working", "idle"]), patch.object(
+            waiter, "wait_for_state", return_value=Result()
+        ):
+            self.assertEqual(waiter.wait_semantic(self.args()), 4)
+
+    def test_failed_state_wait_sleeps_for_remaining_poll_interval(self):
+        with patch.object(waiter, "run_herdr", return_value=Result(returncode=1)), patch.object(
+            waiter.time, "monotonic", side_effect=[10.0, 10.1]
+        ), patch.object(waiter.time, "sleep") as sleep:
+            waiter.wait_for_state("w1:p2", "working", 1_000)
+
+        sleep.assert_called_once()
+        self.assertAlmostEqual(sleep.call_args.args[0], 0.9)
+
     def test_marker_requires_reply_after_match(self):
         with patch.object(waiter, "run_herdr", return_value=Result()):
             self.assertEqual(waiter.wait_marker(self.args()), 4)


### PR DESCRIPTION
## Issues

- Close #143

## Why

アーカイブ済みのtmux向けAgent分割・メッセージングを、HerdrのAgent識別、状態待機、pane操作を使う統合スキルへ移行するためです。Codex、Claude Code、OpenCodeなどへ同じ手順で委譲し、結果回収まで扱えるようにします。

## Summary

`herdr-agent-delegate` を追加し、明示したidle Agentの再利用、同一TabへのGrid状起動、安全なMarkdownタスク交換、semantic stateまたはmarkerによる完了待機を定義しました。決定的な処理はPython標準ライブラリだけのhelperへ分離し、単体テストを追加しています。

## Changes

- 親と今回起動した子だけを候補に、最大面積と端末セル比から約2×2へ近づく分割先を選択
- `task.md`、atomic renameされる `reply.md`、一意なmarkerによるタスク交換を実装
- `idle` の明示宛先だけを再利用し、self、working、blocked、done、unknownを拒否
- Codex、Claude Code、OpenCodeはsemantic state、その他のCLIはoutput markerで待機
- ネスト委譲を直上の親子間だけで管理し、成功時cleanup・異常時保持を定義
- READMEとAgent UIメタデータを同期

## ADR: tmux版JSON Payloadを移植しない

### Context

tmux版ではAgent識別、状態遷移、完了イベントがなかったため、長文配送、request/response対応、timeout、ネストtrace、通知を独自JSON Payloadとwatchdogで補っていました。HerdrはAgent・paneの解決、semantic state、`wait agent-status`、`wait output`、timeoutをCLIとして提供します。

### Decision

永続JSON Payload、グローバルtrace、独立watchdogは移植しません。Herdr CLIを制御面に使い、長文配送と結果対応だけを一意なtagを持つMarkdownタスクディレクトリで扱います。ネストはホップ単位とします。

### Consequences

- Herdr標準機能との責務重複を避け、保守対象を減らせる
- 長文、改行、クォートをファイル経由で安全に扱える
- rootから全子孫を横断するtraceや永続監査ログは持たない
- 横断相関や永続監査が必要になった場合は、別要件としてプロトコルを再検討する

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s herdr-agent-delegate/tests -v` - 12 tests passed
- `python3 /home/u7dev/.codex/skills/.system/skill-creator/scripts/quick_validate.py herdr-agent-delegate` - passed
- `bash scripts/validate-skills.sh` - 28 skills passed
- `herdr pane layout --current | herdr-agent-delegate/scripts/choose_layout.py --parent "$HERDR_PANE_ID"` - current layoutで分割判断を確認
- `herdr integration status` - Claude Code、Codex、OpenCodeがcurrent
- `codex --version` / `claude --version` / `opencode --version` - 起動CLIを確認
- `git diff --check` - passed

live Agentを新規起動するE2E smoke testは未実施です。

## Checklist

- [x] スキル形式・README整合性
- [x] Python構文・単体テスト
- [x] Herdr CLI出力を使ったlayout smoke test
- [ ] Codex、Claude Code、OpenCodeを実際に起動するE2E smoke test
