### PR TITLE
fix(herdr): wait for agent input readiness

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -53,9 +53,17 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
   --child <child-pane-id>
 ```
 
-3. 検証済みの新規 pane ID へ `herdr pane run <new-pane-id> '<agent-command>'` を実行する。
-4. semantic state対応Agentは `agent-status idle`、その他は画面出力と `pane read` で起動を確認する。確認できない場合は依頼を送らない。
-5. 分割判断に使ったlayout一時ファイルを削除する。
+3. 検証済みの新規 pane ID へ `herdr pane run <new-pane-id> '<agent-command>'` だけを実行する。
+4. 別コマンドの `herdr wait agent-status <new-pane-id> --status idle --timeout 30000` でsemantic stateによるAgent検出を待つ。この時点の `agent_status=idle` は入力可能を意味しない。
+5. Codex、Claude Code、OpenCodeは次を別コマンドで実行し、Agent別の入力欄を `wait output` と `pane read` の両方で確認する。
+
+```bash
+<skill-dir>/scripts/wait_for_input_ready.py \
+  --target <new-pane-id> --agent <codex|claude|opencode> --task-dir <task-dir>
+```
+
+6. その他のCLIは `references/agent-cli.md` の観測可能な入力可能条件を使う。条件が未定義または確認失敗なら、noticeもEnterも送らずpaneとtask directoryを保持して失敗終了する。
+7. 分割判断に使ったlayout一時ファイルを削除する。
 
 `split_scoped_pane.py` は検証失敗時に Agent を起動しない。事後検証失敗時は、新規 pane が安全に帰属できる場合だけ `herdr pane close` する。帰属不能または close 失敗時は pane と task directory を保持して停止する。診断情報は `<task-dir>/split_scoped_pane.diagnostics.json` に保存する。
 
@@ -68,7 +76,7 @@ Agentへは短い通知だけを送る。
 ファイル全文を読み、Completion contractに従って結果を確定してください。
 ```
 
-対応Agentには `herdr agent send <target> <notice>`、その他には `herdr pane send-text <pane-id> <notice>` を使い、送信後のEnterは `herdr pane send-keys <pane-id> Enter` で分ける。送信直後にsemantic stateが `working` へ遷移するか、画面が処理開始を示すことを確認する。
+新規Agentでは入力可能確認の成功後に限り、対応Agentへの `herdr agent send <target> <notice>`（その他は `herdr pane send-text`）、`herdr pane send-keys <pane-id> Enter`、`working` 遷移確認をこの順の別コマンドで実行する。起動から送信までを `&&` で連結しない。既存idle Agentの再利用でもnoticeとEnterを分け、送信直後にsemantic stateが `working` へ遷移するか、画面が処理開始を示すことを確認する。遷移を確認できなければpaneとtask directoryを保持して失敗終了する。
 
 ## 6. 完了を待つ
 

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -11,20 +11,33 @@
 
 ユーザーが指定した引数は該当コマンドへ渡す。指定されていない引数を補わない。シェル展開が必要な文字列を組み立てず、コマンドは `herdr pane run` の1引数として渡す。
 
-## 起動確認
+## 新規起動の入力可能確認
 
 1. `herdr pane split` のJSONから新規 `pane_id` を読む。
 2. `herdr pane run <pane-id> '<command>'` を実行する。
