### PR TITLE
feat(herdr-agent-delegate): guarantee same-space pane split for delegated agents

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -42,25 +42,22 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 親と「今回この親が起動した子」のpane IDだけを候補にする。無関係な既存paneや再利用Agentは候補へ入れない。
 
 1. `herdr pane layout --current` のJSONを一時ファイルへ保存する。
-2. 次を実行し、出力された分割対象・方向を使う。子を増やすたび `--child` を追加する。
+2. 次を実行し、親と同一 `workspace_id`・`tab_id` へ分割されたことを事前・事後に検証済みの新規 pane ID を取得する。子を増やすたび `--child` を追加する。
 
 ```bash
-<skill-dir>/scripts/choose_layout.py \
+<skill-dir>/scripts/split_scoped_pane.py \
+  --parent-pane-id "$HERDR_PANE_ID" \
+  --task-dir <task-dir> \
+  --cwd <cwd> \
   --layout-file <layout.json> \
-  --parent "$HERDR_PANE_ID" \
   --child <child-pane-id>
 ```
 
-3. 約50%で分割し、レスポンスの `result.pane.pane_id` を新しいIDとして取得する。
-
-```bash
-herdr pane split <target-pane-id> \
-  --direction <right-or-down> --ratio 0.5 --cwd <cwd> --no-focus
-herdr pane run <new-pane-id> '<agent-command>'
-```
-
+3. 検証済みの新規 pane ID へ `herdr pane run <new-pane-id> '<agent-command>'` を実行する。
 4. semantic state対応Agentは `agent-status idle`、その他は画面出力と `pane read` で起動を確認する。確認できない場合は依頼を送らない。
 5. 分割判断に使ったlayout一時ファイルを削除する。
+
+`split_scoped_pane.py` は検証失敗時に Agent を起動しない。事後検証失敗時は、新規 pane が安全に帰属できる場合だけ `herdr pane close` する。帰属不能または close 失敗時は pane と task directory を保持して停止する。診断情報は `<task-dir>/split_scoped_pane.diagnostics.json` に保存する。
 
 ## 5. 依頼を送る
 

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -41,7 +41,7 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 
 親と「今回この親が起動した子」のpane IDだけを候補にする。無関係な既存paneや再利用Agentは候補へ入れない。
 
