### PR TITLE
feat: cagentを使うcoding-agent-subagent Skillを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 |-------|-------------|
 | [herdr-worktree-create](herdr-worktree-create/SKILL.md) | Herdr 公式コマンドで独立した worktree と workspace を作成する |
 | [herdr-github-implement-pr](herdr-github-implement-pr/SKILL.md) | Issue 確認から Herdr Agent による実装、PR 作成、レビュー・FB 対応までを一連で進める |
+| [coding-agent-subagent](coding-agent-subagent/SKILL.md) | Herdr委譲向けにcagentで基礎Agent種別と対話起動コマンドを解決する |
 | [herdr-agent-delegate](herdr-agent-delegate/SKILL.md) | Herdr公式プリミティブでCLI Agentを1タブあたり最大4paneに配置し、送信・待機・出力回収を行う |
 | [herdr-prompt-eval-loop](herdr-prompt-eval-loop/SKILL.md) | Herdrの独立Agentでプロンプトを反復実行し、非公開要件による評価と最小改善を行う |
 | [html-artifact-format](html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLを判断し、視覚化要素入りの単一HTMLを生成する |

--- a/coding-agent-subagent/SKILL.md
+++ b/coding-agent-subagent/SKILL.md
@@ -33,7 +33,9 @@ description: >
 
 ユーザー指定をコスト最適化や独自判断で変更しない。明示された値だけを対応するCLIオプションへ渡す。
 
-- agent未指定: agentを推測せず `--agent` を省略し、`default_agent` に任せる。
+- agentの実効値はcagentと同じ `ユーザー明示の --agent > CAGENT_AGENT > config.default_agent` の優先順位で確定する。
+- agent未指定: agentを推測せず `--agent` を省略する。`CAGENT_AGENT` が設定されていればその値、なければ `default_agent` を選択対象とする。
+- `base-agent-type` は、この優先順位で選んだ同じagent IDのprovider / adapterから解決する。
 - model未指定: `--model` を省略する。
 - effort未指定: `--effort` を省略する。
 - level未指定: 次節で判断し、判断不能な場合だけlevelを省略して `default_level` に任せる。
@@ -74,7 +76,7 @@ cagent --agent codex --model gpt-5.6-sol --effort high high
 cagent
 ```
 
-agent未指定でも、doctorで検証された `default_agent` のprovider / adapterから `base-agent-type` を解決する。`agent-command` の実行ファイル名から推測しない。
+agent未指定でも、`CAGENT_AGENT` が設定されていればそのagent ID、なければdoctorで検証された `default_agent` のprovider / adapterから `base-agent-type` を解決する。`agent-command` の実行ファイル名から推測しない。
 
 ## 5. Herdr委譲へ渡す
 

--- a/coding-agent-subagent/SKILL.md
+++ b/coding-agent-subagent/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: coding-agent-subagent
+description: >
+  Herdr上で設定済みのコーディングエージェントをサブエージェントとして起動するときに使う。
+  pane操作を担うHerdr委譲Skillと併用し、cagentでagent、task level、model、effortを解決して、基礎Agent種別と既存pane向け対話起動コマンドを組み立てる。
+---
+
+# Coding Agent Subagent
+
+`cagent` に選択と起動を任せ、Herdr の pane 操作は Herdr 委譲側に任せる。結果は必ず次の2値に分ける。
+
+- `base-agent-type`: 入力可能判定・送信・完了判定に使う実体のAgent種別（`codex` / `claude` / `opencode` など）
+- `agent-command`: 既存paneで実行する `cagent ...` の対話起動コマンド
+
+ラッパー名 `cagent` を `base-agent-type` として扱わない。
+
+## 1. プリフライト
+
+1. `HERDR_ENV=1` と空でない `HERDR_PANE_ID` を確認する。満たさなければ停止する。
+2. `command -v herdr` と `command -v cagent` を確認する。自動インストールしない。
+3. `cagent doctor` を実行する。失敗または `ERROR` があれば停止する。
+4. doctorで検証済みの設定から、選択対象のagent IDと、そのprovider / adapterに対応する `base-agent-type` を確認する。対応種別を特定できなければ停止する。
+
+いずれかに失敗しても `codex`、`claude`、`opencode` などを直接起動して回避しない。paneを作成・操作する前に失敗理由を報告する。
+
+## 2. 明示指定を確定する
+
+優先順位を次に固定する。
+
+1. ユーザーが明示し、依頼から理解した `agent` / `level` / `model` / `effort`
+2. このSkillによるtask level判断
+3. cagent configの `default_agent` / `default_level` / model / effort
+
+ユーザー指定をコスト最適化や独自判断で変更しない。明示された値だけを対応するCLIオプションへ渡す。
+
+- agent未指定: agentを推測せず `--agent` を省略し、`default_agent` に任せる。
+- model未指定: `--model` を省略する。
+- effort未指定: `--effort` を省略する。
+- level未指定: 次節で判断し、判断不能な場合だけlevelを省略して `default_level` に任せる。
+
+## 3. task levelを判断する
+
+役割名では固定せず、タスク難度・影響範囲・失敗コストを合わせて判断する。
+
+| Level | 基準 | 例 |
+| --- | --- | --- |
+| `low` | 小さく反復的で、失敗しても容易にやり直せる | typo、README整形、単純調査、小さな文言修正 |
+| `mid` | 通常の実装・保守で、影響範囲が限定的 | 1〜数ファイルの実装、バグ修正、テスト追加、軽いrefactor |
+| `high` | 設計判断、広い影響範囲、高い失敗コストを伴う | architecture、認証・DB・CI設計、複雑な障害調査、破壊的変更前review |
+
+通常のreviewを常に `high`、通常の実装を常に `mid` とはしない。根拠を持って分類できない場合はlevelを省略する。
+
+## 4. 対話起動コマンドを組み立てる
+
+次の順で、値が確定した要素だけを追加する。levelは位置引数にする。
+
+```bash
+cagent [--agent <agent>] [--model <model>] [--effort <effort>] [<level>]
+```
+
+例:
+
+```bash
+# agent未指定、通常実装
+cagent mid
+
+# agentとlevelを明示
+cagent --agent opencode-go high
+
+# agent、model、effort、levelを明示
+cagent --agent codex --model gpt-5.6-sol --effort high high
+
+# levelを判断できないためconfigへ委ねる
+cagent
+```
+
+agent未指定でも、doctorで検証された `default_agent` のprovider / adapterから `base-agent-type` を解決する。`agent-command` の実行ファイル名から推測しない。
+
+## 5. Herdr委譲へ渡す
+
+`base-agent-type` と `agent-command` を分離したまま渡す。Herdr委譲側は `agent-command` を既存paneで起動し、readiness・依頼送信・完了判定には `base-agent-type` を使う。
+
+通常フローでは `cagent run`、`cagent mux start`、`cagent mux run` を使わない。`cagent` が指定値や設定を解決できない場合も直接CLIへfallbackせず停止する。

--- a/coding-agent-subagent/SKILL.md
+++ b/coding-agent-subagent/SKILL.md
@@ -18,10 +18,9 @@ description: >
 
 1. `HERDR_ENV=1` と空でない `HERDR_PANE_ID` を確認する。満たさなければ停止する。
 2. `command -v herdr` と `command -v cagent` を確認する。自動インストールしない。
-3. `cagent doctor` を実行する。失敗または `ERROR` があれば停止する。
-4. doctorで検証済みの設定から、選択対象のagent IDと、そのprovider / adapterに対応する `base-agent-type` を確認する。対応種別を特定できなければ停止する。
+3. `cagent --help` を実行し、rootの対話起動、`doctor`、`--dry-run`、`--agent`、`--model`、`--effort`、任意のlevel位置引数が表示されることを確認する。実行失敗または不足があれば、必要なcapabilityを欠く非互換binとして停止する。
 
-いずれかに失敗しても `codex`、`claude`、`opencode` などを直接起動して回避しない。paneを作成・操作する前に失敗理由を報告する。
+いずれかに失敗しても `codex`、`claude`、`opencode` などを直接起動して回避しない。paneを作成・操作する前に、失敗した確認項目と理由を報告する。
 
 ## 2. 明示指定を確定する
 
@@ -76,7 +75,13 @@ cagent --agent codex --model gpt-5.6-sol --effort high high
 cagent
 ```
 
-agent未指定でも、`CAGENT_AGENT` が設定されていればそのagent ID、なければdoctorで検証された `default_agent` のprovider / adapterから `base-agent-type` を解決する。`agent-command` の実行ファイル名から推測しない。
+paneを作成する前に、選択値に依存する次のpreflightを順に行う。
+
+1. ユーザーがagentを明示した場合は `cagent --agent <agent> doctor`、明示しなかった場合は `cagent doctor` を実行する。後者では `CAGENT_AGENT` または `default_agent` がそのまま選択される。終了コードが非0、または出力に `ERROR` があれば、設定不整合や選択対象Agentのbin不在として停止する。
+2. 組み立てた `agent-command` と同じagent / model / effort / levelを指定し、`--dry-run` を加えたrootコマンドを実行する。終了コードが非0、または解決済みのAgent CLIコマンドを出力できなければ停止する。これはAgent CLIやpaneを起動せず、対話起動に必要な選択値とadapterの解決可否を検証するために使う。
+3. doctorで検証済みの同じ選択対象agent IDからprovider / adapterに対応する `base-agent-type` を確認する。対応種別を特定できなければ停止する。
+
+agent未指定でも、`CAGENT_AGENT` が設定されていればそのagent ID、なければdoctorで検証された `default_agent` のprovider / adapterから `base-agent-type` を解決する。`agent-command` の実行ファイル名から推測しない。preflight用の `--dry-run` は実際に渡す `agent-command` には含めない。
 
 ## 5. Herdr委譲へ渡す
 

--- a/coding-agent-subagent/agents/openai.yaml
+++ b/coding-agent-subagent/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Coding Agent Subagent"
+  short_description: "Herdr上でcagentの対話起動コマンドと基礎Agent種別を解決"
+  default_prompt: "Use $coding-agent-subagent to resolve the cagent interactive launch command for this Herdr delegation."

--- a/coding-agent-subagent/tests/test_skill_contract.py
+++ b/coding-agent-subagent/tests/test_skill_contract.py
@@ -16,8 +16,13 @@ class SkillContractTest(unittest.TestCase):
         for name in ("agent", "level", "model", "effort"):
             self.assertIn(name, self.skill)
 
-    def test_defaults_are_selected_by_omission(self):
+    def test_agent_resolution_matches_cagent_priority(self):
         self.assertIn("`--agent` を省略", self.skill)
+        priority = "`ユーザー明示の --agent > CAGENT_AGENT > config.default_agent`"
+        self.assertIn(priority, self.skill)
+        self.assertIn("この優先順位で選んだ同じagent ID", self.skill)
+
+    def test_defaults_are_selected_by_omission(self):
         self.assertIn("`default_agent`", self.skill)
         self.assertIn("levelを省略して `default_level`", self.skill)
 

--- a/coding-agent-subagent/tests/test_skill_contract.py
+++ b/coding-agent-subagent/tests/test_skill_contract.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+class SkillContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_user_values_have_highest_priority(self):
+        self.assertIn("ユーザーが明示", self.skill)
+        self.assertIn("ユーザー指定をコスト最適化や独自判断で変更しない", self.skill)
+        for name in ("agent", "level", "model", "effort"):
+            self.assertIn(name, self.skill)
+
+    def test_defaults_are_selected_by_omission(self):
+        self.assertIn("`--agent` を省略", self.skill)
+        self.assertIn("`default_agent`", self.skill)
+        self.assertIn("levelを省略して `default_level`", self.skill)
+
+    def test_preflight_failures_do_not_fallback(self):
+        for requirement in (
+            "HERDR_ENV=1",
+            "HERDR_PANE_ID",
+            "command -v cagent",
+            "cagent doctor",
+            "直接起動して回避しない",
+        ):
+            self.assertIn(requirement, self.skill)
+
+    def test_normal_flow_uses_only_interactive_cagent_command(self):
+        self.assertIn("cagent [--agent <agent>]", self.skill)
+        for forbidden in ("cagent " + "run", "cagent " + "mux"):
+            occurrences = [
+                line
+                for line in self.skill.splitlines()
+                if forbidden in line and "使わない" not in line
+            ]
+            self.assertEqual([], occurrences)
+
+    def test_handoff_separates_agent_type_from_command(self):
+        self.assertIn("base-agent-type", self.skill)
+        self.assertIn("agent-command", self.skill)
+        self.assertIn("ラッパー名 `cagent`", self.skill)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/coding-agent-subagent/tests/test_skill_contract.py
+++ b/coding-agent-subagent/tests/test_skill_contract.py
@@ -31,10 +31,27 @@ class SkillContractTest(unittest.TestCase):
             "HERDR_ENV=1",
             "HERDR_PANE_ID",
             "command -v cagent",
+            "cagent --help",
             "cagent doctor",
             "直接起動して回避しない",
         ):
             self.assertIn(requirement, self.skill)
