### PR TITLE
fix(herdr-agent-delegate): Claude 長文依頼の [Pasted text #1] 発火対応 (#174)

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -75,15 +75,20 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
 
 ## 5. 依頼を直接送る
 
-入力可能を確認した新規Agentには、依頼本文をEnter込みで原子的に送る。Herdr 0.7.3 のCLI契約では `herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、依頼の実行開始が必要な送信には使わない。
+入力可能を確認した新規Agentには、依頼本文をEnter込みで原子的に送る。`herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、依頼の実行開始が必要な送信には使わない。Agent種別ごとの差異は `send_request.py` で吸収する。
 
 ```bash
-herdr pane run <pane-id> "<依頼本文>"
+<skill-dir>/scripts/send_request.py \
+  --target <pane-id> \
+  --agent <codex|claude|opencode> \
+  --prompt "<依頼本文>"
 ```
 
-既存idle Agentの再利用時も同様に `herdr pane run` で直接送る。送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。依頼ファイル、replyファイル、完了markerは作らない。
+既存idle Agentの再利用時も同じく `send_request.py` を使う。依頼ファイル、replyファイル、完了markerは作らない。
 
-30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は二重実行の可能性があるため自動で行わない。代わりに読み取り専用の診断で状態を取得し、異常を報告してこの依頼の送信を中止する。以降の完了待機や出力回収も行わず、人間の判断を待つ。
+`send_request.py` は `herdr pane run` で依頼を送信し、30秒以内の `working` 遷移を待つ。Claude Code のみ、長文ペーストが `[Pasted text #1]` として入力欄に留まり実行されない場合があるため、活性化用の短いプロンプトを `herdr pane run` で追加送信し、再び `working` を待つ。同じ依頼本文の `pane run` による再送信やEnter追送は二重実行の可能性があるため自動で行わない。
+
+送信が失敗した場合、読み取り専用で状態を取得し、異常を報告してこの依頼の送信を中止する。以降の完了待機や出力回収も行わず、人間の判断を待つ。
 
 ```bash
 herdr pane get <pane-id>

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -21,13 +21,23 @@
 
 ## 依頼送信
 
-入力可能を確認してから、Enter込みの公式操作を直接使う。Herdr 0.7.3 のCLI契約では `herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、実行開始が必要な依頼送信には使わない。
+入力可能を確認してから、Enter込みの公式操作を直接使う。`herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、実行開始が必要な依頼送信には使わない。Agent種別ごとの差異は `../scripts/send_request.py` で吸収する。
 
 ```bash
-herdr pane run <pane-id> "<依頼本文>"
+<skill-dir>/scripts/send_request.py \
+  --target <pane-id> \
+  --agent <codex|claude|opencode> \
+  --prompt "<依頼本文>"
 ```
 
-送信後は `herdr wait agent-status <pane-id> --status working --timeout 30000` で開始を確認する。30秒以内に `working` へ遷移しなかった場合、同じ依頼の `pane run` 再実行やEnter追送は行わず、`herdr pane get` と `herdr pane read <pane-id> --source recent-unwrapped --lines 80` で状態を取得して報告し、異常を報告してこの依頼の送信を停止する。以降の完了待機や出力回収も行わず、人間の判断を待つ。
+`send_request.py` は `herdr pane run` で依頼を送信し、30秒以内の `working` 遷移を待つ。Claude Code のみ、長文ペーストが `[Pasted text #1]` として入力欄に留まることがあるため、活性化用の短いプロンプトを追加送信して再び `working` を待つ。
+
+30秒以内に `working` へ遷移しなかった場合、読み取り専用で状態を取得して報告し、異常を報告してこの依頼の送信を停止する。以降の完了待機や出力回収も行わず、人間の判断を待つ。
+
+```bash
+herdr pane get <pane-id>
+herdr pane read <pane-id> --source recent-unwrapped --lines 80
+```
 
 ## 完了と回収
 

--- a/herdr-agent-delegate/scripts/send_request.py
+++ b/herdr-agent-delegate/scripts/send_request.py
@@ -27,13 +27,21 @@ DEFAULT_ACTIVATION_TEXT: Final = "実行して"
 def run_herdr(
     arguments: list[str], timeout: float | None = None
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["herdr", *arguments],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    try:
+        return subprocess.run(
+            ["herdr", *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(
+            cmd=exc.cmd if isinstance(exc.cmd, list) else ["herdr", *arguments],
+            returncode=124,
+            stdout="",
+            stderr=f"herdr command timed out after {timeout}s",
+        )
 
 
 def wait_for_working(target: str, timeout_ms: int) -> bool:
@@ -116,7 +124,12 @@ def send_request(args: argparse.Namespace) -> int:
         return 1
 
     # First wait: give the agent a chance to start normally.
-    first_wait_ms = max(0, min(activation_timeout_ms, total_timeout_ms))
+    # Non-Claude agents always wait the full timeout; Claude uses the shorter
+    # activation window first so we can detect the stuck paste state early.
+    first_wait_ms = (
+        activation_timeout_ms if args.agent == "claude" else total_timeout_ms
+    )
+    first_wait_ms = max(0, min(first_wait_ms, total_timeout_ms))
     if wait_for_working(args.target, first_wait_ms):
         return 0
 
@@ -145,6 +158,12 @@ def send_request(args: argparse.Namespace) -> int:
                 print(json.dumps(diagnostics, ensure_ascii=False), file=sys.stderr)
                 return 1
 
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            remaining_ms = max(0, total_timeout_ms - elapsed_ms)
+            if wait_for_working(args.target, remaining_ms):
+                return 0
+        else:
+            # No placeholder yet: keep waiting for the rest of the total timeout.
             elapsed_ms = int((time.monotonic() - started) * 1000)
             remaining_ms = max(0, total_timeout_ms - elapsed_ms)
             if wait_for_working(args.target, remaining_ms):
@@ -195,8 +214,8 @@ def main() -> None:
         parser.error("--timeout must be greater than zero")
     if args.activation_timeout <= 0:
         parser.error("--activation-timeout must be greater than zero")
-    if args.activation_timeout > args.timeout:
-        parser.error("--activation-timeout must not exceed --timeout")
+    if args.activation_timeout >= args.timeout:
+        parser.error("--activation-timeout must be shorter than --timeout")
     if not args.prompt:
         parser.error("--prompt must not be empty")
 

--- a/herdr-agent-delegate/scripts/send_request.py
+++ b/herdr-agent-delegate/scripts/send_request.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Send a request to a CLI Agent pane and wait for it to start working.
+
+This wrapper exists because Claude Code does not always auto-execute a long
+pasted prompt: the input field shows ``[Pasted text #1]`` and stays idle.
+For Claude only, when this happens we send a short activation prompt via the
+same ``herdr pane run`` primitive to trigger execution. Other agents receive a
+single ``herdr pane run`` and the usual working-status wait.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Final
+
+
+SUPPORTED_AGENTS: Final = ("codex", "claude", "opencode")
+DEFAULT_TIMEOUT_MS: Final = 30_000
+DEFAULT_ACTIVATION_TIMEOUT_MS: Final = 10_000
+DEFAULT_ACTIVATION_TEXT: Final = "実行して"
+
+
+def run_herdr(
+    arguments: list[str], timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["herdr", *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def wait_for_working(target: str, timeout_ms: int) -> bool:
+    """Wait up to ``timeout_ms`` for the pane to become ``working``.
+
+    Returns ``True`` if the status was reached, ``False`` on timeout or error.
+    """
+    if timeout_ms <= 0:
+        return False
+    result = run_herdr(
+        [
+            "wait",
+            "agent-status",
+            target,
+            "--status",
+            "working",
+            "--timeout",
+            str(timeout_ms),
+        ],
+        timeout=timeout_ms / 1000 + 5,
+    )
+    return result.returncode == 0
+
+
+def read_recent_output(target: str, lines: int = 80) -> subprocess.CompletedProcess[str]:
+    return run_herdr(
+        [
+            "pane",
+            "read",
+            target,
+            "--source",
+            "recent-unwrapped",
+            "--lines",
+            str(lines),
+        ],
+        timeout=10,
+    )
+
+
+def diagnose(target: str) -> dict[str, object]:
+    pane_get = run_herdr(["pane", "get", target], timeout=10)
+    pane_read = read_recent_output(target, lines=80)
+    return {
+        "pane_get": {
+            "returncode": pane_get.returncode,
+            "stdout": pane_get.stdout,
+            "stderr": pane_get.stderr,
+        },
+        "pane_read": {
+            "returncode": pane_read.returncode,
+            "stdout": pane_read.stdout,
+            "stderr": pane_read.stderr,
+        },
+    }
+
+
+def send_request(args: argparse.Namespace) -> int:
+    started = time.monotonic()
+    total_timeout_ms = args.timeout
+    activation_timeout_ms = min(args.activation_timeout, total_timeout_ms)
+
+    delivery = run_herdr(
+        ["pane", "run", args.target, args.prompt],
+        timeout=10,
+    )
+    if delivery.returncode != 0:
+        diagnostics = {
+            "status": "request_delivery_failed",
+            "phase": "delivery",
+            "target": args.target,
+            "agent": args.agent,
+            "delivery": {
+                "returncode": delivery.returncode,
+                "stdout": delivery.stdout,
+                "stderr": delivery.stderr,
+            },
+        }
+        diagnostics.update(diagnose(args.target))
+        print(json.dumps(diagnostics, ensure_ascii=False), file=sys.stderr)
+        return 1
+
+    # First wait: give the agent a chance to start normally.
+    first_wait_ms = max(0, min(activation_timeout_ms, total_timeout_ms))
+    if wait_for_working(args.target, first_wait_ms):
+        return 0
+
+    # Claude-specific fallback for the "[Pasted text #1]" idle state.
+    if args.agent == "claude":
+        read = read_recent_output(args.target, lines=80)
+        output = read.stdout if read.returncode == 0 else ""
+        if "[Pasted text" in output:
+            activation = run_herdr(
+                ["pane", "run", args.target, args.activation_text],
+                timeout=10,
+            )
+            if activation.returncode != 0:
+                diagnostics = {
+                    "status": "request_delivery_failed",
+                    "phase": "activation",
+                    "target": args.target,
+                    "agent": args.agent,
+                    "activation": {
+                        "returncode": activation.returncode,
+                        "stdout": activation.stdout,
+                        "stderr": activation.stderr,
+                    },
+                }
+                diagnostics.update(diagnose(args.target))
+                print(json.dumps(diagnostics, ensure_ascii=False), file=sys.stderr)
+                return 1
+
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            remaining_ms = max(0, total_timeout_ms - elapsed_ms)
+            if wait_for_working(args.target, remaining_ms):
+                return 0
+
+    diagnostics = {
+        "status": "request_delivery_failed",
+        "phase": "working_wait",
+        "target": args.target,
+        "agent": args.agent,
+    }
+    diagnostics.update(diagnose(args.target))
+    print(json.dumps(diagnostics, ensure_ascii=False), file=sys.stderr)
+    return 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, help="target pane id")
+    parser.add_argument(
+        "--agent",
+        required=True,
+        choices=SUPPORTED_AGENTS,
+        help="agent type running in the target pane",
+    )
+    parser.add_argument("--prompt", required=True, help="request body to send")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_MS,
+        help="total timeout in milliseconds to wait for working (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--activation-timeout",
+        type=int,
+        default=DEFAULT_ACTIVATION_TIMEOUT_MS,
+        help="timeout in milliseconds before trying the Claude activation fallback "
+        "(default: %(default)s)",
+    )
+    parser.add_argument(
+        "--activation-text",
+        default=DEFAULT_ACTIVATION_TEXT,
+        help="short prompt used to activate a stuck Claude paste (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    if args.timeout <= 0:
+        parser.error("--timeout must be greater than zero")
+    if args.activation_timeout <= 0:
+        parser.error("--activation-timeout must be greater than zero")
+    if args.activation_timeout > args.timeout:
+        parser.error("--activation-timeout must not exceed --timeout")
+    if not args.prompt:
+        parser.error("--prompt must not be empty")
+
+    raise SystemExit(send_request(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/herdr-agent-delegate/tests/test_send_request.py
+++ b/herdr-agent-delegate/tests/test_send_request.py
@@ -40,18 +40,20 @@ class SendRequestTest(unittest.TestCase):
         the order ``send_request`` invokes ``run_herdr``.
         """
         response_iter = iter(responses)
+        calls = []
 
         def fake_run_herdr(arguments, timeout=None):
+            calls.append(list(arguments))
             return next(response_iter)
 
         stderr = io.StringIO()
         with patch.object(send_request, "run_herdr", side_effect=fake_run_herdr):
             with patch.object(sys, "stderr", stderr):
                 rc = send_request.send_request(self._args(**overrides))
-        return rc, stderr.getvalue()
+        return rc, stderr.getvalue(), calls
 
     def test_codex_starts_immediately_without_activation(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 0, "", ""),
@@ -61,9 +63,13 @@ class SendRequestTest(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertEqual(stderr, "")
+        self.assertEqual(calls[0], ["pane", "run", "w1Z:pX", "self introduction"])
+        self.assertEqual(calls[1][:2], ["wait", "agent-status"])
+        self.assertIn("--timeout", calls[1])
+        self.assertNotIn(["pane", "run", "w1Z:pX", "実行して"], calls)
 
     def test_claude_short_prompt_starts_without_activation(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 0, "", ""),
@@ -73,9 +79,12 @@ class SendRequestTest(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertEqual(stderr, "")
+        self.assertEqual(calls[0], ["pane", "run", "w1Z:pX", "自己紹介して"])
+        self.assertEqual(calls[1][:2], ["wait", "agent-status"])
+        self.assertNotIn(["pane", "run", "w1Z:pX", "実行して"], calls)
 
     def test_claude_long_paste_activates_and_succeeds(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 1, "", ""),
@@ -90,9 +99,14 @@ class SendRequestTest(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertEqual(stderr, "")
+        self.assertEqual(calls[0], ["pane", "run", "w1Z:pX", "x" * 4000])
+        self.assertEqual(calls[1][:2], ["wait", "agent-status"])
+        self.assertEqual(calls[2][:2], ["pane", "read"])
+        self.assertEqual(calls[3], ["pane", "run", "w1Z:pX", "実行して"])
+        self.assertEqual(calls[4][:2], ["wait", "agent-status"])
 
     def test_claude_no_placeholder_waits_remaining_timeout_and_succeeds(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 1, "", ""),
@@ -104,9 +118,13 @@ class SendRequestTest(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertEqual(stderr, "")
+        self.assertEqual(
+            len([c for c in calls if c[:2] == ["wait", "agent-status"]]), 2
+        )
+        self.assertNotIn(["pane", "run", "w1Z:pX", "実行して"], calls)
 
     def test_claude_long_paste_without_placeholder_diagnoses_after_full_timeout(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 1, "", ""),
@@ -122,9 +140,11 @@ class SendRequestTest(unittest.TestCase):
         diagnostics = stderr
         self.assertIn("request_delivery_failed", diagnostics)
         self.assertIn("still idle", diagnostics)
+        self.assertEqual(calls[-2][:2], ["pane", "get"])
+        self.assertEqual(calls[-1][:2], ["pane", "read"])
 
     def test_codex_slow_start_waits_full_timeout_then_diagnoses(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 1, "", ""),
@@ -137,9 +157,12 @@ class SendRequestTest(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("request_delivery_failed", stderr)
         self.assertIn("still idle", stderr)
+        self.assertEqual(
+            len([c for c in calls if c[:2] == ["wait", "agent-status"]]), 1
+        )
 
     def test_claude_activation_fails_then_diagnoses(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 1, "", ""),
@@ -157,9 +180,10 @@ class SendRequestTest(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("request_delivery_failed", stderr)
         self.assertIn("stuck idle", stderr)
+        self.assertEqual(calls[3], ["pane", "run", "w1Z:pX", "実行して"])
 
     def test_delivery_failure_diagnoses_immediately(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 1, "", "pane not found"),
                 CompletedProcess(["pane", "get"], 0, "{}", ""),
@@ -171,6 +195,9 @@ class SendRequestTest(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("request_delivery_failed", stderr)
         self.assertIn("pane not found", stderr)
+        self.assertEqual(calls[0], ["pane", "run", "w1Z:pX", "hello"])
+        self.assertEqual(calls[1][:2], ["pane", "get"])
+        self.assertEqual(calls[2][:2], ["pane", "read"])
 
     def test_argument_validation(self):
         with patch.object(
@@ -193,7 +220,7 @@ class SendRequestTest(unittest.TestCase):
         self.assertNotEqual(ctx.exception.code, 0)
 
     def test_opencode_starts_immediately_without_activation(self):
-        rc, stderr = self._run(
+        rc, stderr, calls = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 0, "", ""),
@@ -203,6 +230,8 @@ class SendRequestTest(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertEqual(stderr, "")
+        self.assertEqual(calls[0], ["pane", "run", "w1Z:pX", "self introduction"])
+        self.assertEqual(calls[1][:2], ["wait", "agent-status"])
 
 
 if __name__ == "__main__":

--- a/herdr-agent-delegate/tests/test_send_request.py
+++ b/herdr-agent-delegate/tests/test_send_request.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for herdr-agent-delegate/scripts/send_request.py."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+import unittest
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import send_request  # noqa: E402
+
+
+class SendRequestTest(unittest.TestCase):
+    @staticmethod
+    def _args(**overrides):
+        defaults = {
+            "target": "w1Z:pX",
+            "agent": "claude",
+            "prompt": "long " * 500,
+            "timeout": 30_000,
+            "activation_timeout": 10_000,
+            "activation_text": "実行して",
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def _run(self, responses, **overrides):
+        """Run send_request with a fake run_herdr that yields each response.
+
+        ``responses`` is an iterable of CompletedProcess instances returned in
+        the order ``send_request`` invokes ``run_herdr``.
+        """
+        response_iter = iter(responses)
+
+        def fake_run_herdr(arguments, timeout=None):
+            return next(response_iter)
+
+        stderr = io.StringIO()
+        with patch.object(send_request, "run_herdr", side_effect=fake_run_herdr):
+            with patch.object(sys, "stderr", stderr):
+                rc = send_request.send_request(self._args(**overrides))
+        return rc, stderr.getvalue()
+
+    def test_codex_starts_immediately_without_activation(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 0, "", ""),
+            ],
+            agent="codex",
+            prompt="self introduction",
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+
+    def test_claude_short_prompt_starts_without_activation(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 0, "", ""),
+            ],
+            agent="claude",
+            prompt="自己紹介して",
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+
+    def test_claude_long_paste_activates_and_succeeds(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
+                CompletedProcess(
+                    ["pane", "read"], 0, "before\n[Pasted text #1]\nafter", ""
+                ),
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 0, "", ""),
+            ],
+            agent="claude",
+            prompt="x" * 4000,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+
+    def test_claude_long_paste_without_placeholder_diagnoses(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
+                CompletedProcess(["pane", "read"], 0, "no placeholder here", ""),
+                CompletedProcess(["pane", "get"], 0, "{}", ""),
+                CompletedProcess(["pane", "read"], 0, "still idle", ""),
+            ],
+            agent="claude",
+            prompt="x" * 4000,
+        )
+        self.assertEqual(rc, 1)
+        diagnostics = stderr
+        self.assertIn("request_delivery_failed", diagnostics)
+        self.assertIn("still idle", diagnostics)
+
+    def test_claude_activation_fails_then_diagnoses(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
+                CompletedProcess(
+                    ["pane", "read"], 0, "[Pasted text #1]", ""
+                ),
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
+                CompletedProcess(["pane", "get"], 0, "{}", ""),
+                CompletedProcess(["pane", "read"], 0, "stuck idle", ""),
+            ],
+            agent="claude",
+            prompt="x" * 4000,
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("request_delivery_failed", stderr)
+        self.assertIn("stuck idle", stderr)
+
+    def test_delivery_failure_diagnoses_immediately(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 1, "", "pane not found"),
+                CompletedProcess(["pane", "get"], 0, "{}", ""),
+                CompletedProcess(["pane", "read"], 0, "error", ""),
+            ],
+            agent="codex",
+            prompt="hello",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("request_delivery_failed", stderr)
+        self.assertIn("pane not found", stderr)
+
+    def test_argument_validation(self):
+        with patch.object(sys, "argv", ["send_request.py", "--target", "w1:p2", "--agent", "claude", "--prompt", "x", "--activation-timeout", "40000"]):
+            with self.assertRaises(SystemExit) as ctx:
+                send_request.main()
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-agent-delegate/tests/test_send_request.py
+++ b/herdr-agent-delegate/tests/test_send_request.py
@@ -91,12 +91,27 @@ class SendRequestTest(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(stderr, "")
 
-    def test_claude_long_paste_without_placeholder_diagnoses(self):
+    def test_claude_no_placeholder_waits_remaining_timeout_and_succeeds(self):
         rc, stderr = self._run(
             [
                 CompletedProcess(["pane", "run"], 0, "", ""),
                 CompletedProcess(["wait", "agent-status"], 1, "", ""),
                 CompletedProcess(["pane", "read"], 0, "no placeholder here", ""),
+                CompletedProcess(["wait", "agent-status"], 0, "", ""),
+            ],
+            agent="claude",
+            prompt="x" * 4000,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+
+    def test_claude_long_paste_without_placeholder_diagnoses_after_full_timeout(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
+                CompletedProcess(["pane", "read"], 0, "no placeholder here", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
                 CompletedProcess(["pane", "get"], 0, "{}", ""),
                 CompletedProcess(["pane", "read"], 0, "still idle", ""),
             ],
@@ -107,6 +122,21 @@ class SendRequestTest(unittest.TestCase):
         diagnostics = stderr
         self.assertIn("request_delivery_failed", diagnostics)
         self.assertIn("still idle", diagnostics)
+
+    def test_codex_slow_start_waits_full_timeout_then_diagnoses(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 1, "", ""),
+                CompletedProcess(["pane", "get"], 0, "{}", ""),
+                CompletedProcess(["pane", "read"], 0, "still idle", ""),
+            ],
+            agent="codex",
+            prompt="x" * 4000,
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("request_delivery_failed", stderr)
+        self.assertIn("still idle", stderr)
 
     def test_claude_activation_fails_then_diagnoses(self):
         rc, stderr = self._run(
@@ -143,10 +173,36 @@ class SendRequestTest(unittest.TestCase):
         self.assertIn("pane not found", stderr)
 
     def test_argument_validation(self):
-        with patch.object(sys, "argv", ["send_request.py", "--target", "w1:p2", "--agent", "claude", "--prompt", "x", "--activation-timeout", "40000"]):
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "send_request.py",
+                "--target",
+                "w1:p2",
+                "--agent",
+                "claude",
+                "--prompt",
+                "x",
+                "--activation-timeout",
+                "40000",
+            ],
+        ):
             with self.assertRaises(SystemExit) as ctx:
                 send_request.main()
         self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_opencode_starts_immediately_without_activation(self):
+        rc, stderr = self._run(
+            [
+                CompletedProcess(["pane", "run"], 0, "", ""),
+                CompletedProcess(["wait", "agent-status"], 0, "", ""),
+            ],
+            agent="opencode",
+            prompt="self introduction",
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
 
 
 if __name__ == "__main__":

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -99,6 +99,7 @@ fi
         self.assertIn("herdr pane run", self.skill)
         self.assertIn("herdr wait agent-status", self.skill)
         self.assertIn("herdr pane read", self.skill)
+        self.assertTrue((ROOT / "scripts" / "send_request.py").exists())
         removed_scripts = ["wait_for_" + "completion.py", "task_" + "exchange.py"]
         for name in removed_scripts:
             self.assertNotIn(name, self.skill)
@@ -167,7 +168,7 @@ fi
             )
         return blocks
 
-    def test_request_delivery_uses_pane_run_only(self):
+    def test_request_delivery_uses_send_request_script(self):
         skill_blocks = self._request_delivery_command_blocks(
             self.skill, "依頼を直接送る"
         )
@@ -175,14 +176,26 @@ fi
             self.reference, "依頼送信"
         )
         for blocks in (skill_blocks, reference_blocks):
-            # 少なくとも1つの実行例で pane run を使う
+            # 少なくとも1つの実行例で send_request.py を使う
             self.assertTrue(
-                any("herdr pane run" in block for block in blocks),
-                "依頼送信セクションに pane run の実行例がありません",
+                any("send_request.py" in block for block in blocks),
+                "依頼送信セクションに send_request.py の実行例がありません",
             )
             # セクション内の全 bash コードブロックに agent send が混入していない
             for block in blocks:
                 self.assertNotIn("herdr agent send", block)
+
+        script_path = ROOT / "scripts" / "send_request.py"
+        self.assertTrue(script_path.exists(), "send_request.py が存在しません")
+        self.assertTrue(
+            script_path.stat().st_mode & 0o111,
+            "send_request.py が実行可能ではありません",
+        )
+
+    def test_claude_pasted_text_fallback_is_documented(self):
+        for text in (self.skill, self.reference):
+            self.assertIn("[Pasted text", text)
+            self.assertIn("Claude Code", text)
 
     def test_agent_send_is_not_used_for_request_execution(self):
         for text in (self.skill, self.reference):

--- a/herdr-github-implement-pr/references/implementation-delegation.md
+++ b/herdr-github-implement-pr/references/implementation-delegation.md
@@ -66,7 +66,7 @@ Herdr 外、CLI 不足、認証・trust 待ちは実装委譲失敗とする。�
 - Herdr の Completion contract に従って結果を確定すること
 ```
 
-依頼本文を `herdr pane run` または `herdr agent send` で直接送り、処理開始を確認して完了まで待つ。`blocked` とtimeoutは成功扱いせず、paneと作業ツリーを保持して停止する。
+依頼本文は `herdr-agent-delegate` の `scripts/send_request.py` を使って送り、処理開始を確認して完了まで待つ。`blocked` とtimeoutは成功扱いせず、paneと作業ツリーを保持して停止する。
 
 ## 5. ユーザー判断事項を処理する
 


### PR DESCRIPTION
## Issues

- Close #174

## Why

`herdr-agent-delegate` スキルで Claude Code へ長文依頼を `herdr pane run` 単発で送ると、入力欄が `[Pasted text #1]` のまま `working` に遷移しない問題がある。

## Summary

Claude の長文ペーストの自動実行を支援する `send_request.py` を追加し、全 Agent の依頼送信をこのスクリプトに統一する。

## Changes

- `herdr-agent-delegate/scripts/send_request.py` を追加
  - `herdr pane run` で依頼を送信
  - Claude のみ、`[Pasted text #1]` で留まった場合に短い活性化プロンプトを追加送信
  - それでも `working` にならない場合は読み取り専用で診断して停止
- `herdr-agent-delegate/SKILL.md` と `references/agent-cli.md` の送信手順を `send_request.py` に更新
- `tests/test_send_request.py` を新規追加
- `tests/test_skill_contract.py` を `send_request.py` ベースに更新

## Checklist

- [x] テスト
- [x] validate-skills
- [x] Claude Code 手動E2E確認（長文・短文）