-1. `herdr pane layout --current` のJSONを一時ファイルへ保存する。
+1. `herdr pane layout --pane "$HERDR_PANE_ID"` のJSONを一時ファイルへ保存する。
 2. 次を実行し、親と同一 `workspace_id`・`tab_id` へ分割されたことを事前・事後に検証済みの新規 pane ID を取得する。子を増やすたび `--child` を追加する。
 
 ```bash

--- a/herdr-agent-delegate/scripts/split_scoped_pane.py
+++ b/herdr-agent-delegate/scripts/split_scoped_pane.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Split a herdr pane and verify the new pane stays in the parent's fixed scope."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NoReturn
+
+
+def _load_choose_layout() -> Any:
+    scripts_dir = Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_file_location("choose_layout", scripts_dir / "choose_layout.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+choose_layout = _load_choose_layout()
+
+
+def run_herdr(arguments: list[str], timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a herdr CLI command. This function is the injection point for tests."""
+    return subprocess.run(
+        ["herdr", *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def parse_pane(payload: dict[str, Any], label: str) -> dict[str, str]:
+    """Extract pane_id, workspace_id, tab_id from a herdr pane response."""
+    try:
+        pane = payload["result"]["pane"]
+        return {
+            "pane_id": str(pane["pane_id"]),
+            "workspace_id": str(pane["workspace_id"]),
+            "tab_id": str(pane["tab_id"]),
+        }
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"{label}: invalid pane payload: {error}") from error
+
+
+def get_current_pane(expected_parent_id: str) -> dict[str, str]:
+    result = run_herdr(["pane", "current", "--current"], timeout=10)
+    if result.returncode != 0:
+        raise RuntimeError(f"pane current failed: {result.stderr.strip()}")
+    pane = parse_pane(json.loads(result.stdout), "current pane")
+    if pane["pane_id"] != expected_parent_id:
+        raise ValueError(
+            f"current pane {pane['pane_id']} does not match expected parent {expected_parent_id}"
+        )
+    return pane
+
+
+def get_layout_json(layout_file: Path | None) -> dict[str, Any]:
+    if layout_file is not None:
+        with layout_file.open(encoding="utf-8") as stream:
+            return json.load(stream)
+    result = run_herdr(["pane", "layout", "--current"], timeout=10)
+    if result.returncode != 0:
+        raise RuntimeError(f"pane layout failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def validate_layout_scope(layout: dict[str, Any], expected: dict[str, str], parent_id: str) -> None:
+    panes = layout.get("result", {}).get("layout", {}).get("panes", [])
+    pane_ids = {p.get("pane_id") for p in panes}
+    if parent_id not in pane_ids:
+        raise ValueError("parent pane is not present in the current layout")
+
+    scope_sources = [
+        layout.get("result", {}).get("layout", {}),
+        layout.get("result", {}),
+    ]
+    found_scope = False
+    for source in scope_sources:
+        if "workspace_id" in source or "tab_id" in source:
+            found_scope = True
+            for key in ("workspace_id", "tab_id"):
+                value = source.get(key)
+                if not isinstance(value, str) or value == "":
+                    raise ValueError(f"layout {key} is missing, null, empty, or not a string")
+                if value != expected[key]:
+                    raise ValueError(f"layout {key} mismatch: expected {expected[key]}, got {value}")
+
+    if not found_scope:
+        pane_scopes = [
+            (p.get("workspace_id"), p.get("tab_id"))
+            for p in panes
+            if "workspace_id" in p or "tab_id" in p
+        ]
+        if not pane_scopes:
+            raise ValueError("layout response does not contain workspace_id or tab_id")
+        for workspace_id, tab_id in pane_scopes:
+            if workspace_id != expected["workspace_id"] or tab_id != expected["tab_id"]:
+                raise ValueError("layout pane scope does not match expected scope")
+
+
+def get_pane(pane_id: str, label: str) -> dict[str, str]:
+    result = run_herdr(["pane", "get", pane_id], timeout=10)
+    if result.returncode != 0:
+        raise RuntimeError(f"pane get {pane_id} failed: {result.stderr.strip()}")
+    return parse_pane(json.loads(result.stdout), label)
+
+
+def validate_scope(pane: dict[str, str], expected: dict[str, str], label: str) -> None:
+    for key in ("workspace_id", "tab_id"):
+        value = pane.get(key)
+        if not isinstance(value, str) or value == "":
+            raise ValueError(f"{label}: {key} is missing, null, empty, or not a string")
+        if value != expected[key]:
+            raise ValueError(f"{label}: {key} mismatch: expected {expected[key]}, got {value}")
+
+
+def split_pane(target_id: str, direction: str, cwd: str) -> dict[str, str]:
+    result = run_herdr(
+        [
+            "pane",
+            "split",
+            target_id,
+            "--direction",
+            direction,
+            "--ratio",
+            "0.5",
+            "--cwd",
+            cwd,
+            "--no-focus",
+        ],
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"pane split failed: {result.stderr.strip()}")
+    return parse_pane(json.loads(result.stdout), "split response")
+
+
+def close_pane(pane_id: str) -> subprocess.CompletedProcess[str]:
+    return run_herdr(["pane", "close", pane_id], timeout=10)
+
+
+def can_close_safely(new_pane: dict[str, str] | None, forbidden_ids: set[str]) -> bool:
+    if new_pane is None:
+        return False
+    new_pane_id = new_pane.get("pane_id")
+    if not isinstance(new_pane_id, str) or new_pane_id == "":
+        return False
+    if new_pane_id in forbidden_ids:
+        return False
+    return True
+
+
+def save_diagnostics(task_dir: Path, diagnostics: dict[str, Any]) -> Path:
+    path = task_dir / "split_scoped_pane.diagnostics.json"
+    path.write_text(json.dumps(diagnostics, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def fail_with_diagnostics(
+    message: str, diagnostics: dict[str, Any], task_dir: Path, exit_code: int = 1
+) -> NoReturn:
+    diagnostics["failure_reason"] = message
+    save_diagnostics(task_dir, diagnostics)
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def run(args: argparse.Namespace) -> dict[str, str]:
+    task_dir = Path(args.task_dir).resolve()
+    if not task_dir.is_dir():
+        raise SystemExit(f"ERROR: task directory does not exist: {task_dir}")
+
+    diagnostics: dict[str, Any] = {
+        "parent_pane_id": args.parent_pane_id,
+        "cwd": args.cwd,
+        "task_dir": str(task_dir),
+    }
+
+    try:
+        parent_before = get_current_pane(args.parent_pane_id)
+        expected_scope = {
+            "workspace_id": parent_before["workspace_id"],
+            "tab_id": parent_before["tab_id"],
+        }
+        diagnostics["parent_before"] = parent_before
+        diagnostics["expected_scope"] = expected_scope
+        validate_scope(parent_before, expected_scope, "parent_before")
+    except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        fail_with_diagnostics(str(error), diagnostics, task_dir)
+
+    try:
+        layout = get_layout_json(Path(args.layout_file) if args.layout_file is not None else None)
+        diagnostics["layout"] = layout
+        validate_layout_scope(layout, expected_scope, args.parent_pane_id)
+    except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired, OSError) as error:
+        fail_with_diagnostics(str(error), diagnostics, task_dir)
+
+    children = list(args.child)
+    try:
+        choice = choose_layout.choose(layout, args.parent_pane_id, children, args.cell_aspect)
+        diagnostics["choice"] = choice
+        target_id = choice["target_pane_id"]
+    except (ValueError, KeyError, TypeError) as error:
+        fail_with_diagnostics(str(error), diagnostics, task_dir)
+
+    try:
+        target_before = get_pane(target_id, "split_target_before")
+        diagnostics["target_before"] = target_before
+        validate_scope(target_before, expected_scope, "split_target_before")
+    except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        fail_with_diagnostics(str(error), diagnostics, task_dir)
+
+    pre_split_panes = layout.get("result", {}).get("layout", {}).get("panes", [])
+    forbidden_ids: set[str] = {p.get("pane_id") for p in pre_split_panes}
+    forbidden_ids.add(args.parent_pane_id)
+    forbidden_ids.update(children)
+
+    new_pane: dict[str, str] | None = None
+    try:
+        new_pane = split_pane(target_id, choice["direction"], args.cwd)
+        diagnostics["split_response"] = new_pane
+    except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        fail_with_diagnostics(str(error), diagnostics, task_dir)
+
+    if not new_pane["pane_id"]:
+        diagnostics["close_attempted"] = False
+        diagnostics["close_succeeded"] = None
+        fail_with_diagnostics("split response pane_id is empty", diagnostics, task_dir)
+
+    if new_pane["pane_id"] in forbidden_ids:
+        diagnostics["close_attempted"] = False
+        diagnostics["close_succeeded"] = None
+        fail_with_diagnostics(
+            f"split returned a pane ID already present before the split: {new_pane['pane_id']}",
+            diagnostics,
+            task_dir,
+        )
+
+    post_errors: list[str] = []
+    try:
+        parent_after = get_current_pane(args.parent_pane_id)
+        validate_scope(parent_after, expected_scope, "parent_after")
+        diagnostics["parent_after"] = parent_after
+    except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        post_errors.append(str(error))
+
+    try:
+        new_pane_after = get_pane(new_pane["pane_id"], "new_pane_after")
+        validate_scope(new_pane_after, expected_scope, "new_pane_after")
+        diagnostics["new_pane_after"] = new_pane_after
+    except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        post_errors.append(str(error))
+
+    if post_errors:
+        diagnostics["close_attempted"] = False
+        diagnostics["close_succeeded"] = None
+        if can_close_safely(new_pane, forbidden_ids):
+            diagnostics["close_attempted"] = True
+            close_result = close_pane(new_pane["pane_id"])
+            diagnostics["close_exit_code"] = close_result.returncode
+            diagnostics["close_stdout"] = close_result.stdout
+            diagnostics["close_stderr"] = close_result.stderr
+            diagnostics["close_succeeded"] = close_result.returncode == 0
+        fail_with_diagnostics("; ".join(post_errors), diagnostics, task_dir)
+
+    return {
+        "pane_id": new_pane["pane_id"],
+        "workspace_id": new_pane["workspace_id"],
+        "tab_id": new_pane["tab_id"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parent-pane-id", required=True, help="HERDR_PANE_ID of the invoking pane")
+    parser.add_argument("--task-dir", required=True, help="task directory for diagnostics")
+    parser.add_argument("--cwd", required=True, help="working directory for the new pane")
+    parser.add_argument("--layout-file", help="herdr pane layout JSON; default: fetch via herdr")
+    parser.add_argument("--child", action="append", default=[], help="previously created child pane IDs")
+    parser.add_argument("--cell-aspect", type=float, default=0.5)
+    args = parser.parse_args()
+    if args.cell_aspect <= 0:
+        parser.error("--cell-aspect must be greater than zero")
+    result = run(args)
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/herdr-agent-delegate/scripts/split_scoped_pane.py
+++ b/herdr-agent-delegate/scripts/split_scoped_pane.py
@@ -38,10 +38,14 @@ def parse_pane(payload: dict[str, Any], label: str) -> dict[str, str]:
     """Extract pane_id, workspace_id, tab_id from a herdr pane response."""
     try:
         pane = payload["result"]["pane"]
+        for key in ("pane_id", "workspace_id", "tab_id"):
+            value = pane[key]
+            if not isinstance(value, str) or value == "":
+                raise ValueError(f"{label}: {key} is not a non-empty string")
         return {
-            "pane_id": str(pane["pane_id"]),
-            "workspace_id": str(pane["workspace_id"]),
-            "tab_id": str(pane["tab_id"]),
+            "pane_id": pane["pane_id"],
+            "workspace_id": pane["workspace_id"],
+            "tab_id": pane["tab_id"],
         }
     except (KeyError, TypeError, ValueError) as error:
         raise ValueError(f"{label}: invalid pane payload: {error}") from error
@@ -107,7 +111,12 @@ def get_pane(pane_id: str, label: str) -> dict[str, str]:
     result = run_herdr(["pane", "get", pane_id], timeout=10)
     if result.returncode != 0:
         raise RuntimeError(f"pane get {pane_id} failed: {result.stderr.strip()}")
-    return parse_pane(json.loads(result.stdout), label)
+    pane = parse_pane(json.loads(result.stdout), label)
+    if pane["pane_id"] != pane_id:
+        raise ValueError(
+            f"{label}: pane get returned unexpected pane_id: expected {pane_id}, got {pane['pane_id']}"
+        )
+    return pane
 
 
 def validate_scope(pane: dict[str, str], expected: dict[str, str], label: str) -> None:
@@ -179,6 +188,8 @@ def run(args: argparse.Namespace) -> dict[str, str]:
         "parent_pane_id": args.parent_pane_id,
         "cwd": args.cwd,
         "task_dir": str(task_dir),
+        "close_attempted": False,
+        "close_succeeded": None,
     }
 
     try:
@@ -264,17 +275,22 @@ def run(args: argparse.Namespace) -> dict[str, str]:
         diagnostics["close_succeeded"] = None
         if can_close_safely(new_pane, forbidden_ids):
             diagnostics["close_attempted"] = True
-            close_result = close_pane(new_pane["pane_id"])
-            diagnostics["close_exit_code"] = close_result.returncode
-            diagnostics["close_stdout"] = close_result.stdout
-            diagnostics["close_stderr"] = close_result.stderr
-            diagnostics["close_succeeded"] = close_result.returncode == 0
+            try:
+                close_result = close_pane(new_pane["pane_id"])
+                diagnostics["close_exit_code"] = close_result.returncode
+                diagnostics["close_stdout"] = close_result.stdout
+                diagnostics["close_stderr"] = close_result.stderr
+                diagnostics["close_succeeded"] = close_result.returncode == 0
+            except subprocess.TimeoutExpired as error:
+                diagnostics["close_exit_code"] = None
+                diagnostics["close_succeeded"] = False
+                diagnostics["close_timeout_seconds"] = error.timeout
         fail_with_diagnostics("; ".join(post_errors), diagnostics, task_dir)
 
     return {
-        "pane_id": new_pane["pane_id"],
-        "workspace_id": new_pane["workspace_id"],
-        "tab_id": new_pane["tab_id"],
+        "pane_id": new_pane_after["pane_id"],
+        "workspace_id": new_pane_after["workspace_id"],
+        "tab_id": new_pane_after["tab_id"],
     }
 
 

--- a/herdr-agent-delegate/scripts/split_scoped_pane.py
+++ b/herdr-agent-delegate/scripts/split_scoped_pane.py
@@ -59,11 +59,11 @@ def get_current_pane(expected_parent_id: str) -> dict[str, str]:
     return pane
 
 
-def get_layout_json(layout_file: Path | None) -> dict[str, Any]:
+def get_layout_json(layout_file: Path | None, parent_pane_id: str) -> dict[str, Any]:
     if layout_file is not None:
         with layout_file.open(encoding="utf-8") as stream:
             return json.load(stream)
-    result = run_herdr(["pane", "layout", "--current"], timeout=10)
+    result = run_herdr(["pane", "layout", "--pane", parent_pane_id], timeout=10)
     if result.returncode != 0:
         raise RuntimeError(f"pane layout failed: {result.stderr.strip()}")
     return json.loads(result.stdout)
@@ -194,7 +194,10 @@ def run(args: argparse.Namespace) -> dict[str, str]:
         fail_with_diagnostics(str(error), diagnostics, task_dir)
 
     try:
-        layout = get_layout_json(Path(args.layout_file) if args.layout_file is not None else None)
+        layout = get_layout_json(
+            Path(args.layout_file) if args.layout_file is not None else None,
+            args.parent_pane_id,
+        )
         diagnostics["layout"] = layout
         validate_layout_scope(layout, expected_scope, args.parent_pane_id)
     except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired, OSError) as error:

--- a/herdr-agent-delegate/tests/test_split_scoped_pane.py
+++ b/herdr-agent-delegate/tests/test_split_scoped_pane.py
@@ -1,0 +1,408 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "split_scoped_pane.py"
+SPEC = importlib.util.spec_from_file_location("split_scoped_pane", MODULE_PATH)
+split_scoped_pane = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(split_scoped_pane)
+
+
+def pane_payload(pane_id: str, workspace_id: str = "w1", tab_id: str = "w1:t1", **extra: object) -> dict:
+    return {"result": {"pane": {"pane_id": pane_id, "workspace_id": workspace_id, "tab_id": tab_id, **extra}}}
+
+
+def layout_payload(
+    panes: list[dict], workspace_id: str = "w1", tab_id: str = "w1:t1"
+) -> dict:
+    return {"result": {"layout": {"workspace_id": workspace_id, "tab_id": tab_id, "panes": panes}}}
+
+
+class MockResult:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class HerdrMock:
+    def __init__(self) -> None:
+        self.responses: list[tuple[list[str], MockResult]] = []
+        self.calls: list[list[str]] = []
+
+    def add(self, arguments: list[str], result: MockResult) -> None:
+        self.responses.append((arguments, result))
+
+    def __call__(self, arguments: list[str], timeout: float | None = None) -> MockResult:
+        self.calls.append(arguments)
+        for index, (expected, result) in enumerate(self.responses):
+            if arguments == expected:
+                self.responses.pop(index)
+                return result
+        raise AssertionError(f"unexpected herdr call: {arguments}")
+
+
+class SplitScopedPaneTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.task_dir = Path(self.temporary.name) / "task"
+        self.task_dir.mkdir()
+        self.layout_file = Path(self.temporary.name) / "layout.json"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def write_layout(self, payload: dict) -> None:
+        self.layout_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    def args(self, **overrides) -> Namespace:
+        defaults = {
+            "parent_pane_id": "w1:p1",
+            "task_dir": str(self.task_dir),
+            "cwd": "/work",
+            "layout_file": str(self.layout_file),
+            "child": [],
+            "cell_aspect": 0.5,
+        }
+        defaults.update(overrides)
+        return Namespace(**defaults)
+
+    def diagnostics(self) -> dict:
+        path = self.task_dir / "split_scoped_pane.diagnostics.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_successful_split_returns_verified_pane(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.run(self.args())
+
+        self.assertEqual(result, {"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1"})
+        self.assertFalse((self.task_dir / "split_scoped_pane.diagnostics.json").exists())
+
+    def test_parent_mismatch_fails_before_split(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p9"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("w1:p9", self.diagnostics()["failure_reason"])
+        self.assertNotIn(["pane", "split", "w1:p1", "--direction", "right"], mock.calls)
+
+    def test_missing_workspace_id_in_parent_fails(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(
+            ["pane", "current", "--current"],
+            MockResult(stdout=json.dumps({"result": {"pane": {"pane_id": "w1:p1", "tab_id": "w1:t1"}}})),
+        )
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("workspace_id", self.diagnostics()["failure_reason"])
+        self.assertNotIn(["pane", "split", "w1:p1"], [c[:3] for c in mock.calls])
+
+    def test_layout_scope_mismatch_fails_before_split(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}], workspace_id="w2"))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("layout workspace_id mismatch", self.diagnostics()["failure_reason"])
+        self.assertNotIn(["pane", "split", "w1:p1"], [c[:3] for c in mock.calls])
+
+    def test_layout_missing_parent_fails_before_split(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p9", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("parent pane is not present", self.diagnostics()["failure_reason"])
+
+    def test_target_scope_mismatch_fails_before_split(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1", workspace_id="w2"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("split_target_before", self.diagnostics()["failure_reason"])
+        self.assertNotIn(["pane", "split", "w1:p1"], [c[:3] for c in mock.calls])
+
+    def test_split_command_failure_does_not_close(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(returncode=1, stderr="split rejected"),
+        )
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("split rejected", self.diagnostics()["failure_reason"])
+        self.assertNotIn(["pane", "close", "w1:p2"], mock.calls)
+
+    def test_parent_moved_after_split_triggers_safe_close(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1", workspace_id="w2"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+        mock.add(["pane", "close", "w1:p2"], MockResult())
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertIn("parent_after", diagnostics["failure_reason"])
+        self.assertTrue(diagnostics["close_attempted"])
+        self.assertTrue(diagnostics["close_succeeded"])
+        self.assertEqual(["pane", "close", "w1:p2"], mock.calls[-1])
+
+    def test_new_pane_scope_mismatch_triggers_safe_close(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2", workspace_id="w2"))))
+        mock.add(["pane", "close", "w1:p2"], MockResult())
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertIn("new_pane_after", diagnostics["failure_reason"])
+        self.assertTrue(diagnostics["close_attempted"])
+        self.assertTrue(diagnostics["close_succeeded"])
+
+    def test_duplicate_new_pane_id_is_not_closed(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p1"))),
+        )
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertIn("already present before the split", diagnostics["failure_reason"])
+        self.assertFalse(diagnostics["close_attempted"])
+        self.assertNotIn(["pane", "close", "w1:p1"], mock.calls)
+
+    def test_close_failure_is_recorded_without_retry(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1", workspace_id="w2"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+        mock.add(["pane", "close", "w1:p2"], MockResult(returncode=1, stderr="close rejected"))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertTrue(diagnostics["close_attempted"])
+        self.assertFalse(diagnostics["close_succeeded"])
+        self.assertEqual(diagnostics["close_stderr"], "close rejected")
+        close_calls = [c for c in mock.calls if c[:2] == ["pane", "close"]]
+        self.assertEqual(len(close_calls), 1)
+
+    def test_child_candidate_is_preferred_and_verified(self):
+        self.write_layout(
+            layout_payload(
+                [
+                    {"pane_id": "w1:p1", "rect": {"width": 60, "height": 40}},
+                    {"pane_id": "w1:p2", "rect": {"width": 120, "height": 40}},
+                ]
+            )
+        )
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+        mock.add(
+            ["pane", "split", "w1:p2", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p3"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p3"], MockResult(stdout=json.dumps(pane_payload("w1:p3"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.run(self.args(child=["w1:p2"]))
+
+        self.assertEqual(result["pane_id"], "w1:p3")
+
+    def test_layout_fetched_via_herdr_when_file_not_given(self):
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "layout", "--current"],
+            MockResult(stdout=json.dumps(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))),
+        )
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.run(self.args(layout_file=None))
+
+        self.assertEqual(result["pane_id"], "w1:p2")
+        self.assertIn(["pane", "layout", "--current"], mock.calls)
+
+    def test_empty_tab_id_in_layout_fails(self):
+        self.write_layout(
+            {"result": {"layout": {"workspace_id": "w1", "tab_id": "", "panes": [{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]}}}
+        )
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("layout tab_id", self.diagnostics()["failure_reason"])
+
+    def test_tab_id_mismatch_in_new_pane_triggers_close(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2", tab_id="w1:t2"))))
+        mock.add(["pane", "close", "w1:p2"], MockResult())
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertIn("new_pane_after", diagnostics["failure_reason"])
+        self.assertTrue(diagnostics["close_attempted"])
+
+    def test_empty_new_pane_id_is_not_closed(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps({"result": {"pane": {"pane_id": "", "workspace_id": "w1", "tab_id": "w1:t1"}}})),
+        )
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertFalse(diagnostics["close_attempted"])
+        self.assertNotIn(["pane", "close", ""], mock.calls)
+
+    def test_post_validation_pane_get_failure_triggers_safe_close(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(returncode=1, stderr="pane vanished"))
+        mock.add(["pane", "close", "w1:p2"], MockResult())
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertIn("pane get w1:p2 failed", diagnostics["failure_reason"])
+        self.assertTrue(diagnostics["close_attempted"])
+        self.assertTrue(diagnostics["close_succeeded"])
+
+    def test_command_order_is_pre_validation_split_post_validation(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            split_scoped_pane.run(self.args())
+
+        self.assertEqual(mock.calls[0], ["pane", "current", "--current"])
+        self.assertEqual(mock.calls[1], ["pane", "get", "w1:p1"])
+        self.assertEqual(mock.calls[2][:2], ["pane", "split"])
+        self.assertEqual(mock.calls[3], ["pane", "current", "--current"])
+        self.assertEqual(mock.calls[4], ["pane", "get", "w1:p2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-agent-delegate/tests/test_split_scoped_pane.py
+++ b/herdr-agent-delegate/tests/test_split_scoped_pane.py
@@ -409,21 +409,33 @@ class SplitScopedPaneTest(unittest.TestCase):
         self.assertEqual(mock.calls[3], ["pane", "current", "--current"])
         self.assertEqual(mock.calls[4], ["pane", "get", "w1:p2"])
 
-    def test_non_string_pane_id_in_split_response_is_rejected(self):
-        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
-        mock = HerdrMock()
-        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
-        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
-        mock.add(
-            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
-            MockResult(stdout=json.dumps({"result": {"pane": {"pane_id": None, "workspace_id": "w1", "tab_id": "w1:t1"}}})),
-        )
+    def test_non_string_identifier_is_rejected(self):
+        cases = [
+            ("pane_id", None),
+            ("pane_id", 123),
+            ("workspace_id", None),
+            ("workspace_id", 123),
+            ("tab_id", None),
+            ("tab_id", 123),
+        ]
+        for field, bad_value in cases:
+            with self.subTest(field=field, value=bad_value):
+                self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+                pane = {"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1"}
+                pane[field] = bad_value
+                mock = HerdrMock()
+                mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+                mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+                mock.add(
+                    ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+                    MockResult(stdout=json.dumps({"result": {"pane": pane}})),
+                )
 
-        with patch.object(split_scoped_pane, "run_herdr", mock):
-            with self.assertRaises(SystemExit):
-                split_scoped_pane.run(self.args())
+                with patch.object(split_scoped_pane, "run_herdr", mock):
+                    with self.assertRaises(SystemExit):
+                        split_scoped_pane.run(self.args())
 
-        self.assertIn("pane_id is not a non-empty string", self.diagnostics()["failure_reason"])
+                self.assertIn(f"{field} is not a non-empty string", self.diagnostics()["failure_reason"])
 
     def test_pane_get_returning_different_id_fails(self):
         self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
@@ -442,9 +454,10 @@ class SplitScopedPaneTest(unittest.TestCase):
         mock = HerdrMock()
         mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
         mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        # split response scope differs from post-validated scope to ensure output comes from post-validation
         mock.add(
             ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
-            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+            MockResult(stdout=json.dumps(pane_payload("w1:p2", workspace_id="w2", tab_id="w2:t1"))),
         )
         mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
         mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))

--- a/herdr-agent-delegate/tests/test_split_scoped_pane.py
+++ b/herdr-agent-delegate/tests/test_split_scoped_pane.py
@@ -33,17 +33,22 @@ class MockResult:
 
 class HerdrMock:
     def __init__(self) -> None:
-        self.responses: list[tuple[list[str], MockResult]] = []
+        self.responses: list[tuple[list[str], MockResult | Exception]] = []
         self.calls: list[list[str]] = []
 
     def add(self, arguments: list[str], result: MockResult) -> None:
         self.responses.append((arguments, result))
+
+    def add_exception(self, arguments: list[str], exception: Exception) -> None:
+        self.responses.append((arguments, exception))
 
     def __call__(self, arguments: list[str], timeout: float | None = None) -> MockResult:
         self.calls.append(arguments)
         for index, (expected, result) in enumerate(self.responses):
             if arguments == expected:
                 self.responses.pop(index)
+                if isinstance(result, Exception):
+                    raise result
                 return result
         raise AssertionError(f"unexpected herdr call: {arguments}")
 
@@ -357,6 +362,7 @@ class SplitScopedPaneTest(unittest.TestCase):
                 split_scoped_pane.run(self.args())
 
         diagnostics = self.diagnostics()
+        self.assertIn("pane_id is not a non-empty string", diagnostics["failure_reason"])
         self.assertFalse(diagnostics["close_attempted"])
         self.assertNotIn(["pane", "close", ""], mock.calls)
 
@@ -402,6 +408,78 @@ class SplitScopedPaneTest(unittest.TestCase):
         self.assertEqual(mock.calls[2][:2], ["pane", "split"])
         self.assertEqual(mock.calls[3], ["pane", "current", "--current"])
         self.assertEqual(mock.calls[4], ["pane", "get", "w1:p2"])
+
+    def test_non_string_pane_id_in_split_response_is_rejected(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps({"result": {"pane": {"pane_id": None, "workspace_id": "w1", "tab_id": "w1:t1"}}})),
+        )
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("pane_id is not a non-empty string", self.diagnostics()["failure_reason"])
+
+    def test_pane_get_returning_different_id_fails(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p99"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        self.assertIn("unexpected pane_id", self.diagnostics()["failure_reason"])
+
+    def test_success_uses_post_validated_pane_values(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.run(self.args())
+
+        self.assertEqual(result["pane_id"], "w1:p2")
+        self.assertEqual(result["workspace_id"], "w1")
+        self.assertEqual(result["tab_id"], "w1:t1")
+
+    def test_close_timeout_is_recorded(self):
+        import subprocess as sp
+
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["pane", "split", "w1:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w1:p2"))),
+        )
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1", workspace_id="w2"))))
+        mock.add(["pane", "get", "w1:p2"], MockResult(stdout=json.dumps(pane_payload("w1:p2"))))
+        mock.add_exception(["pane", "close", "w1:p2"], sp.TimeoutExpired(cmd=["herdr", "pane", "close", "w1:p2"], timeout=10))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args())
+
+        diagnostics = self.diagnostics()
+        self.assertTrue(diagnostics["close_attempted"])
+        self.assertFalse(diagnostics["close_succeeded"])
+        self.assertEqual(diagnostics["close_exit_code"], None)
+        self.assertEqual(diagnostics["close_timeout_seconds"], 10)
 
 
 if __name__ == "__main__":

--- a/herdr-agent-delegate/tests/test_split_scoped_pane.py
+++ b/herdr-agent-delegate/tests/test_split_scoped_pane.py
@@ -291,7 +291,7 @@ class SplitScopedPaneTest(unittest.TestCase):
         mock = HerdrMock()
         mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
         mock.add(
-            ["pane", "layout", "--current"],
+            ["pane", "layout", "--pane", "w1:p1"],
             MockResult(stdout=json.dumps(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 120, "height": 40}}]))),
         )
         mock.add(["pane", "get", "w1:p1"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
@@ -306,7 +306,7 @@ class SplitScopedPaneTest(unittest.TestCase):
             result = split_scoped_pane.run(self.args(layout_file=None))
 
         self.assertEqual(result["pane_id"], "w1:p2")
-        self.assertIn(["pane", "layout", "--current"], mock.calls)
+        self.assertIn(["pane", "layout", "--pane", "w1:p1"], mock.calls)
 
     def test_empty_tab_id_in_layout_fails(self):
         self.write_layout(

--- a/herdr-github-implement-pr/references/implementation-delegation.md
+++ b/herdr-github-implement-pr/references/implementation-delegation.md
@@ -39,6 +39,8 @@ Herdr 外、CLI 不足、認証・trust 待ちは実装委譲失敗とする。�
 
 指定された既存 Agent が存在しない、自分自身、または `idle` でない場合は失敗とする。別 Agent の起動、Codex への切り替え、自動再試行はしない。新規 Agent は `herdr-agent-delegate` の Grid 配置と起動確認に従い、その pane ID を親が管理する。
 
+新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用はこの検証・cleanup の対象外とする。
+
 ## 4. 実装を同期委譲する
 
 実装タスクに少なくとも次を含める。

--- a/herdr-github-implement-pr/references/review-loop.md
+++ b/herdr-github-implement-pr/references/review-loop.md
@@ -21,6 +21,8 @@ PR 作成成功後に読み、`herdr-agent-delegate` のタスク交換、待機
 
 指定された既存 Agent が存在しない、自分自身である、または `idle` でない場合は失敗とする。別 Agent の起動、Codex への切り替え、自動再試行はしない。新規 Agent は `herdr-agent-delegate` の Grid 配置と起動確認に従い、その pane ID を親が管理する。
 
+新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用はこの検証・cleanup の対象外とする。
+
 ## 3. 初回レビューを同期委譲する
 
 レビュータスクに次を含める。
@@ -65,7 +67,7 @@ FB 対応タスクに次を含める。
 - Herdr の Completion contract に従って結果を確定すること
 ```
 