+
+    def test_preflight_rejects_incompatible_or_unresolvable_cagent(self):
+        for capability in (
+            "rootの対話起動",
+            "`--dry-run`",
+            "`--agent`",
+            "`--model`",
+            "`--effort`",
+            "任意のlevel位置引数",
+        ):
+            self.assertIn(capability, self.skill)
+
+        self.assertIn("cagent --agent <agent> doctor", self.skill)
+        self.assertIn("同じagent / model / effort / level", self.skill)
+        self.assertIn("選択対象Agentのbin不在", self.skill)
+        self.assertIn("Agent CLIやpaneを起動せず", self.skill)
 
     def test_normal_flow_uses_only_interactive_cagent_command(self):
         self.assertIn("cagent [--agent <agent>]", self.skill)

--- a/herdr-agent-delegate/SKILL.md
+++ b/herdr-agent-delegate/SKILL.md
@@ -7,12 +7,19 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
 
 このスキルのディレクトリを `<skill-dir>` として絶対パスで解決する。Agent別の起動・入力可能条件は `references/agent-cli.md` を読む。
 
+新規Agentの起動契約は次の2値を分けて扱う。
+
+- `base-agent-type`: 入力可能判定・送信・完了判定に使う基礎Agent種別（`codex` / `claude` / `opencode` など）
+- `agent-command`: paneで実行する対話起動コマンド。直接CLIに限らず、基礎Agentを起動するラッパーコマンドも受け取れる
+
+`agent-command` の実行ファイル名から `base-agent-type` を推測しない。
+
 ## 1. プリフライト
 
 1. `HERDR_ENV=1` と空でない `HERDR_PANE_ID` を確認する。満たさなければHerdr外から対象を推測せず終了する。
