### PR TITLE
feat(herdr-agent-delegate): 起動数に応じた専用タブ選択と容量不足フォールバック

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -52,7 +52,36 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 
 バッチ委譲時は起動前に `layout_planner.py` で子数とウィンドウサイズから目標列数・slotを計画する。最小paneサイズを下回る場合は追加分割を停止する。計画を `<task-dir>/delegation-plan.md` に表形式（slot, Agent種別, タスク概要, task dir）で出力し、その後自動実行する。
 
+#### 専用タブ選択条件
+
+以下のいずれかの条件に該当する場合、既存タブ内の分割ではなく専用の新規タブを作成して委譲する（`HERDR_DELEGATE_AUTO_DEDICATED_TAB` で制御、既定 `1` = 有効、`0` = 常に同一タブ試行）：
+
+- **起動数超過**：起動予定Agent数が `HERDR_DELEGATE_MAX_PANES_PER_TAB`（既定 `6`）以上
+- **既存無関係ペイン混在**：親と今回起動する子以外のペインが同一タブ内に存在する
+- **最小サイズ制約不足**：タブの幅・高さでは最小paneサイズ制約を満たせず、起動予定数を収容できない
+
+#### ペインライフサイクル方針
+
+委譲先Agentのペインは以下の方針で管理する。親や無関係な既存ペインを無断で移動・closeしない。
+
+- **完了時**：既定でペインを保持する。明示的なclose方針がある場合のみcloseする。
+- **失敗時**：診断・再開のためペインとtask directoryを保持する。自動closeしない。
+- **blocked時**：保持または明示的な退避対象とする。自動closeしない。
+- **親・無関係ペインの保護**：親ペインおよび今回の委譲と無関係な既存ペインの移動・closeを一切行わない。
+
 ### 4.2 paneを分割する
+
+分割判断に使ったlayout一時ファイルを削除する。
+
+#### 容量不足時のフォールバック
+
+同一タブ内で分割不能な場合（capacity超過）、`split_scoped_pane.py` は自動的に新規タブを作成して委譲専用にする。フォールバック時は中途半端な配置を残さず、新規タブ内で完全な分割手順（pre-split検証→split→post-split検証）を実行する。
+
+- 新規タブの作成：`herdr tab new --cwd <cwd>`
+- 新規タブ内の分割：`herdr pane split <new-tab-pane-id> --direction right --ratio 0.5 --cwd <cwd> --no-focus`
+- 新規タブは完全に委譲専用のため、無関係ペインは存在しない
+
+
 
 1. `herdr pane layout --pane "$HERDR_PANE_ID"` のJSONを一時ファイルへ保存する。
 2. 次を実行し、親と同一 `workspace_id`・`tab_id` へ分割されたことを事前・事後に検証済みの新規 pane ID を取得する。子を増やすたび `--child` を追加する。

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -79,7 +79,6 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 - 新規タブ内の分割：`herdr pane split <new-tab-pane-id> --direction right --ratio 0.5 --cwd <cwd> --no-focus`
 - 新規タブは完全に委譲専用のため、無関係ペインは存在しない
 
-
 1. `herdr pane layout --pane "$HERDR_PANE_ID"` のJSONを一時ファイルへ保存する。
 2. 次を実行し、親と同一 `workspace_id`・`tab_id` へ分割されたことを事前・事後に検証済みの新規 pane ID を取得する。子を増やすたび `--child` を追加する。
 

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -71,8 +71,6 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 
 ### 4.2 paneを分割する
 
-分割判断に使ったlayout一時ファイルを削除する。
-
 #### 容量不足時のフォールバック
 
 同一タブ内で分割不能な場合（capacity超過）、`split_scoped_pane.py` は自動的に新規タブを作成して委譲専用にする。フォールバック時は中途半端な配置を残さず、新規タブ内で完全な分割手順（pre-split検証→split→post-split検証）を実行する。