-`question` または `blocked` が返った場合は自動対応を止める。正常完了時は `task_exchange.py collect --keep` で結果を検証・回収し、task directory を残したまま、親が子の報告だけでなく次を確認する。
+FB 対応 Agent も新規起動する。親と同一 `workspace_id`・`tab_id` への pane 分割は `herdr-agent-delegate/scripts/split_scoped_pane.py` で検証し、失敗時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。`question` または `blocked` が返った場合は自動対応を止める。正常完了時は `task_exchange.py collect --keep` で結果を検証・回収し、task directory を残したまま、親が子の報告だけでなく次を確認する。
 
 - 意図した差分だけが含まれる。
 - 必要な検証が成功している。


### PR DESCRIPTION
## Issues

- Close #152

## Why

`herdr-agent-delegate` は新規 Agent を親と同一 tab へペイン分割して起動するが、Herdr の Space に相当する `workspace_id` を明示的に検証していませんでした。識別子欠落、対象ペインの移動、CLI 応答異常を検出できるように、fail-closed なペイン作成処理が必要です。

## Summary

新規 Agent 用のペインを親と同一 `workspace_id`・`tab_id` へ分割する際に、分割前後でスコープを検証する `split_scoped_pane.py` を追加します。検証失敗時は Agent を起動せず、安全に帰属できる未起動 pane だけを close します。

## Changes

- `herdr-agent-delegate/scripts/split_scoped_pane.py` を追加
  - 親ペインの `(workspace_id, tab_id)` を固定スコープとして固定
  - 分割前：親ペイン、layout、分割対象の `pane get` 結果を検証
  - 分割後：親ペインと新規ペインを再取得してスコープ検証
  - 事後検証失敗時は安全な未起動 pane だけを close
  - 診断情報を task directory 内に保存
- `herdr-agent-delegate/SKILL.md` の新規 Agent 起動手順を更新
- `herdr-github-implement-pr` の実装委譲・レビューループ参照文書に保証要件を追記
- 正常系、境界値、異常系、cleanup 経路の単体テストを追加

## Checklist

- [x] 単体テスト
- [x] `bash scripts/validate-skills.sh`
- [x] `git diff --check`