-2. `command -v herdr`、`command -v jq`、利用するAgent CLIを確認する。自動インストールしない。
+2. `command -v herdr`、`command -v jq`、`agent-command` の起動プログラムを確認する。自動インストールしない。
 3. `herdr pane current --current` から現在の `pane_id`、`workspace_id`、`tab_id`、`cwd` を取得する。IDは応答から都度読み、推測・永続化しない。
-4. ユーザー指定がなければ現在のAgent種別とcwdを引き継ぐ。Agent種別も不明なら確認する。起動オプションは明示されたものだけを使う。
+4. ユーザー指定がなければ現在の基礎Agent種別とcwdを引き継ぐ。`base-agent-type` が不明なら確認する。`agent-command` が別の解決処理から渡された場合は書き換えず、未指定の場合だけ基礎Agent種別の既定の直接起動コマンドを使う。起動オプションは明示されたものだけを使う。
 
 ## 2. 宛先を解決する
 
@@ -59,23 +66,23 @@ description: Herdr上でCLI Agentへタスクを委譲し、公式プリミテ�
 
 ## 4. Agentを起動して入力可能まで待つ
 
-1. 分割レスポンスの `pane_id` に対して `herdr pane run <pane-id> '<agent-command>'` を実行する。
+1. 分割レスポンスの `pane_id` に対して `herdr pane run <pane-id> '<agent-command>'` を実行する。`agent-command` は1つのコマンド文字列として渡し、後ろに引数を追加しない。
 2. `herdr wait agent-status <pane-id> --status idle --timeout 30000` を別コマンドで実行する。このidleだけでは入力可能と判定しない。