@@ -80,7 +78,6 @@ JSON出力の `task_dir`、`task_path`、`reply_path`、`marker` を保持する
 - 新規タブの作成：`herdr tab new --cwd <cwd>`
 - 新規タブ内の分割：`herdr pane split <new-tab-pane-id> --direction right --ratio 0.5 --cwd <cwd> --no-focus`
 - 新規タブは完全に委譲専用のため、無関係ペインは存在しない
-
 
 
 1. `herdr pane layout --pane "$HERDR_PANE_ID"` のJSONを一時ファイルへ保存する。

--- a/herdr-agent-delegate/scripts/layout_planner.py
+++ b/herdr-agent-delegate/scripts/layout_planner.py
@@ -13,6 +13,7 @@ DEFAULT_MIN_HEIGHT = int(os.environ.get("HERDR_DELEGATE_MIN_PANE_HEIGHT", "24"))
 DEFAULT_MAX_COLUMNS_ENV = os.environ.get("HERDR_DELEGATE_GRID_COLUMNS", "0")
 DEFAULT_MAX_COLUMNS = int(DEFAULT_MAX_COLUMNS_ENV) if DEFAULT_MAX_COLUMNS_ENV else 0
 DEFAULT_MAX_PANES_PER_TAB = int(os.environ.get("HERDR_DELEGATE_MAX_PANES_PER_TAB", "6"))
