### PR TITLE
feat(herdr-agent-delegate): move task exchange directory into workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+.herdr-agent-delegate/

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -18,13 +18,15 @@ description: Herdr上でCodex、Claude Code、OpenCode、その他のCLI Agent�
 
 依頼本文を読み取り可能な一時Markdownへ保存し、本文をコマンド引数へ直接埋め込まず次を実行する。追加コンテキストは読み取り可能な絶対パスで繰り返し指定する。
 
+`task_exchange.py create` を呼ぶ前に、親Agentは `HERDR_AGENT_DELEGATE_WORKSPACE` を委譲元ワークスペースの絶対パスで設定する。相対パスはcwdの変化により保存先が不一致になるため許可されず、検証でエラーとなる。
+
 ```bash
 <skill-dir>/scripts/task_exchange.py create \
   --task-file <request.md> \
   --context-file <absolute-context-path>
 ```
 
-入力用 `request.md` は、委譲元のワークスペース内の一時領域（例: `.herdr-agent-delegate/` 配下）へ作成し、本文が失われないようにする。`task.md` へのコピーを確認後、入力用に作った `request.md` は削除する。
+入力用 `request.md` は、委譲元のワークスペース内の専用領域（例: `.herdr-agent-delegate/requests/`）へ作成し、本文が失われないようにする。`task.md` へのコピーを確認後、入力用に作った `request.md` は削除する。
 
 JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する。これはCLI結果であり、Agent間Payloadではない。
 
@@ -62,7 +64,7 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
   --child <child-pane-id>
 ```
 
-3. 検証済みの新規 pane ID へ `herdr pane run <new-pane-id> '<agent-command>'` だけを実行する。
+3. 検証済みの新規 pane ID へ `herdr pane run <new-pane-id> '<agent-command>'` だけを実行する。子Agentは親と同一のcwd・環境変数で起動されるため、`HERDR_AGENT_DELEGATE_WORKSPACE` などは子の `complete` / `collect` 実行時もそのまま引き継がれる。
 4. 別コマンドの `herdr wait agent-status <new-pane-id> --status idle --timeout 30000` でsemantic stateによるAgent検出を待つ。この時点の `agent_status=idle` は入力可能を意味しない。
 5. セッション名が指定されている場合、`herdr agent rename <new-pane-id> '<session-name>'` で名前を設定する。失敗時は pane と task directory を保持して停止する。
 6. Codex、Claude Code、OpenCodeは次を別コマンドで実行し、Agent別の入力欄を `wait output` と `pane read` の両方で確認する。

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -20,6 +20,8 @@ description: Herdr上でCodex、Claude Code、OpenCode、その他のCLI Agent�
 
 `task_exchange.py create` を呼ぶ前に、親Agentは `HERDR_AGENT_DELEGATE_WORKSPACE` を委譲元ワークスペースの絶対パスで設定する。相対パスはcwdの変化により保存先が不一致になるため許可されず、検証でエラーとなる。
 
+`HERDR_AGENT_DELEGATE_ROOT` と `HERDR_AGENT_DELEGATE_WORKSPACE` の両方が未設定の場合、`task_exchange.py` は実行時のカレントディレクトリをワークスペースとしてフォールバックする。このとき `create` で使用したcwdと `complete`/`collect` でのcwdが異なると、タスクディレクトリが保存ルートの外にあると判定され失敗する。Herdr 経由の委譲では、子Agentは親と同一の環境変数・cwdで起動されるため、必ず `HERDR_AGENT_DELEGATE_WORKSPACE` を絶対パスで設定すること。これは運用上の推奨ではなく、正確な保存先を保証するため実質的に必須である。未設定時は `task_exchange.py` がstderrに警告を出力する。
+
 ```bash
 <skill-dir>/scripts/task_exchange.py create \
   --task-file <request.md> \

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -24,8 +24,9 @@ description: Herdr上でCodex、Claude Code、OpenCode、その他のCLI Agent�
   --context-file <absolute-context-path>
 ```
 
+入力用 `request.md` は、委譲元のワークスペース内の一時領域（例: `.herdr-agent-delegate/` 配下）へ作成し、本文が失われないようにする。`task.md` へのコピーを確認後、入力用に作った `request.md` は削除する。
+
 JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する。これはCLI結果であり、Agent間Payloadではない。
-`task.md` へのコピーを確認後、入力用に作った `request.md` は削除する。
 
 ## 3. 宛先を解決する
 

--- a/herdr-agent-delegate/references/task-protocol.md
+++ b/herdr-agent-delegate/references/task-protocol.md
@@ -3,7 +3,7 @@
 ## 保存形式
 
 ```text
