### PR TITLE
fix(herdr-agent-delegate): extend completion timeout to 30 minutes

### DIFF
--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -116,7 +116,7 @@ case "$tab_focused" in
 esac
 
 wait_rc=0
-herdr wait agent-status "$target_pane_id" --status "$wait_status" --timeout 120000 || wait_rc=$?
+herdr wait agent-status "$target_pane_id" --status "$wait_status" --timeout 1800000 || wait_rc=$?
 final_pane_json="$(herdr pane get "$target_pane_id")"
 final_status="$(printf '%s' "$final_pane_json" | jq -r '.result.pane.agent_status // empty')"
 
@@ -133,7 +133,7 @@ esac
 ```
 <!-- completion-wait-contract:end -->
 
-foreground tabは `idle`、background tabは `done` を待つ。待機中にattention stateが変わる可能性があるため、waitがtimeoutしても直ちに未完了とせず、最後の `pane get` では `idle` と `done` の双方を完了扱いにする。最終状態が `working`、`blocked`、`unknown`、または取得不能なら完了扱いしない。
+foreground tabは `idle`、background tabは `done` を最大30分待つ。イベント駆動待機のため、完了時は上限を待たずに戻る。待機中にattention stateが変わる可能性があるため、waitがtimeoutしても直ちに未完了とせず、最後の `pane get` では `idle` と `done` の双方を完了扱いにする。最終状態が `working`、`blocked`、`unknown`、または取得不能なら完了扱いしない。
 
 完了後は公式の読み取りを直接使う。
 

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -83,6 +83,13 @@ fi
         self.assertEqual(returncode, 0)
         self.assertIn("--status done", wait_command)
 
+    def test_completion_wait_timeout_is_thirty_minutes(self):
+        returncode, wait_command = self.run_completion_contract(
+            focused=True, final_status="idle"
+        )
+        self.assertEqual(returncode, 0)
+        self.assertIn("--timeout 1800000", wait_command)
+
     def test_final_idle_is_accepted_after_wait_timeout(self):
         returncode, _ = self.run_completion_contract(
             focused=False, final_status="idle", wait_rc=124


### PR DESCRIPTION
## Why

Herdr Agentへ委譲する実装やレビューは2分を超えることがあり、処理中でも完了待機がタイムアウトして停止していました。

## Summary

イベント駆動の完了待機上限を2分から30分へ延長します。Agentが早く完了した場合は従来どおり即座に復帰し、タイムアウト後の最終状態確認も維持します。

## Changes

- Completion contractの待機上限を`120000` msから`1800000` msへ変更
- 最大30分のイベント駆動待機であることを明記
- 30分の待機上限を保証する契約テストを追加

## Checklist

- [x] `python3 -m unittest discover -s herdr-agent-delegate/tests -v`（46 tests passed）
- [x] `python3 /home/u7dev/.codex/skills/.system/skill-creator/scripts/quick_validate.py herdr-agent-delegate`
- [x] `bash scripts/validate-skills.sh`
- [x] `git diff --check`