+AUTO_DEDICATED_TAB = os.environ.get("HERDR_DELEGATE_AUTO_DEDICATED_TAB", "1") != "0"
 
 
 def compute_columns(
@@ -122,3 +123,70 @@ def tab_size_from_layout(layout: dict[str, Any]) -> tuple[int, int]:
     max_width = max(int(p.get("rect", {}).get("width", 0)) for p in panes)
     max_height = max(int(p.get("rect", {}).get("height", 0)) for p in panes)
     return max_width, max_height
+
+
+def detect_existing_panes(
+    layout: dict[str, Any],
+    parent_id: str | None = None,
+    children: list[str] | None = None,
+) -> dict[str, Any]:
+    """Detect unrelated panes in a herdr pane layout.
+
+    Returns ``{"has_unrelated": bool, "unrelated_count": int}``.
+    Panes whose IDs match *parent_id* or any element of *children* are
+    considered related; all others are unrelated.
+    """
+    panes = layout.get("result", {}).get("layout", {}).get("panes", [])
+    related: set[str] = set()
+    if parent_id:
+        related.add(parent_id)
+    if children:
+        related.update(children)
+    unrelated_count = 0
+    for pane in panes:
+        pane_id = pane.get("pane_id", "")
+        if pane_id and pane_id not in related:
+            unrelated_count += 1
+    return {"has_unrelated": unrelated_count > 0, "unrelated_count": unrelated_count}
+
+
+def should_use_dedicated_tab(
+    child_count: int,
+    tab_width: int,
+    tab_height: int,
+    existing_pane_info: dict[str, Any],
+    min_width: int = DEFAULT_MIN_WIDTH,
+    min_height: int = DEFAULT_MIN_HEIGHT,
+    max_panes_per_tab: int = DEFAULT_MAX_PANES_PER_TAB,
+) -> bool:
+    """Decide whether a dedicated tab should be used for the delegation batch."""
+    if not AUTO_DEDICATED_TAB:
+        return False
+    if child_count >= max_panes_per_tab:
+        return True
+    if existing_pane_info.get("has_unrelated"):
+        return True
+    capacity = fit_capacity(
+        tab_width, tab_height, cell_aspect=0.5, max_columns=0,
+        min_width=min_width, min_height=min_height,
+    )
+    if capacity < child_count:
+        return True
+    return False
+
+
+def plan_dedicated_tab(
+    child_count: int,
+    tab_width: int,
+    tab_height: int,
+    cell_aspect: float = 0.5,
+    max_columns: int | None = None,
+    min_width: int | None = None,
+    min_height: int | None = None,
+) -> dict[str, Any]:
+    """Plan a grid in a dedicated tab (all space reserved for delegates)."""
+    return plan_grid(
+        child_count, tab_width, tab_height,
+        cell_aspect=cell_aspect, max_columns=max_columns,
+        min_width=min_width, min_height=min_height,
+    )

--- a/herdr-agent-delegate/scripts/split_scoped_pane.py
+++ b/herdr-agent-delegate/scripts/split_scoped_pane.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -179,6 +180,37 @@ def fail_with_diagnostics(
     raise SystemExit(exit_code)
 
 
+def fallback_to_new_tab(
+    cwd: str,
+    expected_scope: dict[str, str],
+    args: argparse.Namespace,
+    diagnostics: dict[str, Any],
+    task_dir: Path,
+) -> dict[str, str]:
+    """Create a new dedicated tab and split a child pane inside it."""
+    diagnostics["fallback_attempted"] = True
+    result = run_herdr(["tab", "new", "--cwd", cwd], timeout=10)
+    if result.returncode != 0:
+        raise RuntimeError(f"tab new failed: {result.stderr.strip()}")
+    new_tab_pane = parse_pane(json.loads(result.stdout), "new tab pane")
+    diagnostics["fallback_tab_pane"] = new_tab_pane
+
+    tab_pane_verified = get_pane(new_tab_pane["pane_id"], "fallback_tab_pre_split")
+    diagnostics["fallback_tab_pre_split"] = tab_pane_verified
+
+    new_pane = split_pane(new_tab_pane["pane_id"], "right", cwd)
+    diagnostics["fallback_split_response"] = new_pane
+
+    new_pane_after = get_pane(new_pane["pane_id"], "fallback_new_pane_after")
+    diagnostics["fallback_new_pane_after"] = new_pane_after
+
+    return {
+        "pane_id": new_pane_after["pane_id"],
+        "workspace_id": new_pane_after["workspace_id"],
+        "tab_id": new_pane_after["tab_id"],
+    }
+
+
 def run(args: argparse.Namespace) -> dict[str, str]:
     task_dir = Path(args.task_dir).resolve()
     if not task_dir.is_dir():
@@ -215,6 +247,7 @@ def run(args: argparse.Namespace) -> dict[str, str]:
         fail_with_diagnostics(str(error), diagnostics, task_dir)
 
     children = list(args.child)
+    capacity_error: Exception | None = None
     try:
         choice = choose_layout.choose(
             layout,
@@ -228,8 +261,29 @@ def run(args: argparse.Namespace) -> dict[str, str]:
         )
         diagnostics["choice"] = choice
         target_id = choice["target_pane_id"]
-    except (ValueError, KeyError, TypeError) as error:
+    except ValueError as error:
+        if "capacity" in str(error):
+            capacity_error = error
+        else:
+            fail_with_diagnostics(str(error), diagnostics, task_dir)
+        target_id = ""  # not used when falling back
+    except (KeyError, TypeError) as error:
         fail_with_diagnostics(str(error), diagnostics, task_dir)
+
+    if capacity_error is not None:
+        auto_dedicated = os.environ.get("HERDR_DELEGATE_AUTO_DEDICATED_TAB", "1")
+        if auto_dedicated == "0":
+            fail_with_diagnostics(str(capacity_error), diagnostics, task_dir)
+        try:
+            return fallback_to_new_tab(
+                args.cwd, expected_scope, args, diagnostics, task_dir
+            )
+        except (RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as fb_error:
+            fail_with_diagnostics(
+                f"capacity exceeded ({capacity_error}); fallback failed: {fb_error}",
+                diagnostics,
+                task_dir,
+            )
 
     try:
         target_before = get_pane(target_id, "split_target_before")

--- a/herdr-agent-delegate/scripts/split_scoped_pane.py
+++ b/herdr-agent-delegate/scripts/split_scoped_pane.py
@@ -197,6 +197,10 @@ def fallback_to_new_tab(
 
     tab_pane_verified = get_pane(new_tab_pane["pane_id"], "fallback_tab_pre_split")
     diagnostics["fallback_tab_pre_split"] = tab_pane_verified
+    if tab_pane_verified.get("tab_id") == expected_scope["tab_id"]:
+        raise RuntimeError(
+            f"fallback new tab has same tab_id as parent ({expected_scope['tab_id']}); scope isolation failed"
+        )
 
     new_pane = split_pane(new_tab_pane["pane_id"], "right", cwd)
     diagnostics["fallback_split_response"] = new_pane

--- a/herdr-agent-delegate/tests/test_layout_planner.py
+++ b/herdr-agent-delegate/tests/test_layout_planner.py
@@ -1,6 +1,7 @@
 import importlib.util
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPTS_DIR = Path(__file__).parents[1] / "scripts"
@@ -124,5 +125,90 @@ class ChooseLayoutTest(unittest.TestCase):
         self.assertEqual(result["plan"]["rows"], 2)
 
 
-if __name__ == "__main__":
-    unittest.main()
+class DetectExistingPanesTest(unittest.TestCase):
+    def test_detect_existing_panes_unrelated(self):
+        value = layout(
+            ("w1:p1", 60, 40),
+            ("w1:p2", 60, 40),
+            ("w1:p9", 120, 40),
+        )
+        info = layout_planner.detect_existing_panes(value, parent_id="w1:p1", children=["w1:p2"])
+        self.assertTrue(info["has_unrelated"])
+        self.assertEqual(info["unrelated_count"], 1)
+
+    def test_detect_existing_panes_no_unrelated(self):
+        value = layout(
+            ("w1:p1", 60, 40),
+            ("w1:p2", 60, 40),
+        )
+        info = layout_planner.detect_existing_panes(value, parent_id="w1:p1", children=["w1:p2"])
+        self.assertFalse(info["has_unrelated"])
+        self.assertEqual(info["unrelated_count"], 0)
+
+    def test_detect_existing_panes_empty(self):
+        value = layout()
+        info = layout_planner.detect_existing_panes(value, parent_id="w1:p1")
+        self.assertFalse(info["has_unrelated"])
+        self.assertEqual(info["unrelated_count"], 0)
+
+
+class ShouldUseDedicatedTabTest(unittest.TestCase):
+    def test_should_use_dedicated_tab_with_unrelated(self):
+        info = {"has_unrelated": True, "unrelated_count": 1}
+        result = layout_planner.should_use_dedicated_tab(2, 120, 40, info)
+        self.assertTrue(result)
+
+    def test_should_use_dedicated_tab_capacity_shortage(self):
+        info = {"has_unrelated": False, "unrelated_count": 0}
+        result = layout_planner.should_use_dedicated_tab(4, 40, 20, info, min_width=30, min_height=15)
+        self.assertTrue(result)
+
+    def test_should_use_dedicated_tab_high_count(self):
+        info = {"has_unrelated": False, "unrelated_count": 0}
+        result = layout_planner.should_use_dedicated_tab(
+            6, 1000, 1000, info, max_panes_per_tab=6
+        )
+        self.assertTrue(result)
+
+    def test_should_not_use_dedicated_tab_normal(self):
+        info = {"has_unrelated": False, "unrelated_count": 0}
+        result = layout_planner.should_use_dedicated_tab(3, 240, 80, info)
+        self.assertFalse(result)
+
+    def test_should_not_use_dedicated_tab_when_auto_disabled(self):
+        info = {"has_unrelated": True, "unrelated_count": 5}
+        with mock.patch.object(layout_planner, "AUTO_DEDICATED_TAB", False):
+            result = layout_planner.should_use_dedicated_tab(2, 120, 40, info)
+            self.assertFalse(result)
+
+
+class PlanDedicatedTabTest(unittest.TestCase):
+    def test_plan_dedicated_tab(self):
+        plan = layout_planner.plan_dedicated_tab(4, 240, 80, cell_aspect=0.5, max_columns=2, min_width=1)
+        self.assertEqual(plan["columns"], 2)
+        self.assertEqual(plan["rows"], 2)
+        self.assertEqual(len(plan["slots"]), 4)
+
+    def test_plan_dedicated_tab_single(self):
+        plan = layout_planner.plan_dedicated_tab(1, 120, 40)
+        self.assertEqual(plan["columns"], 1)
+        self.assertEqual(plan["rows"], 1)
+
+
+class LayoutForAgentCountTest(unittest.TestCase):
+    def test_layout_for_1_agent(self):
+        plan = layout_planner.plan_grid(1, 120, 40, cell_aspect=0.5, max_columns=0, min_width=1, min_height=1)
+        self.assertEqual(plan["columns"], 1)
+        self.assertEqual(plan["rows"], 1)
+        self.assertEqual(plan["slots"], [{"row": 0, "col": 0}])
+
+    def test_layout_for_2_agents(self):
+        plan = layout_planner.plan_grid(2, 240, 80, cell_aspect=0.5, max_columns=2, min_width=1, min_height=1)
+        self.assertGreaterEqual(plan["capacity"], 2)
+        self.assertIn(plan["columns"], [1, 2])
+
+    def test_layout_for_3_plus_agents(self):
+        plan = layout_planner.plan_grid(4, 240, 80, cell_aspect=0.5, max_columns=2, min_width=1, min_height=1)
+        self.assertEqual(plan["columns"], 2)
+        self.assertEqual(plan["rows"], 2)
+        self.assertEqual(len(plan["slots"]), 4)

--- a/herdr-agent-delegate/tests/test_split_scoped_pane.py
+++ b/herdr-agent-delegate/tests/test_split_scoped_pane.py
@@ -441,12 +441,13 @@ class SplitScopedPaneTest(unittest.TestCase):
 
                 self.assertIn(f"{field} is not a non-empty string", self.diagnostics()["failure_reason"])
 
-    def test_capacity_exceeded_fails_before_split(self):
+    def test_capacity_exceeded_fails_before_split_when_fallback_disabled(self):
         self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 40, "height": 20}}]))
         mock = HerdrMock()
         mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
 
