### PR TITLE
feat(herdr): add role-based session names for delegated agents

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -63,7 +63,8 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 ```
 
 6. その他のCLIは `references/agent-cli.md` の観測可能な入力可能条件を使う。条件が未定義または確認失敗なら、noticeもEnterも送らずpaneとtask directoryを保持して失敗終了する。
-7. 分割判断に使ったlayout一時ファイルを削除する。
+7. セッション名が指定されている場合、Agent 検出後に入力可能確認を待たず `herdr agent rename <new-pane-id> '<session-name>'` で名前を設定する。失敗時は pane と task directory を保持して停止する。
+8. 分割判断に使ったlayout一時ファイルを削除する。
 
 `split_scoped_pane.py` は検証失敗時に Agent を起動しない。事後検証失敗時は、新規 pane が安全に帰属できる場合だけ `herdr pane close` する。帰属不能または close 失敗時は pane と task directory を保持して停止する。診断情報は `<task-dir>/split_scoped_pane.diagnostics.json` に保存する。
 

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -55,15 +55,15 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 
 3. 検証済みの新規 pane ID へ `herdr pane run <new-pane-id> '<agent-command>'` だけを実行する。
 4. 別コマンドの `herdr wait agent-status <new-pane-id> --status idle --timeout 30000` でsemantic stateによるAgent検出を待つ。この時点の `agent_status=idle` は入力可能を意味しない。
-5. Codex、Claude Code、OpenCodeは次を別コマンドで実行し、Agent別の入力欄を `wait output` と `pane read` の両方で確認する。
+5. セッション名が指定されている場合、`herdr agent rename <new-pane-id> '<session-name>'` で名前を設定する。失敗時は pane と task directory を保持して停止する。
+6. Codex、Claude Code、OpenCodeは次を別コマンドで実行し、Agent別の入力欄を `wait output` と `pane read` の両方で確認する。
 
 ```bash
 <skill-dir>/scripts/wait_for_input_ready.py \
   --target <new-pane-id> --agent <codex|claude|opencode> --task-dir <task-dir>
 ```
 
-6. その他のCLIは `references/agent-cli.md` の観測可能な入力可能条件を使う。条件が未定義または確認失敗なら、noticeもEnterも送らずpaneとtask directoryを保持して失敗終了する。
-7. セッション名が指定されている場合、Agent 検出後に入力可能確認を待たず `herdr agent rename <new-pane-id> '<session-name>'` で名前を設定する。失敗時は pane と task directory を保持して停止する。
+7. その他のCLIは `references/agent-cli.md` の観測可能な入力可能条件を使う。条件が未定義または確認失敗なら、noticeもEnterも送らずpaneとtask directoryを保持して失敗終了する。
 8. 分割判断に使ったlayout一時ファイルを削除する。
 
 `split_scoped_pane.py` は検証失敗時に Agent を起動しない。事後検証失敗時は、新規 pane が安全に帰属できる場合だけ `herdr pane close` する。帰属不能または close 失敗時は pane と task directory を保持して停止する。診断情報は `<task-dir>/split_scoped_pane.diagnostics.json` に保存する。

--- a/herdr-github-implement-pr/references/implementation-delegation.md
+++ b/herdr-github-implement-pr/references/implementation-delegation.md
@@ -39,6 +39,14 @@ Herdr 外、CLI 不足、認証・trust 待ちは実装委譲失敗とする。�
 
 指定された既存 Agent が存在しない、自分自身、または `idle` でない場合は失敗とする。別 Agent の起動、Codex への切り替え、自動再試行はしない。新規 Agent は `herdr-agent-delegate` の Grid 配置と起動確認に従い、その pane ID を親が管理する。
 
+新規起動する実装担当 Agent には `herdr agent rename` で役割と作業対象を示すセッション名を設定する。既存 Agent の再利用時は名前を変更しない。
+
+| 条件 | セッション名 |
+| --- | --- |
+| Issue 番号がある | `implement-issue-<number>` |
+| Issue 番号がなくブランチ名から抽出できる | `implement-<branch-keyword>` |
+| いずれも特定できない | `implement` |
+
 新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。その後は同スキルの更新済みreadiness契約に従い、pane run、semantic検出、Agent別input-ready確認、notice送信、Enter送信、working遷移確認を別工程で行う。input-readyを確認できなければ何も送信せず、paneとtask directoryを保持して停止する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用は分割検証と新規起動用readiness待機の対象外とする。
 
 ## 4. 実装を同期委譲する

--- a/herdr-github-implement-pr/references/review-loop.md
+++ b/herdr-github-implement-pr/references/review-loop.md
@@ -21,6 +21,8 @@ PR 作成成功後に読み、`herdr-agent-delegate` のタスク交換、待機
 
 指定された既存 Agent が存在しない、自分自身である、または `idle` でない場合は失敗とする。別 Agent の起動、Codex への切り替え、自動再試行はしない。新規 Agent は `herdr-agent-delegate` の Grid 配置と起動確認に従い、その pane ID を親が管理する。
 
+新規起動するレビュー担当 Agent には `herdr agent rename` で役割と対象 PR を示すセッション名 `review-pr-<number>` を設定する。既存 Agent の再利用時は名前を変更しない。
+
 新規 Agent 用の pane は、親の `workspace_id`・`tab_id` を固定スコープとして `herdr-agent-delegate/scripts/split_scoped_pane.py` で分割前後に検証する。その後は同スキルの更新済みreadiness契約に従い、pane run、semantic検出、Agent別input-ready確認、notice送信、Enter送信、working遷移確認を別工程で行う。input-readyを確認できなければ何も送信せず、paneとtask directoryを保持して停止する。識別子の欠落・型不正・不一致時は Agent を起動せず、安全に帰属できる未起動 pane だけを close する。帰属不能または close 失敗時は pane と task directory を保持して停止する。明示指定された既存 Agent の再利用は分割検証と新規起動用readiness待機の対象外とする。
 
 ## 3. 初回レビューを同期委譲する
@@ -53,6 +55,8 @@ PR 作成成功後に読み、`herdr-agent-delegate` のタスク交換、待機
 ## 5. 専用 Agent へ FB 対応を委譲する
 
 同じ回の `対応可能` な指摘を、毎回新規起動する 1 体の専用 FB 対応 Agent へまとめる。同一ブランチへの並列変更は禁止する。Agent 種別はレビュー Agent と同じ種別を使い、実装 cwd で起動する。
+
+新規起動する FB 対応 Agent には `herdr agent rename` で役割と対象 PR を示すセッション名 `fb-pr-<number>` を設定する。
 
 FB 対応タスクに次を含める。
 


### PR DESCRIPTION
## Issues

- Refs #158

## Why

Herdr で Agent を委譲する際、実装担当・レビュー担当・FB 対応担当などの役割がセッション名で識別できず、複数ペインが並んだときにどの Agent が何の役割か判別しづらかった。

## Summary

`herdr-agent-delegate` に任意のセッション名設定ステップ（`herdr agent rename`）を追加し、`herdr-github-implement-pr` の各委譲工程で役割と作業対象を示す命名規則を定義する。

## Changes

- `herdr-agent-delegate/SKILL.md`: 新規 Agent 起動フローに `herdr agent rename` ステップを追加（step 7）
- `implementation-delegation.md`: 実装担当 Agent のセッション名を `implement-issue-<N>` / `implement-<keyword>` / `implement` に規定
- `review-loop.md`: レビュー担当を `review-pr-<N>`、FB 対応担当を `fb-pr-<N>` に規定、既存 Agent 再利用時は名前変更しないことを明記