-3. 対応Agentでは `herdr wait agent-status <pane-id> --status idle --timeout 30000` を使う。
-4. 未対応CLIでは期待するプロンプトを `herdr wait output` で待ち、`herdr pane read --source recent-unwrapped --lines 40` でも確認する。
-5. trust、login、初期設定などのダイアログがあれば自動承認しない。内容をユーザーへ報告する。
+3. 対応Agentではsemantic stateで対象Agentが検出されるまで待つ。`agent_status=idle` だけでは入力可能と判定しない。
+4. `wait_for_input_ready.py` で次の表示を `herdr wait output` と直後の `pane read` の両方から確認する。
+
+| Agent | 新規起動時の入力可能表示 |
+| --- | --- |
+| Codex | 行頭の入力プロンプト `›` |
+| Claude Code | 行頭の入力プロンプト `❯` |
+| OpenCode | 入力欄フッター `ctrl+p commands` |
+
+5. trust、login、初期設定などのダイアログがあれば自動承認しない。入力可能失敗としてpaneとtask directoryを保持し、内容を報告する。
+
+新規起動では `pane run`、semantic検出、入力可能確認、notice送信、Enter送信、`working` 遷移確認を別々に実行する。入力可能を確認できなければnoticeもEnterも送らない。未対応CLIは観測可能な固有プロンプトを事前に定義できる場合だけ同じ二重確認を行い、未定義なら失敗とする。
+
+## 既存idle Agentの再利用
+
+明示指定された既存Agentは、`herdr agent get` で操作直前に `idle` と確認できれば再利用できる。すでに起動済みのTUIなので新規起動用の入力可能待機は行わない。ただしnotice送信とEnter送信は分離し、直後の `working` 遷移を必ず確認する。`done`、`blocked`、`working`、`unknown` は再利用しない。
 
 ## IDと送信
 
 - pane IDはcloseなどで変化しうる。`agent list`、`agent get`、`pane current`、create/splitレスポンスから都度読む。
 - `agent send` と `pane send-text` はEnterを送らない。`pane send-keys <pane-id> Enter` を別に実行する。
 - シェルへコマンドを送る時だけ `pane run` を使う。Agentの入力欄へ依頼を送る時はtextとEnterを分離する。
-- `agent_status=done` は再利用可能なidleではない。新しい依頼を送らない。
+- 新規起動の工程を単一の `&&` チェーンにまとめない。各観測結果を確認してから次へ進む。
 
 ## semantic待機の判定
 

