### PR TITLE
feat: add post-merge PR cleanup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | [github-pr-feedback-address](github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う |
 | [github-pr-review](github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う |
 | [github-pr-comment-reply](github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する |
+| [github-pr-post-merge-cleanup](github-pr-post-merge-cleanup/SKILL.md) | マージ済み PR の基準ブランチへ戻り、ローカル作業ブランチを安全に整理する |
 | [ai-identity-resolve](ai-identity-resolve/SKILL.md) | AIレビュー補助コメント用のエージェント名・モデル名を推測せず取得する |
 
 ### 実装 / 成果物生成

--- a/github-pr-post-merge-cleanup/SKILL.md
+++ b/github-pr-post-merge-cleanup/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: github-pr-post-merge-cleanup
+description: GitHub PRをユーザーがマージした後、PRのbase branchへ戻り、最新化してローカルの作業ブランチを削除するときに使う。「マージ後の片付け」「基準ブランチに戻して」「次の開発に備えてブランチを整理して」などの依頼が対象。PRのマージ操作やremote branchの削除は行わない。
+---
+
+# GitHub PR Post-Merge Cleanup
+
+マージ済みPRの作業環境を片付け、次の開発を始められる状態に戻す。
+
+## 原則
+
+- PRのマージは行わない。ユーザーがGitHub上でマージした後にだけ実行する。
+- 現在のローカルブランチに紐づくPRを対象にする。会話にPR番号があれば同じPRか照合する。
+- PRのbase branchは`main`または`develop`だけを許可する。それ以外なら停止する。
+- 削除対象は対象PRのローカルhead branchだけに限定する。
+- remote branch、他のローカルブランチ、worktree、stashは変更しない。
+- 未コミット変更または未追跡ファイルがあれば停止する。自動stashしない。
+
+## 手順
+
+1. `gh auth status`で認証を確認する。
+2. `git status --porcelain`が空であることを確認する。空でなければ何も変更せず停止する。
+3. `git branch --show-current`で現在ブランチを取得する。空、`main`、`develop`なら停止する。
+4. 現在ブランチに紐づくPRを`gh pr view`で取得する。会話にPR番号またはURLがあれば、そのPRを取得して現在ブランチとの一致を検証する。
+5. PRについて次をすべて確認する。一つでも満たさなければ停止する。
+   - `state`が`MERGED`
+   - `mergedAt`が空でない
+   - `headRefName`が現在ブランチ名と一致する
+   - `baseRefName`が`main`または`develop`
+6. `git switch <baseRefName>`で基準ブランチへ切り替える。失敗時は停止する。
+7. `git pull --ff-only origin <baseRefName>`で最新化する。fast-forwardできなければ、自動mergeやrebaseをせず停止する。
+8. PRがマージ済みでhead branchも一致したという手順5の結果を再利用し、`git branch -D <headRefName>`でローカル作業ブランチを削除する。pull失敗時は削除しない。
+9. 現在ブランチ、最新コミット、削除したブランチを報告する。
+
+## 確認コマンド例
+
+```bash
+gh auth status
+git status --porcelain
+git branch --show-current
+gh pr view <branch-or-pr> --json number,url,state,mergedAt,baseRefName,headRefName
+git switch <baseRefName>
+git pull --ff-only origin <baseRefName>
+git branch -D <headRefName>
+git status --short --branch
+git log -1 --oneline
+```
+
+## 停止時の扱い
+
+- 停止理由と、ユーザーが解消すべき状態を簡潔に示す。
+- 基準ブランチへの切り替え後にpullが失敗した場合、元の作業ブランチは削除せず残す。
+- `git branch -D`は、GitHub上のマージ済み状態と現在ブランチとの一致を確認できた場合だけ使う。squash mergeやrebase mergeでは`git branch -d`がマージ済みと判定しないため、この条件下では強制削除を許可する。

--- a/github-pr-post-merge-cleanup/SKILL.md
+++ b/github-pr-post-merge-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-post-merge-cleanup
-description: GitHub PRをユーザーがマージした後、PRのbase branchへ戻り、最新化してローカルの作業ブランチを削除するときに使う。「マージ後の片付け」「基準ブランチに戻して」「次の開発に備えてブランチを整理して」などの依頼が対象。PRのマージ操作やremote branchの削除は行わない。
+description: マージ済みGitHub PRのbase branchへ戻り、最新化してローカル作業ブランチを削除する。「マージ後の片付け」「基準ブランチに戻して」「次の開発に備えてブランチを整理して」などの依頼が対象。
 ---
 
 # GitHub PR Post-Merge Cleanup
@@ -11,7 +11,7 @@ description: GitHub PRをユーザーがマージした後、PRのbase branchへ
 
 - PRのマージは行わない。ユーザーがGitHub上でマージした後にだけ実行する。
 - 現在のローカルブランチに紐づくPRを対象にする。会話にPR番号があれば同じPRか照合する。
-- PRのbase branchは`main`または`develop`だけを許可する。それ以外なら停止する。
+- PRのbase branchは`main`、`master`、または`develop`だけを許可する。それ以外なら停止する。
 - 削除対象は対象PRのローカルhead branchだけに限定する。
 - remote branch、他のローカルブランチ、worktree、stashは変更しない。
 - 未コミット変更または未追跡ファイルがあれば停止する。自動stashしない。
@@ -20,13 +20,13 @@ description: GitHub PRをユーザーがマージした後、PRのbase branchへ
 
 1. `gh auth status`で認証を確認する。
 2. `git status --porcelain`が空であることを確認する。空でなければ何も変更せず停止する。
-3. `git branch --show-current`で現在ブランチを取得する。空、`main`、`develop`なら停止する。
-4. 現在ブランチに紐づくPRを`gh pr view`で取得する。会話にPR番号またはURLがあれば、そのPRを取得して現在ブランチとの一致を検証する。
+3. `git branch --show-current`で現在ブランチを取得する。空、`main`、`master`、`develop`なら停止する。
+4. 現在ブランチに紐づくPRを`gh pr view`で取得する。PRが見つからなければ、何も変更せず停止する。会話にPR番号またはURLがあれば、そのPRを取得して現在ブランチとの一致を検証する。
 5. PRについて次をすべて確認する。一つでも満たさなければ停止する。
    - `state`が`MERGED`
    - `mergedAt`が空でない
    - `headRefName`が現在ブランチ名と一致する
-   - `baseRefName`が`main`または`develop`
+   - `baseRefName`が`main`、`master`、または`develop`
 6. `git switch <baseRefName>`で基準ブランチへ切り替える。失敗時は停止する。
 7. `git pull --ff-only origin <baseRefName>`で最新化する。fast-forwardできなければ、自動mergeやrebaseをせず停止する。
 8. PRがマージ済みでhead branchも一致したという手順5の結果を再利用し、`git branch -D <headRefName>`でローカル作業ブランチを削除する。pull失敗時は削除しない。

--- a/github-pr-post-merge-cleanup/agents/openai.yaml
+++ b/github-pr-post-merge-cleanup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Post-Merge Cleanup"
+  short_description: "マージ済みPRの作業ブランチを安全に整理して基準ブランチへ戻す"
+  default_prompt: "Use $github-pr-post-merge-cleanup to return to the merged PR base branch and safely remove its local work branch."


### PR DESCRIPTION
## Why

PRマージ後に次の開発へ安全に移れるよう、基準ブランチへの復帰とローカル作業ブランチの整理手順を共通化します。

## Summary

GitHub上でマージ済みであることを確認してから、PRのbase branchを最新化し、対象のローカルhead branchだけを削除するスキルを追加します。

## Changes

- `github-pr-post-merge-cleanup`スキルを追加
- 未コミット変更、PR状態、base/head branchの安全確認を定義
- READMEのAvailable Skillsへ追加

## Checklist

- [x] スキル単体バリデーション
- [x] リポジトリ全体のスキル検証
- [x] `git diff --check`