-3. Codex、Claude Code、OpenCodeは次で入力欄を確認する。
+3. ラッパーコマンドの有無にかかわらず、`base-agent-type` がCodex、Claude Code、OpenCodeなら次で入力欄を確認する。
 
 ```bash
 <skill-dir>/scripts/wait_for_input_ready.py \
   --target <pane-id> --agent <codex|claude|opencode>
 ```
 
-4. その他のCLIは `references/agent-cli.md` の条件を使う。条件が未定義、またはtrust/login/初期設定画面なら自動承認せず停止する。
+4. その他の基礎Agent種別は `references/agent-cli.md` の条件を使う。条件が未定義、またはtrust/login/初期設定画面なら自動承認せず停止する。
 5. セッション名が指定されていれば `herdr agent rename <pane-id> '<name>'` を実行する。
 
 起動、semantic検出、入力可能確認は別々に行う。pane 配置（`herdr pane split` や `herdr tab create`）には必要に応じて `--no-focus` を使い、親クライアントのフォーカスを奪わない。Agent 起動・依頼送信に使う `herdr pane run <pane-id> '<agent-command>'` には `--no-focus` を追加しない。`--no-focus` は pane 配置コマンドのフォーカス制御オプションであり、`pane run` の引数に混入すると `codex --no-focus` など未対応引数エラーで起動に失敗する。
 
 ## 5. 依頼を直接送る
 