--- a/herdr-agent-delegate/scripts/wait_for_input_ready.py
+++ b/herdr-agent-delegate/scripts/wait_for_input_ready.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Wait until a newly started Agent TUI can accept input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+READY_RULES = {
+    "codex": ("›", r"(?m)^\s*›(?:\s|$)"),
+    "claude": ("❯", r"(?m)^\s*❯(?:\s|$)"),
+    "opencode": ("ctrl+p commands", r"(?i)ctrl\+p\s+commands"),
+}
+
+
+def run_herdr(arguments: list[str], timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["herdr", *arguments], check=False, capture_output=True, text=True, timeout=timeout
+    )
+
+
+def write_diagnostics(task_dir: Path, payload: dict[str, object]) -> None:
+    (task_dir / "input_readiness.diagnostics.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def wait_for_input_ready(args: argparse.Namespace) -> int:
+    started = time.monotonic()
+    marker, pattern = READY_RULES[args.agent]
+    waited = run_herdr(
+        ["wait", "output", args.target, "--match", marker, "--source", "recent-unwrapped",
+         "--timeout", str(args.timeout)],
+        timeout=args.timeout / 1000 + 5,
+    )
+    read = run_herdr(
+        ["pane", "read", args.target, "--source", "recent-unwrapped", "--lines", str(args.lines)],
+        timeout=10,
+    )
+    elapsed = round(time.monotonic() - started, 3)
+    if waited.returncode == 0 and read.returncode == 0 and re.search(pattern, read.stdout):
+        print(json.dumps({"status": "input_ready", "target": args.target, "agent": args.agent,
+                          "elapsed_seconds": elapsed}))
+        return 0
+
+    diagnostics = {
+        "status": "input_not_ready", "target": args.target, "agent": args.agent,
+        "elapsed_seconds": elapsed, "wait_returncode": waited.returncode,
+        "wait_stderr": waited.stderr, "read_returncode": read.returncode,
+        "read_output": read.stdout, "read_stderr": read.stderr,
+    }
+    write_diagnostics(Path(args.task_dir), diagnostics)
+    print(json.dumps(diagnostics, ensure_ascii=False), file=sys.stderr)
+    return 2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--agent", required=True, choices=sorted(READY_RULES))
+    parser.add_argument("--task-dir", required=True)
+    parser.add_argument("--timeout", type=int, default=30_000)
+    parser.add_argument("--lines", type=int, default=80)
+    args = parser.parse_args()
+    if args.timeout <= 0 or args.lines <= 0:
+        parser.error("timeout and lines must be greater than zero")
+    raise SystemExit(wait_for_input_ready(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/herdr-agent-delegate/tests/test_wait_for_input_ready.py
+++ b/herdr-agent-delegate/tests/test_wait_for_input_ready.py
@@ -1,0 +1,67 @@
+import importlib.util
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "wait_for_input_ready.py"
+SPEC = importlib.util.spec_from_file_location("wait_for_input_ready", MODULE_PATH)
+readiness = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(readiness)
+
+
+class Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class WaitForInputReadyTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.task_dir = Path(self.temporary.name) / "task"
+        self.task_dir.mkdir()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def args(self, agent="codex"):
+        return Namespace(target="w1:p2", agent=agent, task_dir=str(self.task_dir),
+                         timeout=1_000, lines=80)
+
+    def test_semantic_idle_does_not_trigger_notice_or_enter(self):
+        results = [Result(returncode=1), Result(stdout="agent_status: idle\n")]
+        with patch.object(readiness, "run_herdr", side_effect=results) as run:
+            self.assertEqual(readiness.wait_for_input_ready(self.args()), 2)
+        self.assertEqual(run.call_count, 2)
+        self.assertNotIn("agent-status", str(run.call_args_list))
+        self.assertNotIn("send", str(run.call_args_list))
+        self.assertTrue((self.task_dir / "input_readiness.diagnostics.json").is_file())
+
+    def test_delayed_codex_tui_requires_wait_and_read_confirmation(self):
+        results = [Result(stdout="matched"), Result(stdout="Codex\n\n› Ask for changes\n")]
+        with patch.object(readiness, "run_herdr", side_effect=results) as run:
+            self.assertEqual(readiness.wait_for_input_ready(self.args()), 0)
+        self.assertEqual(run.call_args_list[0].args[0][:2], ["wait", "output"])
+        self.assertEqual(run.call_args_list[1].args[0][:2], ["pane", "read"])
+
+    def test_wait_match_without_prompt_in_readback_fails(self):
+        results = [Result(stdout="matched"), Result(stdout="Codex is still starting\n")]
+        with patch.object(readiness, "run_herdr", side_effect=results):
+            self.assertEqual(readiness.wait_for_input_ready(self.args()), 2)
+
+    def test_agent_specific_ready_signatures(self):
+        outputs = {"claude": "❯ ", "opencode": "Build · Model  ctrl+p commands"}
+        for agent, output in outputs.items():
+            with self.subTest(agent=agent), patch.object(
+                readiness, "run_herdr", side_effect=[Result(), Result(stdout=output)]
+            ):
+                self.assertEqual(readiness.wait_for_input_ready(self.args(agent)), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-github-implement-pr/agents/openai.yaml
+++ b/herdr-github-implement-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "GitHub Implement PR"
-  short_description: "GitHub Issue対応を実装委譲からレビューまで一括管理する"
-  default_prompt: "Use $herdr-github-implement-pr to delegate a GitHub issue implementation, create a PR, and manage review feedback."
+  display_name: "Herdr GitHub Implement PR"
+  short_description: "Herdr AgentへGitHub Issue実装を委譲しPRレビューまで管理する"
+  default_prompt: "Use $herdr-github-implement-pr to orchestrate GitHub issue implementation and PR review through Herdr agents."

--- a/herdr-github-implement-pr/references/implementation-delegation.md
+++ b/herdr-github-implement-pr/references/implementation-delegation.md
@@ -39,7 +39,7 @@ Herdr 外、CLI 不足、認証・trust 待ちは実装委譲失敗とする。�
 
 指定された既存 Agent が存在しない、自分自身、または `idle` でない場合は失敗とする。別 Agent の起動、Codex への切り替え、自動再試行はしない。新規 Agent は `herdr-agent-delegate` の Grid 配置と起動確認に従い、その pane ID を親が管理する。
 
-新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用はこの検証・cleanup の対象外とする。
+新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。その後は同スキルの更新済みreadiness契約に従い、pane run、semantic検出、Agent別input-ready確認、notice送信、Enter送信、working遷移確認を別工程で行う。input-readyを確認できなければ何も送信せず、paneとtask directoryを保持して停止する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用は分割検証と新規起動用readiness待機の対象外とする。
 
 ## 4. 実装を同期委譲する
 

--- a/herdr-github-implement-pr/references/review-loop.md
+++ b/herdr-github-implement-pr/references/review-loop.md
@@ -21,7 +21,7 @@ PR 作成成功後に読み、`herdr-agent-delegate` のタスク交換、待機
 
 指定された既存 Agent が存在しない、自分自身である、または `idle` でない場合は失敗とする。別 Agent の起動、Codex への切り替え、自動再試行はしない。新規 Agent は `herdr-agent-delegate` の Grid 配置と起動確認に従い、その pane ID を親が管理する。
 
-新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用はこの検証・cleanup の対象外とする。
+新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。その後は同スキルの更新済みreadiness契約に従い、pane run、semantic検出、Agent別input-ready確認、notice送信、Enter送信、working遷移確認を別工程で行う。input-readyを確認できなければ何も送信せず、paneとtask directoryを保持して停止する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用は分割検証と新規起動用readiness待機の対象外とする。
 
 ## 3. 初回レビューを同期委譲する
 
@@ -67,7 +67,7 @@ FB 対応タスクに次を含める。
 - Herdr の Completion contract に従って結果を確定すること
 ```
 
-FB 対応 Agent も新規起動する。親と同一 `workspace_id`・`tab_id` への pane 分割は `herdr-agent-delegate/scripts/split_scoped_pane.py` で検証し、失敗時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。`question` または `blocked` が返った場合は自動対応を止める。正常完了時は `task_exchange.py collect --keep` で結果を検証・回収し、task directory を残したまま、親が子の報告だけでなく次を確認する。
+FB 対応 Agent も新規起動する。親と同一 `workspace_id`・`tab_id` への pane 分割は `herdr-agent-delegate/scripts/split_scoped_pane.py` で検証し、上記と同じ新規起動readiness契約を適用する。分割またはinput-ready確認に失敗した場合は何も送信せず、paneとtask directoryを保持する。安全に帰属できる未起動 pane だけを close する。`question` または `blocked` が返った場合は自動対応を止める。正常完了時は `task_exchange.py collect --keep` で結果を検証・回収し、task directory を残したまま、親が子の報告だけでなく次を確認する。
 
 - 意図した差分だけが含まれる。
 - 必要な検証が成功している。


### PR DESCRIPTION
## Issues

- Close #154

## Why

新規 Herdr Agent の semantic `idle` が TUI の入力受付開始より先に成立し、委譲通知と Enter が失われる起動競合を防ぐためです。

## Summary

Agent 固有の入力可能表示を二重確認する readiness helper を追加し、起動から送信までを独立した工程として定義しました。Herdr GitHub 実装フローにも同じ契約を適用し、Codex 用 YAML の説明を Herdr 指向へ更新しています。

## Changes

- Codex、Claude Code、OpenCode の input-ready 表示を `wait output` と `pane read` で確認
- readiness 失敗時の診断保存と、通知を送らない失敗契約を追加
- 起動競合と Agent 別判定を検証する単体テストを追加
- 実装・レビュー・FB 対応委譲へ readiness 契約を反映
- `herdr-github-implement-pr/agents/openai.yaml` の表示名・説明・既定プロンプトを Herdr 系へ修正

## Verification

- `python3 -m unittest discover -s herdr-agent-delegate/tests -v` - passed (41 tests)
- `python3 -m py_compile herdr-agent-delegate/scripts/wait_for_input_ready.py` - passed
- `bash scripts/validate-skills.sh` - passed (28 skills)
- `git diff --check` - passed
