### PR TITLE
fix(herdr-agent-delegate): 新規タブの空アンカーpaneを廃止しroot paneを直接Agent起動先にする

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -26,7 +26,15 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
 
 ## 3. 新規paneを配置する
 
-`MAX_PANES_PER_TAB = 4` とし、親と今回この親が作った子だけを配置対象にする。分割順序は次に固定する。
+`MAX_PANES_PER_TAB = 4` とし、実Agent数として数える。親と今回この親が作った子だけを配置対象にする。分割順序は次に固定する。
+
+1. 子1（新規タブ）: `tab create` のroot paneをAgent起動先として使う（splitしない）
+2. 子2: 子1（root pane）を下分割
+3. 子3: 子2を右分割
+4. 子4: 子3を下分割
+5. 子5以降: 新規タブで子1から繰り返す
+
+既存groupに追加する場合:
 
 1. 子1: 親を右分割
 2. 子2: 子1を下分割
@@ -45,7 +53,7 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
   --child <child-pane-id>
 ```
 
-事前配置で新しいgroupを始める場合は `--new-tab` を付ける。返却JSONの `pane_id` を子1、`anchor_pane_id` をそのgroupの親として保持し、以後はそのgroup内で同じ固定順序を繰り返す。
+事前配置で新しいgroupを始める場合は `--new-tab` を付ける。返却JSONの `pane_id`（= `group_parent_pane_id`）を子1兼そのgroupの親として保持し、以後はそのgroup内で同じ固定順序を繰り返す。互換用に `anchor_pane_id` も同じpane IDを指す。新規タブではroot paneを直接Agent起動先として使うため、Agent未起動の空Bashアンカーpaneを生成しない。
 
 スクリプトは最小サイズ不足、4pane超過、無関係pane混在時に新規タブへフォールバックする。分割後は `herdr pane get` で新規paneの `workspace_id` / `tab_id` を検証する。検証失敗時にcloseできるのは今回のsplitが返した新規paneだけで、親・既存の子・無関係paneは操作しない。
 

--- a/herdr-agent-delegate/scripts/layout_planner.py
+++ b/herdr-agent-delegate/scripts/layout_planner.py
@@ -11,21 +11,30 @@ SPLIT_DIRECTIONS = ("right", "down", "right", "down")
 
 
 def incremental_slot(child_number: int) -> dict[str, Any]:
-    """Return the tab, slot, and split direction for a one-based child number."""
+    """Return the tab, slot, and split direction for a one-based child number.
+
+    The first child in every tab (slot 1) uses the root pane directly and
+    does not need a split.  Its direction is ``None``.
+    """
     if child_number < 1:
         raise ValueError("child_number must be at least 1")
     zero_based = child_number - 1
     slot = zero_based % MAX_PANES_PER_TAB
+    starts_new_tab = zero_based >= MAX_PANES_PER_TAB and slot == 0
     return {
         "tab_index": zero_based // MAX_PANES_PER_TAB,
         "slot": slot + 1,
-        "direction": SPLIT_DIRECTIONS[slot],
-        "starts_new_tab": zero_based >= MAX_PANES_PER_TAB and slot == 0,
+        "direction": SPLIT_DIRECTIONS[slot] if slot > 0 else None,
+        "starts_new_tab": starts_new_tab,
     }
 
 
 def plan_tabs(child_count: int) -> list[dict[str, Any]]:
-    """Group a known batch into tabs of at most four delegated panes."""
+    """Group a known batch into tabs of at most four delegated panes.
+
+    The first child of every tab is placed on the root pane (no split).
+    Only children 2‑4 receive split directions (``down / right / down``).
+    """
     if child_count < 0:
         raise ValueError("child_count must not be negative")
     tabs: list[dict[str, Any]] = []
@@ -36,7 +45,7 @@ def plan_tabs(child_count: int) -> list[dict[str, Any]]:
                 "tab_index": len(tabs),
                 "first_child": first,
                 "child_count": count,
-                "directions": list(SPLIT_DIRECTIONS[:count]),
+                "directions": list(SPLIT_DIRECTIONS[1:count]),
             }
         )
     return tabs

--- a/herdr-agent-delegate/scripts/split_scoped_pane.py
+++ b/herdr-agent-delegate/scripts/split_scoped_pane.py
@@ -139,23 +139,20 @@ def split_pane(target_id: str, direction: str, cwd: str) -> dict[str, str]:
 
 
 def create_in_new_tab(cwd: str, workspace_id: str, old_tab_id: str) -> dict[str, Any]:
-    anchor = command_pane(
+    root = command_pane(
         ["tab", "create", "--workspace", workspace_id, "--cwd", cwd, "--no-focus"],
         "new tab pane",
         result_key="root_pane",
     )
-    anchor = get_pane(anchor["pane_id"], "new tab pane after create")
-    if anchor["workspace_id"] != workspace_id:
+    root = get_pane(root["pane_id"], "new tab pane after create")
+    if root["workspace_id"] != workspace_id:
         raise ValueError("new tab was created outside the expected workspace")
-    if anchor["tab_id"] == old_tab_id:
+    if root["tab_id"] == old_tab_id:
         raise ValueError("tab create returned the existing tab")
-
-    child = split_pane(anchor["pane_id"], SPLIT_DIRECTIONS[0], cwd)
-    verified = get_pane(child["pane_id"], "new pane after split")
-    validate_scope(verified, anchor["workspace_id"], anchor["tab_id"], "new pane after split")
     return {
-        **verified,
-        "anchor_pane_id": anchor["pane_id"],
+        **root,
+        "group_parent_pane_id": root["pane_id"],
+        "anchor_pane_id": root["pane_id"],
         "new_tab": True,
     }
 

--- a/herdr-agent-delegate/tests/test_layout_planner.py
+++ b/herdr-agent-delegate/tests/test_layout_planner.py
@@ -38,7 +38,7 @@ class LayoutPlannerTest(unittest.TestCase):
         slots = [layout_planner.incremental_slot(number) for number in range(1, 6)]
         self.assertEqual(
             [slot["direction"] for slot in slots],
-            ["right", "down", "right", "down", "right"],
+            [None, "down", "right", "down", None],
         )
         self.assertEqual([slot["tab_index"] for slot in slots], [0, 0, 0, 0, 1])
         self.assertTrue(slots[4]["starts_new_tab"])
@@ -51,19 +51,19 @@ class LayoutPlannerTest(unittest.TestCase):
                     "tab_index": 0,
                     "first_child": 1,
                     "child_count": 4,
-                    "directions": ["right", "down", "right", "down"],
+                    "directions": ["down", "right", "down"],
                 },
                 {
                     "tab_index": 1,
                     "first_child": 5,
                     "child_count": 4,
-                    "directions": ["right", "down", "right", "down"],
+                    "directions": ["down", "right", "down"],
                 },
                 {
                     "tab_index": 2,
                     "first_child": 9,
                     "child_count": 1,
-                    "directions": ["right"],
+                    "directions": [],
                 },
             ],
         )

--- a/herdr-agent-delegate/tests/test_split_scoped_pane.py
+++ b/herdr-agent-delegate/tests/test_split_scoped_pane.py
@@ -123,16 +123,13 @@ class SplitScopedPaneTest(unittest.TestCase):
                 ),
                 (["tab", "create", "--workspace", "w1", "--cwd", "/work", "--no-focus"], Result(tab_payload("w1:p10"))),
                 (["pane", "get", "w1:p10"], Result(pane_payload("w1:p10", tab_id="w1:t2"))),
-                (
-                    ["pane", "split", "w1:p10", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
-                    Result(pane_payload("w1:p11", tab_id="w1:t2")),
-                ),
-                (["pane", "get", "w1:p11"], Result(pane_payload("w1:p11", tab_id="w1:t2"))),
             ]
         )
         with patch.object(split_scoped_pane, "run_herdr", mock):
             result = split_scoped_pane.run(args(children))
         self.assertTrue(result["new_tab"])
+        self.assertEqual(result["pane_id"], "w1:p10")
+        self.assertEqual(result["group_parent_pane_id"], "w1:p10")
         self.assertEqual(result["anchor_pane_id"], "w1:p10")
 
     def test_unrelated_pane_uses_new_tab_without_touching_it(self):
@@ -142,13 +139,13 @@ class SplitScopedPaneTest(unittest.TestCase):
                 (["pane", "layout", "--pane", "w1:p1"], Result(layout_payload(["w1:p1", "w1:p9"]))),
                 (["tab", "create", "--workspace", "w1", "--cwd", "/work", "--no-focus"], Result(tab_payload("w1:p10"))),
                 (["pane", "get", "w1:p10"], Result(pane_payload("w1:p10", tab_id="w1:t2"))),
-                (["pane", "split", "w1:p10", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"], Result(pane_payload("w1:p11", tab_id="w1:t2"))),
-                (["pane", "get", "w1:p11"], Result(pane_payload("w1:p11", tab_id="w1:t2"))),
             ]
         )
         with patch.object(split_scoped_pane, "run_herdr", mock):
-            split_scoped_pane.run(args())
+            result = split_scoped_pane.run(args())
         self.assertFalse(any(call[:2] == ["pane", "close"] for call in mock.calls))
+        self.assertEqual(result["pane_id"], "w1:p10")
+        self.assertEqual(result["group_parent_pane_id"], "w1:p10")
 
     def test_new_pane_scope_is_verified_and_only_new_child_is_closed(self):
         responses = self.split_responses([], "right")[:-1]
@@ -172,32 +169,50 @@ class SplitScopedPaneTest(unittest.TestCase):
                 (["pane", "get", "w1:p1"], Result(pane_payload("w1:p1"))),
                 (["tab", "create", "--workspace", "w1", "--cwd", "/work", "--no-focus"], Result(tab_payload("w1:p10"))),
                 (["pane", "get", "w1:p10"], Result(pane_payload("w1:p10", tab_id="w1:t2"))),
-                (["pane", "split", "w1:p10", "--direction", "right", "--ratio", "0.5", "--cwd", "/work", "--no-focus"], Result(pane_payload("w1:p11", tab_id="w1:t2"))),
-                (["pane", "get", "w1:p11"], Result(pane_payload("w1:p11", tab_id="w1:t2"))),
             ]
         )
         with patch.object(split_scoped_pane, "run_herdr", mock):
             result = split_scoped_pane.run(args())
         self.assertTrue(result["new_tab"])
+        self.assertEqual(result["pane_id"], "w1:p10")
 
-    def test_new_tab_anchor_can_be_used_as_next_group_parent(self):
+    def test_new_tab_root_pane_used_as_group_parent(self):
         mock = HerdrMock(
             [
                 (["pane", "current", "--current"], Result(pane_payload("w1:p1"))),
                 (["pane", "get", "w1:p10"], Result(pane_payload("w1:p10", tab_id="w1:t2"))),
-                (["pane", "layout", "--pane", "w1:p10"], Result(layout_payload(["w1:p10", "w1:p11"]))),
+                (["pane", "layout", "--pane", "w1:p10"], Result(layout_payload(["w1:p10"]))),
+                (["pane", "get", "w1:p10"], Result(pane_payload("w1:p10", tab_id="w1:t2"))),
+                (
+                    ["pane", "split", "w1:p10", "--direction", "down", "--ratio", "0.5", "--cwd", "/work", "--no-focus"],
+                    Result(pane_payload("w1:p11", tab_id="w1:t2")),
+                ),
                 (["pane", "get", "w1:p11"], Result(pane_payload("w1:p11", tab_id="w1:t2"))),
-                (["pane", "split", "w1:p11", "--direction", "down", "--ratio", "0.5", "--cwd", "/work", "--no-focus"], Result(pane_payload("w1:p12", tab_id="w1:t2"))),
-                (["pane", "get", "w1:p12"], Result(pane_payload("w1:p12", tab_id="w1:t2"))),
             ]
         )
         group_args = Namespace(
             parent_pane_id="w1:p10",
             cwd="/work",
-            child=["w1:p11"],
+            child=["w1:p10"],
             new_tab=False,
         )
         with patch.object(split_scoped_pane, "run_herdr", mock):
             result = split_scoped_pane.run(group_args)
         self.assertFalse(result["new_tab"])
-        self.assertEqual(result["pane_id"], "w1:p12")
+        self.assertEqual(result["pane_id"], "w1:p11")
+
+    def test_create_in_new_tab_returns_root_as_agent_pane(self):
+        mock = HerdrMock(
+            [
+                (["tab", "create", "--workspace", "w1", "--cwd", "/work", "--no-focus"], Result(tab_payload("w1:p10"))),
+                (["pane", "get", "w1:p10"], Result(pane_payload("w1:p10", tab_id="w1:t2"))),
+            ]
+        )
+        with patch.object(split_scoped_pane, "run_herdr", mock):
+            result = split_scoped_pane.create_in_new_tab("/work", "w1", "w1:t1")
+        self.assertTrue(result["new_tab"])
+        self.assertEqual(result["pane_id"], "w1:p10")
+        self.assertEqual(result["group_parent_pane_id"], "w1:p10")
+        self.assertEqual(result["anchor_pane_id"], "w1:p10")
+        self.assertEqual(result["workspace_id"], "w1")
+        self.assertEqual(result["tab_id"], "w1:t2")


### PR DESCRIPTION
## Issues

- Close #169

## Why

`herdr-agent-delegate` は新規タブへAgentグループを配置する際、`tab create` が返すroot paneを右分割し、左側を空Bashアンカーとして保持していました。このアンカーpaneはAgentを起動せず、ユーザー視点では用途が不明で、Agent終了後も空タブとして残る問題がありました。

## Summary

新規タブのroot paneをそのままAgent起動先として使い、不要なアンカー分割を廃止します。1タブあたりの実Agent pane数を最大4体に統一します。

## Changes

- `create_in_new_tab()`: `tab create` のroot paneを直接返し、直後の `split_pane()` を削除
- 返却契約: `pane_id` = `group_parent_pane_id` = root pane、`anchor_pane_id` は互換alias
- `SKILL.md`: 新規タブ・既存groupの分割順序説明を分離し、空アンカー非生成を明記
- テスト: 新契約に対応する全テストを更新、`create_in_new_tab()` の単体テストを追加

## Checklist

- [x] テスト (28 passed)