-/tmp/herdr-agent-delegate/<uid>/<tag>/
+<workspace>/.herdr-agent-delegate/<uid>/<tag>/
 ├── task.md
 ├── marker
 ├── result.md
@@ -11,8 +11,16 @@
 └── reply.md
 ```
 
+`<workspace>` は以下の優先順位で決まる。
+
+1. `HERDR_AGENT_DELEGATE_ROOT` が設定済みならその絶対パス
+2. `HERDR_AGENT_DELEGATE_WORKSPACE` が設定済みなら `<workspace>/.herdr-agent-delegate/`
+3. どちらも未設定ならカレントディレクトリをワークスペースとして `<cwd>/.herdr-agent-delegate/`
+
+`HERDR_AGENT_DELEGATE_ROOT` による明示的な保存先上書きは維持される。保存ルート直下にはユーザーごとの `<uid>` ディレクトリを作り、さらにその下に一意な `<tag>` ディレクトリを作成する。
+
 `task_exchange.py create` がユーザーごとの保存ルート、tag、`task.md`、markerを作る。Agent間では `task.md` の絶対パスだけを通知する。CLIが返すJSONは呼び出し元が各パスを取得するための結果であり、保存・配送するPayloadではない。
-入力用に別途作った依頼Markdownは `task.md` へのコピー確認後に呼び出し元が削除する。
+入力用に別途作った依頼Markdownは、委譲元ワークスペース内の専用領域へ作成し、`task.md` へのコピーを確認後に呼び出し元が削除する。
 
 ## 子Agentの完了
 

--- a/herdr-agent-delegate/references/task-protocol.md
+++ b/herdr-agent-delegate/references/task-protocol.md
@@ -15,9 +15,11 @@
 
 1. `HERDR_AGENT_DELEGATE_ROOT` が設定済みならその絶対パス
 2. `HERDR_AGENT_DELEGATE_WORKSPACE` が設定済みなら `<workspace>/.herdr-agent-delegate/`
-3. どちらも未設定ならカレントディレクトリをワークスペースとして `<cwd>/.herdr-agent-delegate/`
+3. どちらも未設定ならカレントディレクトリをワークスペースとして `<cwd>/.herdr-agent-delegate/`（運用上非推奨）
 
 `HERDR_AGENT_DELEGATE_ROOT` と `HERDR_AGENT_DELEGATE_WORKSPACE` は両方とも絶対パスで指定する。相対パスはcwdの変化により保存先が不一致になるため許可されず、`task_exchange.py` はエラーで終了する。
+
+どちらの環境変数も未設定の場合、`task_exchange.py` は実行時のカレントディレクトリをワークスペースとしてフォールバックする。このフォールバックは呼び出し時のcwdをワークスペースと見なすため、`create` から `complete`/`collect` までの間にcwdが変わると、タスクディレクトリが保存ルートの外にあると判定され失敗する。Herdr 経由の委譲では、子Agentが親と同一の環境変数・cwdで起動されるにもかかわらず、子側でcwdが変わる可能性があるため、`HERDR_AGENT_DELEGATE_WORKSPACE` を絶対パスで設定することが推奨される。未設定時は `task_exchange.py` がstderrに警告を出力する。
 
 `HERDR_AGENT_DELEGATE_ROOT` による明示的な保存先上書きは維持される。`HERDR_AGENT_DELEGATE_WORKSPACE` を使う場合、保存先をワークスペース基準にする責務は親Agentが負う。保存ルート直下にはユーザーごとの `<uid>` ディレクトリを作り、さらにその下に一意な `<tag>` ディレクトリを作成する。
 

--- a/herdr-agent-delegate/references/task-protocol.md
+++ b/herdr-agent-delegate/references/task-protocol.md
@@ -17,10 +17,12 @@
 2. `HERDR_AGENT_DELEGATE_WORKSPACE` が設定済みなら `<workspace>/.herdr-agent-delegate/`
 3. どちらも未設定ならカレントディレクトリをワークスペースとして `<cwd>/.herdr-agent-delegate/`
 
-`HERDR_AGENT_DELEGATE_ROOT` による明示的な保存先上書きは維持される。保存ルート直下にはユーザーごとの `<uid>` ディレクトリを作り、さらにその下に一意な `<tag>` ディレクトリを作成する。
+`HERDR_AGENT_DELEGATE_ROOT` と `HERDR_AGENT_DELEGATE_WORKSPACE` は両方とも絶対パスで指定する。相対パスはcwdの変化により保存先が不一致になるため許可されず、`task_exchange.py` はエラーで終了する。
+
+`HERDR_AGENT_DELEGATE_ROOT` による明示的な保存先上書きは維持される。`HERDR_AGENT_DELEGATE_WORKSPACE` を使う場合、保存先をワークスペース基準にする責務は親Agentが負う。保存ルート直下にはユーザーごとの `<uid>` ディレクトリを作り、さらにその下に一意な `<tag>` ディレクトリを作成する。
 
 `task_exchange.py create` がユーザーごとの保存ルート、tag、`task.md`、markerを作る。Agent間では `task.md` の絶対パスだけを通知する。CLIが返すJSONは呼び出し元が各パスを取得するための結果であり、保存・配送するPayloadではない。
-入力用に別途作った依頼Markdownは、委譲元ワークスペース内の専用領域へ作成し、`task.md` へのコピーを確認後に呼び出し元が削除する。
+入力用に別途作った依頼Markdownは、委譲元ワークスペース内の専用領域（例: `.herdr-agent-delegate/requests/`）へ作成し、`task.md` へのコピーを確認後に呼び出し元が削除する。
 
 ## 子Agentの完了
 

--- a/herdr-agent-delegate/scripts/task_exchange.py
+++ b/herdr-agent-delegate/scripts/task_exchange.py
@@ -25,6 +25,10 @@ def _require_absolute(path: str, name: str) -> None:
         die(f"{name} must be an absolute path: {path}")
 
 
+def warn(message: str) -> None:
+    print(f"WARNING: {message}", file=sys.stderr)
+
+
 def storage_root() -> Path:
     configured = os.environ.get("HERDR_AGENT_DELEGATE_ROOT")
     if configured:
@@ -36,7 +40,15 @@ def storage_root() -> Path:
             _require_absolute(workspace, "HERDR_AGENT_DELEGATE_WORKSPACE")
             base = Path(workspace) / ".herdr-agent-delegate"
         else:
-            base = Path.cwd() / ".herdr-agent-delegate"
+            cwd = Path.cwd()
+            warn(
+                "HERDR_AGENT_DELEGATE_WORKSPACE is not set; falling back to the current "
+                f"directory as the workspace ({cwd}). complete/collect may fail if the "
+                "working directory changes between create and those commands. When "
+                "delegating through Herdr, set HERDR_AGENT_DELEGATE_WORKSPACE to the "
+                "absolute path of the workspace."
+            )
+            base = cwd / ".herdr-agent-delegate"
     return base / str(os.getuid())
 
 

--- a/herdr-agent-delegate/scripts/task_exchange.py
+++ b/herdr-agent-delegate/scripts/task_exchange.py
@@ -22,7 +22,15 @@ def die(message: str) -> NoReturn:
 
 def storage_root() -> Path:
     configured = os.environ.get("HERDR_AGENT_DELEGATE_ROOT")
-    return Path(configured) if configured else Path("/tmp/herdr-agent-delegate") / str(os.getuid())
+    if configured:
+        base = Path(configured)
+    else:
+        workspace = os.environ.get("HERDR_AGENT_DELEGATE_WORKSPACE")
+        if workspace:
+            base = Path(workspace) / ".herdr-agent-delegate"
+        else:
+            base = Path.cwd() / ".herdr-agent-delegate"
+    return base / str(os.getuid())
 
 
 def ensure_directory(path: Path, *, create: bool = False) -> Path:

--- a/herdr-agent-delegate/scripts/task_exchange.py
+++ b/herdr-agent-delegate/scripts/task_exchange.py
@@ -20,13 +20,20 @@ def die(message: str) -> NoReturn:
     raise SystemExit(1)
 
 
+def _require_absolute(path: str, name: str) -> None:
+    if not os.path.isabs(path):
+        die(f"{name} must be an absolute path: {path}")
+
+
 def storage_root() -> Path:
     configured = os.environ.get("HERDR_AGENT_DELEGATE_ROOT")
     if configured:
+        _require_absolute(configured, "HERDR_AGENT_DELEGATE_ROOT")
         base = Path(configured)
     else:
         workspace = os.environ.get("HERDR_AGENT_DELEGATE_WORKSPACE")
         if workspace:
+            _require_absolute(workspace, "HERDR_AGENT_DELEGATE_WORKSPACE")
             base = Path(workspace) / ".herdr-agent-delegate"
         else:
             base = Path.cwd() / ".herdr-agent-delegate"

--- a/herdr-agent-delegate/tests/test_task_exchange.py
+++ b/herdr-agent-delegate/tests/test_task_exchange.py
@@ -42,6 +42,34 @@ class TaskExchangeTest(unittest.TestCase):
         task_dir = Path(exchange["task_dir"])
         self.assertTrue(str(task_dir).startswith(str(self.root)))
 
+    def test_create_rejects_relative_root(self):
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("HERDR_AGENT_DELEGATE_ROOT", "HERDR_AGENT_DELEGATE_WORKSPACE")
+        }
+        env["HERDR_AGENT_DELEGATE_ROOT"] = "relative/path"
+        failed = self.run_script(
+            "create", "--task-file", str(self.input), env=env, check=False
+        )
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertIn("HERDR_AGENT_DELEGATE_ROOT must be an absolute path", failed.stderr)
+
+    def test_create_rejects_relative_workspace(self):
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("HERDR_AGENT_DELEGATE_ROOT", "HERDR_AGENT_DELEGATE_WORKSPACE")
+        }
+        env["HERDR_AGENT_DELEGATE_WORKSPACE"] = "relative/workspace"
+        failed = self.run_script(
+            "create", "--task-file", str(self.input), env=env, check=False
+        )
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertIn(
+            "HERDR_AGENT_DELEGATE_WORKSPACE must be an absolute path", failed.stderr
+        )
+
     def test_create_uses_cwd_when_no_env_set(self):
         cwd = Path(self.temporary.name) / "cwd"
         cwd.mkdir()

--- a/herdr-agent-delegate/tests/test_task_exchange.py
+++ b/herdr-agent-delegate/tests/test_task_exchange.py
@@ -21,18 +21,51 @@ class TaskExchangeTest(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
-    def run_script(self, *arguments, check=True):
+    def run_script(self, *arguments, env=None, cwd=None, check=True):
         return subprocess.run(
             [sys.executable, str(SCRIPT), *arguments],
-            env=self.env,
+            env=env if env is not None else self.env,
+            cwd=cwd,
             check=check,
             capture_output=True,
             text=True,
         )
 
-    def create(self):
-        result = self.run_script("create", "--task-file", str(self.input))
+    def create(self, env=None, cwd=None):
+        result = self.run_script(
+            "create", "--task-file", str(self.input), env=env, cwd=cwd
+        )
         return json.loads(result.stdout)
+
+    def test_create_uses_configured_root_when_set(self):
+        exchange = self.create()
+        task_dir = Path(exchange["task_dir"])
+        self.assertTrue(str(task_dir).startswith(str(self.root)))
+
+    def test_create_uses_cwd_when_no_env_set(self):
+        cwd = Path(self.temporary.name) / "cwd"
+        cwd.mkdir()
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("HERDR_AGENT_DELEGATE_ROOT", "HERDR_AGENT_DELEGATE_WORKSPACE")
+        }
+        exchange = self.create(env=env, cwd=str(cwd))
+        expected = cwd / ".herdr-agent-delegate" / str(os.getuid())
+        self.assertTrue(str(Path(exchange["task_dir"])).startswith(str(expected)))
+
+    def test_create_uses_workspace_when_set(self):
+        workspace = Path(self.temporary.name) / "workspace"
+        workspace.mkdir()
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("HERDR_AGENT_DELEGATE_ROOT", "HERDR_AGENT_DELEGATE_WORKSPACE")
+        }
+        env["HERDR_AGENT_DELEGATE_WORKSPACE"] = str(workspace)
+        exchange = self.create(env=env)
+        expected = workspace / ".herdr-agent-delegate" / str(os.getuid())
+        self.assertTrue(str(Path(exchange["task_dir"])).startswith(str(expected)))
 
     def test_create_complete_collect_and_cleanup(self):
         exchange = self.create()
@@ -55,9 +88,45 @@ class TaskExchangeTest(unittest.TestCase):
         self.assertEqual(collected.stdout, "# Result\n\n完了\n")
         self.assertFalse(task_dir.exists())
 
+    def test_create_complete_collect_under_cwd(self):
+        cwd = Path(self.temporary.name) / "cwd"
+        cwd.mkdir()
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("HERDR_AGENT_DELEGATE_ROOT", "HERDR_AGENT_DELEGATE_WORKSPACE")
+        }
+        exchange = self.create(env=env, cwd=str(cwd))
+        task_dir = Path(exchange["task_dir"])
+        self.assertTrue(task_dir.exists())
+        self.assertTrue(
+            str(task_dir).startswith(str(cwd / ".herdr-agent-delegate" / str(os.getuid())))
+        )
+
+        result_file = Path(self.temporary.name) / "result.md"
+        result_file.write_text("# Result\n\n完了\n", encoding="utf-8")
+        completed = self.run_script(
+            "complete",
+            "--task-dir",
+            str(task_dir),
+            "--reply-file",
+            str(result_file),
+            env=env,
+            cwd=str(cwd),
+        )
+        self.assertEqual(completed.stdout.strip(), exchange["marker"])
+
+        collected = self.run_script(
+            "collect", "--task-dir", str(task_dir), env=env, cwd=str(cwd)
+        )
+        self.assertEqual(collected.stdout, "# Result\n\n完了\n")
+        self.assertFalse(task_dir.exists())
+
     def test_missing_reply_is_retained(self):
         exchange = self.create()
-        failed = self.run_script("collect", "--task-dir", exchange["task_dir"], check=False)
+        failed = self.run_script(
+            "collect", "--task-dir", exchange["task_dir"], check=False
+        )
         self.assertNotEqual(failed.returncode, 0)
         self.assertTrue(Path(exchange["task_dir"]).exists())
 
@@ -68,6 +137,23 @@ class TaskExchangeTest(unittest.TestCase):
         failed = self.run_script("collect", "--task-dir", str(task_dir), check=False)
         self.assertNotEqual(failed.returncode, 0)
         self.assertTrue(task_dir.exists())
+
+    def test_empty_reply_is_rejected_and_retained(self):
+        exchange = self.create()
+        task_dir = Path(exchange["task_dir"])
+        empty_result = Path(self.temporary.name) / "empty.md"
+        empty_result.write_text("", encoding="utf-8")
+        failed = self.run_script(
+            "complete",
+            "--task-dir",
+            str(task_dir),
+            "--reply-file",
+            str(empty_result),
+            check=False,
+        )
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertTrue(task_dir.exists())
+        self.assertFalse((task_dir / "reply.md").exists())
 
     def test_only_one_concurrent_complete_succeeds(self):
         exchange = self.create()
@@ -99,7 +185,10 @@ class TaskExchangeTest(unittest.TestCase):
         results = [process.communicate() for process in processes]
 
         self.assertEqual(sorted(process.returncode for process in processes), [0, 1])
-        self.assertIn((task_dir / "reply.md").read_text(encoding="utf-8"), {"result 0\n", "result 1\n"})
+        self.assertIn(
+            (task_dir / "reply.md").read_text(encoding="utf-8"),
+            {"result 0\n", "result 1\n"},
+        )
         self.assertEqual(sum(exchange["marker"] in stdout for stdout, _ in results), 1)
 
 


### PR DESCRIPTION
## Issues

- Close #162

## Why

`herdr-agent-delegate` は委譲タスクの交換ファイルを既定で `/tmp/herdr-agent-delegate/<uid>/` に作成していた。ワークスペース外へのファイル作成は実行環境によって権限確認を発生させ、委譲のたびに操作が中断され得る。

## Summary

委譲用 Markdown とタスク交換ディレクトリの既定保存先を、委譲元ワークスペース配下の `.herdr-agent-delegate/<uid>/` に移す。明示的な `HERDR_AGENT_DELEGATE_ROOT` 上書きは維持する。

## Changes

- `herdr-agent-delegate/scripts/task_exchange.py`
  - 既定保存先をワークスペース基準に変更
  - 優先順位: `HERDR_AGENT_DELEGATE_ROOT` > `HERDR_AGENT_DELEGATE_WORKSPACE` > カレントディレクトリ
  - 所有者・通常ファイル・symlink・パーミッション・非空チェックは維持
- `herdr-agent-delegate/SKILL.md`
  - 入力用 `request.md` をワークスペース内の専用領域へ作成することを追記
- `herdr-agent-delegate/references/task-protocol.md`
  - `/tmp` 前提を削除し、ワークスペース基準の保存先と環境変数の優先順位を記載
- `herdr-agent-delegate/tests/test_task_exchange.py`
  - 既定保存先がワークスペース / cwd 基準になるテストを追加
  - `HERDR_AGENT_DELEGATE_WORKSPACE` 設定時のテストを追加
  - 空ファイル `reply` の拒否テストを追加
- `.gitignore`
  - `.herdr-agent-delegate/` を追加

## Verification

- `python -m unittest tests.test_task_exchange -v` - passed
- `bash scripts/validate-skills.sh` - passed
- `git diff --check` - passed