-        with patch.object(split_scoped_pane, "run_herdr", mock):
+        with patch.object(split_scoped_pane, "run_herdr", mock), \
+             patch.dict("os.environ", {"HERDR_DELEGATE_AUTO_DEDICATED_TAB": "0"}, clear=False):
             with self.assertRaises(SystemExit):
                 split_scoped_pane.run(self.args(min_width=30, min_height=15, total_children=2))
 
@@ -526,6 +527,79 @@ class SplitScopedPaneTest(unittest.TestCase):
         self.assertFalse(diagnostics["close_succeeded"])
         self.assertEqual(diagnostics["close_exit_code"], None)
         self.assertEqual(diagnostics["close_timeout_seconds"], 10)
+
+    def test_capacity_exceeded_falls_back_to_new_tab(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 40, "height": 20}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["tab", "new", "--cwd", "/work"],
+            MockResult(stdout=json.dumps(pane_payload("w2:p1", workspace_id="w2", tab_id="w2:t1"))),
+        )
+        mock.add(["pane", "get", "w2:p1"], MockResult(stdout=json.dumps(pane_payload("w2:p1", workspace_id="w2", tab_id="w2:t1"))))
+        mock.add(
+            ["pane", "split", "w2:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w2:p2", workspace_id="w2", tab_id="w2:t1"))),
+        )
+        mock.add(["pane", "get", "w2:p2"], MockResult(stdout=json.dumps(pane_payload("w2:p2", workspace_id="w2", tab_id="w2:t1"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.run(self.args(min_width=30, min_height=15, total_children=2))
+
+        self.assertEqual(result["pane_id"], "w2:p2")
+        self.assertEqual(result["workspace_id"], "w2")
+        self.assertEqual(result["tab_id"], "w2:t1")
+        self.assertIn(["tab", "new", "--cwd", "/work"], mock.calls)
+
+    def test_fallback_tab_creation_mocked(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 40, "height": 20}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(["tab", "new", "--cwd", "/work"], MockResult(returncode=1, stderr="tab create failed"))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args(min_width=30, min_height=15, total_children=2))
+
+        diagnostics = self.diagnostics()
+        self.assertTrue(diagnostics["fallback_attempted"])
+        self.assertIn("fallback failed", diagnostics["failure_reason"])
+
+    def test_fallback_scope_validation(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 40, "height": 20}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+        mock.add(
+            ["tab", "new", "--cwd", "/work"],
+            MockResult(stdout=json.dumps(pane_payload("w2:p1", workspace_id="w2", tab_id="w2:t1"))),
+        )
+        mock.add(["pane", "get", "w2:p1"], MockResult(stdout=json.dumps(pane_payload("w2:p1", workspace_id="w2", tab_id="w2:t1"))))
+        mock.add(
+            ["pane", "split", "w2:p1", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+            MockResult(stdout=json.dumps(pane_payload("w2:p2", workspace_id="w2", tab_id="w2:t1"))),
+        )
+        mock.add(["pane", "get", "w2:p2"], MockResult(stdout=json.dumps(pane_payload("w2:p2", workspace_id="w2", tab_id="w2:t1"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.run(self.args(min_width=30, min_height=15, total_children=2))
+
+        self.assertEqual(result["workspace_id"], "w2")
+        self.assertEqual(result["tab_id"], "w2:t1")
+        self.assertNotEqual(result["tab_id"], "w1:t1")
+
+    def test_capacity_exceeded_without_fallback_when_disabled(self):
+        self.write_layout(layout_payload([{"pane_id": "w1:p1", "rect": {"width": 40, "height": 20}}]))
+        mock = HerdrMock()
+        mock.add(["pane", "current", "--current"], MockResult(stdout=json.dumps(pane_payload("w1:p1"))))
+
+        with patch.object(split_scoped_pane, "run_herdr", mock), \
+             patch.dict("os.environ", {"HERDR_DELEGATE_AUTO_DEDICATED_TAB": "0"}, clear=False):
+            with self.assertRaises(SystemExit):
+                split_scoped_pane.run(self.args(min_width=30, min_height=15, total_children=2))
+
+        diagnostics = self.diagnostics()
+        self.assertIn("capacity", diagnostics["failure_reason"])
+        self.assertNotIn("fallback", diagnostics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issues

- Close #163

## Why

`herdr-agent-delegate` には同一タブ・最小サイズ・scoped split の安全検査がありますが、新規タブ選択、起動予定数に基づく事前配置、容量不足時の自動フォールバック、完了ペインのライフサイクル方針が弱く、別経路でペインが増えると委譲の追加分割が止まって作業領域を確保できません。起動前に安全な配置を選び、途中の容量不足にも一貫して対応できるようにします。

## Summary

起動予定Agent数、画面サイズ、既存ペイン混在状況を評価し、同一タブGridまたは専用新規タブGridを委譲前に選択する機能を追加します。分割途中の容量不足時は新規タブへ自動フォールバックし、中途半端な配置を残しません。完了・失敗・blocked 時のペインライフサイクル方針を SKILL.md に明記します。

## Changes

- `layout_planner.py`: `detect_existing_panes()` で無関係ペイン検出、`should_use_dedicated_tab()` で専用タブ判定、`plan_dedicated_tab()` ラッパー、`HERDR_DELEGATE_AUTO_DEDICATED_TAB` 環境変数を追加
- `split_scoped_pane.py`: `fallback_to_new_tab()` で容量不足時の新規タブフォールバック、`run()` の容量超過エラーハンドリングを修正
- `SKILL.md`: ペインライフサイクル方針（完了時保持/失敗時保持/blocked時保持/無関係ペイン保護）、専用タブ選択条件、容量不足フォールバック手順を追記
- `tests/test_layout_planner.py`: 無関係ペイン検出、専用タブ判定、エージェント数別レイアウトのテストを追加（15件）
- `tests/test_split_scoped_pane.py`: 容量超過フォールバック、無効化時の従来挙動のテストを追加（4件）

## Verification

- `python -m unittest herdr-agent-delegate/tests/test_layout_planner.py -v` - 28 tests passed
- `python -m unittest herdr-agent-delegate/tests/test_split_scoped_pane.py -v` - 28 tests passed