-入力可能を確認した新規Agentには、依頼本文をEnter込みで原子的に送る。`herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、依頼の実行開始が必要な送信には使わない。Agent種別ごとの差異は `send_request.py` で吸収する。
+入力可能を確認した新規Agentには、依頼本文をEnter込みで原子的に送る。`herdr agent send <pane-id> "<文字列>"` は文字列入力のみを行いEnterを送らないため、依頼の実行開始が必要な送信には使わない。基礎Agent種別ごとの差異は `send_request.py` で吸収し、`--agent` には `base-agent-type` を渡す。
 
 ```bash
 <skill-dir>/scripts/send_request.py \

--- a/herdr-agent-delegate/references/agent-cli.md
+++ b/herdr-agent-delegate/references/agent-cli.md
@@ -1,15 +1,17 @@
 # Agent CLI運用差分
 
-## 起動と入力可能確認
+## 起動契約と入力可能確認
 
-| Agent | 起動コマンド | `wait_for_input_ready.py` の表示条件 |
+`base-agent-type` と `agent-command` を分ける。前者は入力可能判定・送信・完了判定に、後者はpaneでの起動だけに使う。`agent-command` がラッパーでも、実体に対応する `base-agent-type` を使い、実行ファイル名から推測しない。
+
+| `base-agent-type` | 未指定時の直接起動コマンド | `wait_for_input_ready.py` の表示条件 |
 | --- | --- | --- |
