### PR TITLE
[herdr-agent-delegate] 依頼送信を pane run に統一して確実に実行開始する (#172)

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -75,13 +75,20 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
 
 ## 5. 依頼を直接送る
 
-入力可能を確認した新規Agentには、依頼本文をEnter込みで原子的に送る。
+入力可能を確認した新規Agentには、依頼本文をEnter込みで原子的に送る。Herdr 0.7.3 のCLI契約では `herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、依頼の実行開始が必要な送信には使わない。
 
 ```bash
 herdr pane run <pane-id> "<依頼本文>"
 ```
 
-対応Agentには `herdr agent send <pane-id> "<依頼本文>"` を使ってもよい。既存idle Agentの再利用時も同様に直接送る。送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。依頼ファイル、replyファイル、完了markerは作らない。
+既存idle Agentの再利用時も同様に `herdr pane run` で直接送る。送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。依頼ファイル、replyファイル、完了markerは作らない。
+
+30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は二重実行の可能性があるため自動で行わない。代わりに読み取り専用の診断で状態を取得し、異常を報告して停止する。
+
+```bash
+herdr pane get <pane-id>
+herdr pane read <pane-id> --source recent-unwrapped --lines 80
+```
 
 ## 6. 完了を待って出力を回収する
 

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -83,7 +83,7 @@ herdr pane run <pane-id> "<依頼本文>"
 
 既存idle Agentの再利用時も同様に `herdr pane run` で直接送る。送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。依頼ファイル、replyファイル、完了markerは作らない。
 
-30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は二重実行の可能性があるため自動で行わない。代わりに読み取り専用の診断で状態を取得し、異常を報告して停止する。
+30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は二重実行の可能性があるため自動で行わない。代わりに読み取り専用の診断で状態を取得し、異常を報告してこの依頼の送信を中止する。以降の完了待機や出力回収も行わず、人間の判断を待つ。
 
 ```bash
 herdr pane get <pane-id>

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -27,7 +27,7 @@
 herdr pane run <pane-id> "<依頼本文>"
 ```
 
-送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行や `send-keys Enter` による自動復旧は行わず、`herdr pane get` と `herdr pane read <pane-id> --source recent-unwrapped --lines 80` で状態を取得して報告する。
+送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は行わず、`herdr pane get` と `herdr pane read <pane-id> --source recent-unwrapped --lines 80` で状態を取得して報告し、異常を報告してこの依頼の送信を停止する。
 
 ## 完了と回収
 

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -27,7 +27,7 @@
 herdr pane run <pane-id> "<依頼本文>"
 ```
 
-送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は行わず、`herdr pane get` と `herdr pane read <pane-id> --source recent-unwrapped --lines 80` で状態を取得して報告し、異常を報告してこの依頼の送信を停止する。
+送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は行わず、`herdr pane get` と `herdr pane read <pane-id> --source recent-unwrapped --lines 80` で状態を取得して報告し、異常を報告してこの依頼の送信を停止する。以降の完了待機や出力回収も行わず、人間の判断を待つ。
 
 ## 完了と回収
 

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -21,15 +21,13 @@
 
 ## 依頼送信
 
-入力可能を確認してから、Enter込みの公式操作を直接使う。
+入力可能を確認してから、Enter込みの公式操作を直接使う。Herdr 0.7.3 のCLI契約では `herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、実行開始が必要な依頼送信には使わない。
 
 ```bash
 herdr pane run <pane-id> "<依頼本文>"
-# または対応Agentへ
-herdr agent send <pane-id> "<依頼本文>"
 ```
 
-送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。
+送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行や `send-keys Enter` による自動復旧は行わず、`herdr pane get` と `herdr pane read <pane-id> --source recent-unwrapped --lines 80` で状態を取得して報告する。
 
 ## 完了と回収
 

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -129,29 +129,79 @@ fi
             for term in removed_terms:
                 self.assertNotIn(term, text)
 
+    @staticmethod
+    def _request_delivery_section(text, section_title):
+        lines = text.splitlines()
+        in_section = False
+        section_lines = []
+        for line in lines:
+            if line.startswith("##") and section_title in line:
+                in_section = True
+                continue
+            if in_section and line.startswith("##") and section_title not in line:
+                break
+            if in_section:
+                section_lines.append(line)
+        section_text = "\n".join(section_lines)
+        if not section_text:
+            raise AssertionError(
+                f"'{section_title}' セクションが見つかりません"
+            )
+        if "```bash" not in section_text:
+            raise AssertionError(
+                f"'{section_title}' セクションに bash コードブロックがありません"
+            )
+        return section_text
+
+    @classmethod
+    def _request_delivery_command_block(cls, text, section_title):
+        section = cls._request_delivery_section(text, section_title)
+        match = re.search(r"```bash\n(.*?)\n```", section, re.DOTALL)
+        if match is None:
+            raise AssertionError(
+                f"'{section_title}' セクションの bash コードブロックが取得できません"
+            )
+        return match.group(1)
+
     def test_request_delivery_uses_pane_run_only(self):
-        for text in (self.skill, self.reference):
-            self.assertIn("herdr pane run", text)
-            self.assertIn("herdr wait agent-status", text)
-            self.assertIn("--status working", text)
+        skill_block = self._request_delivery_command_block(
+            self.skill, "依頼を直接送る"
+        )
+        reference_block = self._request_delivery_command_block(
+            self.reference, "依頼送信"
+        )
+        for block in (skill_block, reference_block):
+            # 実行例は pane run のみ
+            self.assertIn("herdr pane run", block)
+            self.assertNotIn("herdr agent send", block)
 
     def test_agent_send_is_not_used_for_request_execution(self):
         for text in (self.skill, self.reference):
-            self.assertIn("agent send", text)
             self.assertIn("Enterを送らない", text)
             self.assertNotIn(
-                "herdr agent send <pane-id> \"<依頼本文>\"", text
+                'herdr agent send <pane-id> "<依頼本文>"', text
             )
 
     def test_timeout_diagnosis_is_read_only_and_does_not_resend(self):
-        self.assertIn("herdr pane get", self.skill)
-        self.assertIn("herdr pane read", self.skill)
-        self.assertIn("recent-unwrapped", self.skill)
+        skill_section = self._request_delivery_section(
+            self.skill, "依頼を直接送る"
+        )
+        reference_section = self._request_delivery_section(
+            self.reference, "依頼送信"
+        )
+
+        for section in (skill_section, reference_section):
+            self.assertIn("herdr pane get", section)
+            self.assertIn("herdr pane read", section)
+            self.assertIn("recent-unwrapped", section)
+
+        # SKILL.md 側は「依頼の送信を中止」「以降の完了待機や出力回収も行わない」
         self.assertIn("二重実行", self.skill)
         self.assertIn("自動で行わない", self.skill)
+        self.assertIn("この依頼の送信を中止する", self.skill)
+        self.assertIn("以降の完了待機や出力回収も行わず", self.skill)
         self.assertNotIn("send-keys", self.skill)
 
-        self.assertIn("herdr pane get", self.reference)
-        self.assertIn("herdr pane read", self.reference)
-        self.assertIn("recent-unwrapped", self.reference)
-        self.assertIn("自動復旧は行わず", self.reference)
+        # references/agent-cli.md 側も同じく停止を明記
+        self.assertIn("この依頼の送信を停止する", self.reference)
+        self.assertNotIn("send-keys", self.reference)

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -128,3 +128,30 @@ fi
             self.assertIn("pane", text)
             for term in removed_terms:
                 self.assertNotIn(term, text)
+
+    def test_request_delivery_uses_pane_run_only(self):
+        for text in (self.skill, self.reference):
+            self.assertIn("herdr pane run", text)
+            self.assertIn("herdr wait agent-status", text)
+            self.assertIn("--status working", text)
+
+    def test_agent_send_is_not_used_for_request_execution(self):
+        for text in (self.skill, self.reference):
+            self.assertIn("agent send", text)
+            self.assertIn("Enterを送らない", text)
+            self.assertNotIn(
+                "herdr agent send <pane-id> \"<依頼本文>\"", text
+            )
+
+    def test_timeout_diagnosis_is_read_only_and_does_not_resend(self):
+        self.assertIn("herdr pane get", self.skill)
+        self.assertIn("herdr pane read", self.skill)
+        self.assertIn("recent-unwrapped", self.skill)
+        self.assertIn("二重実行", self.skill)
+        self.assertIn("自動で行わない", self.skill)
+        self.assertNotIn("send-keys", self.skill)
+
+        self.assertIn("herdr pane get", self.reference)
+        self.assertIn("herdr pane read", self.reference)
+        self.assertIn("recent-unwrapped", self.reference)
+        self.assertIn("自動復旧は行わず", self.reference)

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -131,14 +131,18 @@ fi
 
     @staticmethod
     def _request_delivery_section(text, section_title):
+        escaped = re.escape(section_title)
+        section_pattern = re.compile(
+            rf"^##+\s+(?:\d+\.\s+)?{escaped}(?:\s|$)"
+        )
         lines = text.splitlines()
         in_section = False
         section_lines = []
         for line in lines:
-            if line.startswith("##") and section_title in line:
+            if section_pattern.match(line):
                 in_section = True
                 continue
-            if in_section and line.startswith("##") and section_title not in line:
+            if in_section and line.startswith("##"):
                 break
             if in_section:
                 section_lines.append(line)
@@ -154,26 +158,31 @@ fi
         return section_text
 
     @classmethod
-    def _request_delivery_command_block(cls, text, section_title):
+    def _request_delivery_command_blocks(cls, text, section_title):
         section = cls._request_delivery_section(text, section_title)
-        match = re.search(r"```bash\n(.*?)\n```", section, re.DOTALL)
-        if match is None:
+        blocks = re.findall(r"```bash\n(.*?)\n```", section, re.DOTALL)
+        if not blocks:
             raise AssertionError(
-                f"'{section_title}' セクションの bash コードブロックが取得できません"
+                f"'{section_title}' セクションから bash コードブロックを取得できません"
             )
-        return match.group(1)
+        return blocks
 
     def test_request_delivery_uses_pane_run_only(self):
-        skill_block = self._request_delivery_command_block(
+        skill_blocks = self._request_delivery_command_blocks(
             self.skill, "依頼を直接送る"
         )
-        reference_block = self._request_delivery_command_block(
+        reference_blocks = self._request_delivery_command_blocks(
             self.reference, "依頼送信"
         )
-        for block in (skill_block, reference_block):
-            # 実行例は pane run のみ
-            self.assertIn("herdr pane run", block)
-            self.assertNotIn("herdr agent send", block)
+        for blocks in (skill_blocks, reference_blocks):
+            # 少なくとも1つの実行例で pane run を使う
+            self.assertTrue(
+                any("herdr pane run" in block for block in blocks),
+                "依頼送信セクションに pane run の実行例がありません",
+            )
+            # セクション内の全 bash コードブロックに agent send が混入していない
+            for block in blocks:
+                self.assertNotIn("herdr agent send", block)
 
     def test_agent_send_is_not_used_for_request_execution(self):
         for text in (self.skill, self.reference):
@@ -202,6 +211,7 @@ fi
         self.assertIn("以降の完了待機や出力回収も行わず", self.skill)
         self.assertNotIn("send-keys", self.skill)
 
-        # references/agent-cli.md 側も同じく停止を明記
+        # references/agent-cli.md 側も同じく停止と後続工程の中止を明記
         self.assertIn("この依頼の送信を停止する", self.reference)
+        self.assertIn("以降の完了待機や出力回収も行わず", self.reference)
         self.assertNotIn("send-keys", self.reference)


### PR DESCRIPTION
## Issues

- Close #172

## Why

`herdr-agent-delegate` の依頼送信手順では `herdr pane run` に加えて `herdr agent send` も使用可能としていましたが、Herdr 0.7.3 のCLI契約では `agent send` は文字列入力のみで Enter を送りません。そのため `agent send` 後は依頼本文が入力欄に表示される一方、実行が開始されず `agent_status` が `idle` のままになる問題がありました。

## Summary

全対応Agentへの依頼送信を `herdr pane run` に統一し、`agent send` がEnterを送らないことを明記します。開始確認がタイムアウトした場合は読み取り専用の診断で停止し、依頼の二重実行を避けます。

## Changes

- `herdr-agent-delegate/SKILL.md`
  - 依頼送信を `herdr pane run` のみに統一
  - `agent send` が文字列入力のみで Enter を送らないことを明記
  - `working` 遷移タイムアウト時の安全な診断・停止手順を追加
- `herdr-agent-delegate/references/agent-cli.md`
  - 同じく `pane run` のみを使う送信契約に更新
  - タイムアウト時の診断フローを追加
- `herdr-agent-delegate/tests/test_skill_contract.py`
  - 送信契約が `pane run` のみであることを検証するテストを追加
  - `agent send` が実行可能な依頼送信例に混入しないことを検証
  - タイムアウト時の診断が読み取り専用で再送しないことを検証

## Checklist

- [x] テスト
- [ ] Codex・Claude Code・OpenCode での手動E2E確認（別途実施予定）
