### PR TITLE
fix(herdr-agent-delegate): prevent --no-focus from leaking into pane run

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -71,7 +71,7 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
 4. その他のCLIは `references/agent-cli.md` の条件を使う。条件が未定義、またはtrust/login/初期設定画面なら自動承認せず停止する。
 5. セッション名が指定されていれば `herdr agent rename <pane-id> '<name>'` を実行する。
 
-起動、semantic検出、入力可能確認は別々に行う。バックグラウンド操作には `--no-focus` を使い、別クライアントのフォーカスに依存しない。
+起動、semantic検出、入力可能確認は別々に行う。pane 配置（`herdr pane split` や `herdr tab create`）には必要に応じて `--no-focus` を使い、親クライアントのフォーカスを奪わない。Agent 起動・依頼送信に使う `herdr pane run <pane-id> '<agent-command>'` には `--no-focus` を追加しない。`--no-focus` は pane 配置コマンドのフォーカス制御オプションであり、`pane run` の引数に混入すると `codex --no-focus` など未対応引数エラーで起動に失敗する。
 
 ## 5. 依頼を直接送る
 

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -9,7 +9,7 @@
 | OpenCode | `opencode` | 入力欄フッター `ctrl+p commands` |
 | その他 | ユーザー指定 | 事前に定義できる固有プロンプト |
 
-ユーザー指定の引数だけを起動コマンドへ渡す。コマンドはシェル文字列を組み立てず、`herdr pane run <pane-id> '<command>'` の1引数として送る。
+ユーザー指定の引数だけを起動コマンドへ渡す。コマンドはシェル文字列を組み立てず、`herdr pane run <pane-id> '<command>'` の1引数として送る。`--no-focus` は `herdr pane split` や `herdr tab create` などの pane 配置操作で使うフォーカス制御オプションであり、`herdr pane run` には追加しない。`herdr pane run <pane-id> '<command>' --no-focus` とすると `<command>` の引数として解釈され、`codex --no-focus` などで起動に失敗する。
 
 新規起動は次の公式プリミティブを順に使う。
 

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -9,7 +9,7 @@
 | OpenCode | `opencode` | 入力欄フッター `ctrl+p commands` |
 | その他 | ユーザー指定 | 事前に定義できる固有プロンプト |
 
-ユーザー指定の引数だけを起動コマンドへ渡す。コマンドはシェル文字列を組み立てず、`herdr pane run <pane-id> '<command>'` の1引数として送る。`--no-focus` は `herdr pane split` や `herdr tab create` などの pane 配置操作で使うフォーカス制御オプションであり、`herdr pane run` には追加しない。`herdr pane run <pane-id> '<command>' --no-focus` とすると `<command>` の引数として解釈され、`codex --no-focus` などで起動に失敗する。
+ユーザー指定の引数だけを起動コマンドへ渡す。コマンドはシェル文字列を組み立てず、`herdr pane run <pane-id> '<command>'` の1引数として送る。`--no-focus` は `herdr pane split` や `herdr tab create` などの pane 配置操作で使うフォーカス制御オプションであり、`herdr pane run` には追加しない。`herdr pane run <pane-id> '<command>'` の後ろに `--no-focus` を付けると `<command>` の引数として解釈され、`codex --no-focus` などで起動に失敗する。
 
 新規起動は次の公式プリミティブを順に使う。
 

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -204,6 +204,38 @@ fi
                 'herdr agent send <pane-id> "<依頼本文>"', text
             )
 