-| Codex | `codex` | 行頭の入力プロンプト `›` |
-| Claude Code | `claude` | 行頭の入力プロンプト `❯` |
-| OpenCode | `opencode` | 入力欄フッター `ctrl+p commands` |
+| `codex` | `codex` | 行頭の入力プロンプト `›` |
+| `claude` | `claude` | 行頭の入力プロンプト `❯` |
+| `opencode` | `opencode` | 入力欄フッター `ctrl+p commands` |
 | その他 | ユーザー指定 | 事前に定義できる固有プロンプト |
 
-ユーザー指定の引数だけを起動コマンドへ渡す。コマンドはシェル文字列を組み立てず、`herdr pane run <pane-id> '<command>'` の1引数として送る。`--no-focus` は `herdr pane split` や `herdr tab create` などの pane 配置操作で使うフォーカス制御オプションであり、`herdr pane run` には追加しない。`herdr pane run <pane-id> '<command>'` の後ろに `--no-focus` を付けると `<command>` の引数として解釈され、`codex --no-focus` などで起動に失敗する。
+別の解決処理から渡された `agent-command` は書き換えない。未指定の場合だけ、`base-agent-type` に対応する直接起動コマンドへユーザー指定の引数を加える。コマンドは `herdr pane run <pane-id> '<command>'` の1引数として送る。`--no-focus` は `herdr pane split` や `herdr tab create` などの pane 配置操作で使うフォーカス制御オプションであり、`herdr pane run` には追加しない。`herdr pane run <pane-id> '<command>'` の後ろに `--no-focus` を付けると `<command>` の引数として解釈され、`codex --no-focus` などで起動に失敗する。
 
 新規起動は次の公式プリミティブを順に使う。
 

--- a/herdr-agent-delegate/tests/test_skill_contract.py
+++ b/herdr-agent-delegate/tests/test_skill_contract.py
@@ -112,6 +112,15 @@ fi
             self.assertNotIn(name, self.skill)
             self.assertFalse((ROOT / "scripts" / name).exists())
 
+    def test_base_agent_type_and_launch_command_are_separate(self):
+        for text in (self.skill, self.reference):
+            self.assertIn("base-agent-type", text)
+            self.assertIn("agent-command", text)
+            self.assertIn("推測しない", text)
+
+        self.assertIn("--agent` には `base-agent-type`", self.skill)
+        self.assertIn("別の解決処理から渡された `agent-command` は書き換えない", self.reference)
+
     def test_removed_environment_variables_are_not_documented(self):
         prefix = "HERDR" + "_DELEGATE_"
         suffixes = (


### PR DESCRIPTION
## Issues

- Close #161

## Why

Herdr 上でコーディングエージェントを委譲するときに、`cagent` の agent・task level・model・effort 解決を既存の pane 管理と安全に組み合わせる必要があるためです。

## Summary

`coding-agent-subagent` Skill を追加し、`cagent` が解決する対話起動コマンドと基礎 Agent 種別を Herdr 委譲へ引き渡す契約を定義しました。あわせて `herdr-agent-delegate` を、基礎 Agent 種別と起動コマンドを分離して扱えるよう一般化しました。

## Changes

- ユーザー指定を最優先し、未指定値を cagent config へ委ねる規則を追加
- タスク難度・影響範囲・失敗コストに基づく `low` / `mid` / `high` 判断を追加
- Herdr・`cagent`・`cagent doctor` の preflight と直接 CLI fallback 禁止を追加
- `base-agent-type` と `agent-command` を分離する Herdr 委譲契約を追加
- 新規・既存契約のテストを追加
- README の Available Skills を同期

## Verification

- [x] Skill Creator quick validation
- [x] `python3 -m unittest discover -s coding-agent-subagent/tests -v`（5件）
- [x] `python3 -m unittest discover -s herdr-agent-delegate/tests -v`（47件）
- [x] `bash scripts/validate-skills.sh`（32 Skill）
- [x] `git diff --check`
- [x] 独立 Agent による Description 連鎖の forward test