+    def test_pane_run_examples_do_not_contain_no_focus(self):
+        """`herdr pane run` のコマンド例そのものに `--no-focus` が混入していないことを確認する。"""
+        # 引用符で閉じられたコマンド例までをマッチ対象とする
+        pane_run_pattern = re.compile(
+            r"herdr pane run\s+[^'\"\n]*['\"][^'\"\n]*['\"]"
+        )
+        for text in (self.skill, self.reference):
+            matches = list(pane_run_pattern.finditer(text))
+            self.assertTrue(
+                matches,
+                "`herdr pane run` の実行例が見つかりません",
+            )
+            for match in matches:
+                command = match.group(0)
+                self.assertNotIn(
+                    "--no-focus",
+                    command,
+                    f"`herdr pane run` の例に `--no-focus` が混入しています: {command.strip()}",
+                )
+
+    def test_no_focus_is_for_layout_operations_not_pane_run(self):
+        """`--no-focus` は pane 配置操作のオプションであり、`pane run` ではないことを確認する。"""
+        for text in (self.skill, self.reference):
+            self.assertIn("--no-focus", text)
+            self.assertIn("pane split", text)
+            self.assertIn("tab create", text)
+            self.assertTrue(
+                "herdr pane run <pane-id> '<agent-command>'" in text
+                or "herdr pane run <pane-id> '<command>'" in text,
+                "`herdr pane run <pane-id> '<agent-command>'` の形式が明記されていません",
+            )
+
     def test_timeout_diagnosis_is_read_only_and_does_not_resend(self):
         skill_section = self._request_delivery_section(
             self.skill, "依頼を直接送る"

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -205,24 +205,19 @@ fi
             )
 
     def test_pane_run_examples_do_not_contain_no_focus(self):
-        """`herdr pane run` のコマンド例そのものに `--no-focus` が混入していないことを確認する。"""
-        # 引用符で閉じられたコマンド例までをマッチ対象とする
-        pane_run_pattern = re.compile(
-            r"herdr pane run\s+[^'\"\n]*['\"][^'\"\n]*['\"]"
+        """引用符で閉じた Agent コマンドの後ろに `--no-focus` がないことを確認する。"""
+        pane_run_with_no_focus = re.compile(
+            r"herdr pane run\s+[^\n`]*?['\"][^'\"\n]*['\"]\s+--no-focus\b"
         )
         for text in (self.skill, self.reference):
-            matches = list(pane_run_pattern.finditer(text))
-            self.assertTrue(
-                matches,
-                "`herdr pane run` の実行例が見つかりません",
-            )
-            for match in matches:
-                command = match.group(0)
-                self.assertNotIn(
-                    "--no-focus",
-                    command,
-                    f"`herdr pane run` の例に `--no-focus` が混入しています: {command.strip()}",
-                )
+            self.assertNotRegex(text, pane_run_with_no_focus)
+
+    def test_pane_run_contract_rejects_arguments_after_agent_command(self):
+        pane_run_with_no_focus = re.compile(
+            r"herdr pane run\s+[^\n`]*?['\"][^'\"\n]*['\"]\s+--no-focus\b"
+        )
+        reproduction = "herdr pane run w24:p7 'codex' --no-focus"
+        self.assertRegex(reproduction, pane_run_with_no_focus)
 
     def test_no_focus_is_for_layout_operations_not_pane_run(self):
         """`--no-focus` は pane 配置操作のオプションであり、`pane run` ではないことを確認する。"""


### PR DESCRIPTION
## Issues

- Close #178

## Why

`herdr-agent-delegate/SKILL.md` における「バックグラウンド操作には `--no-focus` を使う」という記述が、`herdr pane run` にも適用できるように読めていた。実際には `herdr pane run <pane_id> <command>` の構文上、`--no-focus` を追加すると Agent コマンド側の引数として解釈され、`codex --no-focus` などで起動に失敗するため、適用対象を明確に区別する必要がある。

## Summary

`--no-focus` の適用対象を pane 配置操作（`herdr pane split` / `herdr tab create`）に限定し、`herdr pane run <pane-id> '<agent-command>'` には追加しないことを文書化し、契約テストで検証する。

## Changes

- `herdr-agent-delegate/SKILL.md`
  - `--no-focus` の適用対象を `herdr pane split` / `herdr tab create` に限定
  - `herdr pane run <pane-id> '<agent-command>'` への `--no-focus` 追加を禁止
  - pane 配置と Agent 起動・依頼送信の役割を区別
- `herdr-agent-delegate/references/agent-cli.md`
  - `herdr pane run` への `--no-focus` 追加が Agent コマンドの引数として解釈されることを明記
  - pane 配置操作と `pane run` のフォーカス制御の違いを補足
- `herdr-agent-delegate/tests/test_skill_contract.py`
  - `herdr pane run` のコマンド例に `--no-focus` が混入していないことを検証する契約テストを追加
  - `--no-focus` が pane 配置操作のオプションであることを検証する契約テストを追加

## Checklist

- [x] テスト
