### PR TITLE
feat: add delegated issue creation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | Skill | Description |
 |-------|-------------|
 | [github-issue-create-from-plan](github-issue-create-from-plan/SKILL.md) | 設計プラン合意後に GitHub Issue を作成する |
+| [herdr-github-create-issue](herdr-github-create-issue/SKILL.md) | 確定済みプランの Issue 作成を Herdr の新規 Agent へ委譲する |
 | [github-pr-create](github-pr-create/SKILL.md) | PR 本文生成を含めて GitHub に PR を作成する |
 | [github-pr-feedback-address](github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う |
 | [github-pr-review](github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う |

--- a/herdr-github-create-issue/SKILL.md
+++ b/herdr-github-create-issue/SKILL.md
@@ -2,7 +2,7 @@
 name: herdr-github-create-issue
 description: >
   Herdr上で確定済みプランのGitHub Issue作成をcagent lowの新規Agentへ委譲し、
-  AI作業メタ情報と作成結果を確認する。
+  AI Work Metadataと作成結果を確認する。
 ---
 
 # Herdr GitHub Create Issue
@@ -26,7 +26,7 @@ description: >
 作成Issue本文の最終セクションは必ず次の形にする。追加の最終セクションを置かない。
 
 ```markdown
-## AI作業メタ情報
+## AI Work Metadata
 
 | Role | Agent | Model | Effort |
 | --- | --- | --- | --- |
@@ -40,6 +40,7 @@ description: >
 2. `coding-agent-subagent`のpreflightを実施する。Agent、Model、Effortは指定せず、task levelだけを`low`と判断して、対話起動コマンドを必ず`cagent low`として解決する。doctor、dry-run、provider / adapterから`base-agent-type`を確認できなければ停止する。
 3. 既存idle Agentは検索も再利用もしない。`herdr-agent-delegate`の新規pane配置、ID検証、`herdr pane run`、semantic検出、input-ready確認を順に適用し、今回のIssue作成担当だけを起動する。`agent-command`と`base-agent-type`を混同せず、`pane run`へ`--no-focus`を渡さない。
 4. 入力可能確認後にだけ、同スキルの`send_request.py`で依頼をEnter込みで一度だけ送信し、working遷移を確認する。送信失敗時は読み取り専用で状態を回収し、paneを保持して停止する。
+5. 送信前に親が、対象cwd、`git status --short`の出力、`git rev-parse HEAD`、現在ブランチとその対象remote refのOIDまたは不存在をスナップショットとして保持する。remote refは実際のremoteから`git ls-remote --heads`で取得する。さらに対象リポジトリで認証ユーザーが作成したIssue一覧とPR一覧を、それぞれ`gh issue list --author @me --state all --limit 1000 --json number,url`、`gh pr list --author @me --state all --limit 1000 --json number,url`で記録する。取得不能なら送信せず停止する。
 
 ## 3. Issue作成担当への依頼
 
@@ -50,7 +51,7 @@ description: >
 - プラン作成、再壁打ち、再設計、プランの補完、HTML確認・生成をしないこと
 - 規模に応じてテンプレートを片方だけ選び、既存Labelを確認し、具体例・表・コード・設計判断を保持すること
 - 本文を一時ファイルへ書き、gh issue create --body-file で対象リポジトリへ起票すること
-- 本文の最後に、親から渡された値をそのまま使う「## AI作業メタ情報」表を追加すること。不明セルは — とすること
+- 本文の最後に、親から渡された値をそのまま使う「## AI Work Metadata」表を追加すること。不明セルは — とすること
 - gh issue view でURL、title、labels、本文末尾のメタ情報表を確認すること
 - 別Agentへの再委譲、実装、commit、push、PR作成をしないこと
 - Issue URL、title、labels、確認したメタ情報、未解決事項、ユーザー判断事項を返すこと
@@ -63,14 +64,16 @@ description: >
 
 親は対象tabのfocused状態に応じて、HerdrのCompletion contractどおりforegroundでは`idle`、backgroundでは`done`を最大30分待つ。waitの終了理由にかかわらず`herdr pane get`を再取得し、最終状態が`idle`または`done`の場合だけ`recent-unwrapped`の出力を回収する。`working`、`blocked`、`unknown`、取得不能は未完了である。
 
-正常回収後、親は子の報告だけで成功とせず、`gh issue view <url> --json url,title,labels,body`で次を直接確認する。
+正常回収後、親は子の報告だけで成功とせず、`herdr pane read --source recent-unwrapped`の実行出力、送信前スナップショット、GitHub側の作成物を照合する。次をすべて直接確認する。
 
 - URL、title、labelsが子の報告と一致する。
 - 本文に確定済みプランの必要な具体例と判断が保持されている。
-- 本文の最終セクションが`## AI作業メタ情報`で、壁打ちとIssue作成の2行だけを持ち、渡した各セルまたは`—`と一致する。
-- 子が再設計、HTML生成、再委譲、実装、commit、push、PR作成をしていない。
+- `gh issue view <url> --json url,title,labels,body`で、本文の最終セクションが`## AI Work Metadata`であり、壁打ちとIssue作成の2行だけを持ち、渡した各セルまたは`—`と一致する。
+- 対象cwd、`git status --short`、HEAD、対象remote refのOIDまたは不存在が送信前スナップショットと完全一致する。差分、未追跡ファイル、commit、pushを検出した場合は成功にしない。
+- `gh issue list --author @me --state all --limit 1000 --json number,url`の差分は、子が返したURLと一致する今回のIssue 1件だけである。`gh pr list --author @me --state all --limit 1000 --json number,url`は送信前スナップショットと完全一致し、PR作成を検出していない。
+- pane出力と子の報告を最後まで読み、再設計、HTML生成、再委譲、実装、commit、push、PR作成の実行または試行がない。出力が欠ける、判定できない、またはGitHub側の作成物を照合できない場合も成功にしない。
 
-Completion contract、回収、上記確認をすべて満たした成功時だけ、親が今回作成したpaneをHerdr公式操作で閉じる。close後は対象paneが閉じたことを確認する。失敗、ユーザー判断待ち、確認不能、cleanup失敗ではpaneを診断用に保持し、既存paneや今回作成していない資源は閉じない。
+Completion contract、回収、上記確認をすべて満たした成功時だけ、親が今回作成したpaneをHerdr公式操作で閉じる。close後は対象paneが閉じたことを確認する。禁止操作の検出、スナップショット不一致、確認不能、失敗、ユーザー判断待ち、cleanup失敗ではpaneを診断用に保持して停止し、既存paneや今回作成していない資源は閉じない。
 
 ## 最終報告
 
@@ -80,7 +83,8 @@ Completion contract、回収、上記確認をすべて満たした成功時だ�
 
 - [ ] 確定済みプランがなければpaneを作らない
 - [ ] `cagent low`をAgent・Model・Effort無指定で解決し、毎回新規paneへ起動する
-- [ ] 2役割のメタ情報を推測せず、Issue本文の最終表へ伝達する
+- [ ] 2役割のメタ情報を推測せず、Issue本文の最終`## AI Work Metadata`表へ伝達する
 - [ ] `github-issue-create-from-plan`のIssue生成・作成工程だけを適用し、既存スキルを変更しない
+- [ ] 作業ツリー、HEAD、対象remote ref、GitHubのIssue/PR一覧を送信前後で比較し、禁止操作または確認不能ならpaneを保持して停止する
 - [ ] `gh issue view`でURL、title、labels、本文末尾を親が確認する
 - [ ] 成功時だけ今回作成したpaneを閉じ、失敗時は保持する

--- a/herdr-github-create-issue/SKILL.md
+++ b/herdr-github-create-issue/SKILL.md
@@ -19,9 +19,9 @@ description: >
 ## 1. 役割とメタ情報を確定する
 
 - 親の現在Agentを`壁打ち`、新規paneで起動するAgentを`Issue作成`とする。親を`オーケストレーター`として別行に記録しない。
-- 壁打ち担当は、`ai-identity-resolve`に従い、現在の実行環境からAgentとModelを直接取得する。Codexは読める場合に限り`~/.codex/config.toml`の`model`を使う。Effortは実行環境または明示設定から直接取得する。
+- 壁打ち担当は、`ai-identity-resolve`に従い、現在の実行環境からAgentとModelを直接取得する。Codexの場合、送信直前の再取得では読める場合に限り`~/.codex/config.toml`を親が直接再読込し、その時点の`model`を使う。会話開始時または過去の取得値を再利用しない。Effortは実行環境または明示設定から直接取得する。
 - Issue作成担当は、`cagent low`のdoctor / dry-runで解決されたAgent、Model、Effortを使う。起動コマンド、Agent種別、既定値からModelやEffortを推測しない。
-- 各セルは取得できない時だけ`—`とする。親は両役割の確定値を、起動前にスナップショットとして保持して子へ明示する。
+- 各セルは取得できない時だけ`—`とする。両役割の確定値は、入力可能確認後の送信直前に親がハンドオフ時点のスナップショットとして固定し、子へ明示する。子は親のAgent、Model、Effortを再解決、推測、上書きせず、渡された値をそのままAI Work Metadataに使う。
 
 作成Issue本文の最終セクションは必ず次の形にする。追加の最終セクションを置かない。
 
@@ -39,8 +39,11 @@ description: >
 1. `HERDR_ENV=1`、空でない`HERDR_PANE_ID`、`herdr`、`jq`、`cagent`、`gh`を確認し、`herdr pane current --current`から現在のIDと作業ディレクトリを都度取得する。
 2. `coding-agent-subagent`のpreflightを実施する。Agent、Model、Effortは指定せず、task levelだけを`low`と判断して、対話起動コマンドを必ず`cagent low`として解決する。doctor、dry-run、provider / adapterから`base-agent-type`を確認できなければ停止する。
 3. 既存idle Agentは検索も再利用もしない。`herdr-agent-delegate`の新規pane配置、ID検証、`herdr pane run`、semantic検出、input-ready確認を順に適用し、今回のIssue作成担当だけを起動する。`agent-command`と`base-agent-type`を混同せず、`pane run`へ`--no-focus`を渡さない。
-4. 入力可能確認後にだけ、同スキルの`send_request.py`で依頼をEnter込みで一度だけ送信し、working遷移を確認する。送信失敗時は読み取り専用で状態を回収し、paneを保持して停止する。
-5. 送信前に親が、対象cwd、`git status --short`の出力、`git rev-parse HEAD`、現在ブランチとその対象remote refのOIDまたは不存在をスナップショットとして保持する。remote refは実際のremoteから`git ls-remote --heads`で取得する。さらに対象リポジトリで認証ユーザーが作成したIssue一覧とPR一覧を、それぞれ`gh issue list --author @me --state all --limit 1000 --json number,url`、`gh pr list --author @me --state all --limit 1000 --json number,url`で記録する。取得不能なら送信せず停止する。
+4. 入力可能確認後、`send_request.py`で依頼を送信する直前に、親が次の順で送信前処理を完了する。途中で取得不能なら送信せず、paneを保持して停止する。
+   1. 親が、対象cwd、`git status --short`の出力、`git rev-parse HEAD`、現在ブランチとその対象remote refのOIDまたは不存在を送信前スナップショットとして保持する。remote refは実際のremoteから`git ls-remote --heads`で取得する。さらに対象リポジトリで認証ユーザーが作成したIssue一覧とPR一覧を、それぞれ`gh issue list --author @me --state all --limit 1000 --json number,url`、`gh pr list --author @me --state all --limit 1000 --json number,url`で記録する。
+   2. 送信の最後の準備として、壁打ち担当の識別情報を親が再取得する。親がCodexなら、この時点で親自身が`~/.codex/config.toml`を直接再読込し、`model`値を読めた場合はその値を使う。Configを読めない場合は、`ai-identity-resolve`の契約どおり、実行環境が提供する明示的なモデル情報を使い、それも取得できない場合のみModelを`—`とする。モデル名は推測せず、会話開始時または過去の取得値を使わない。
+   3. 再取得した壁打ち担当の値と、`cagent low`のdoctor / dry-runで解決済みのIssue作成担当の値を、ハンドオフ時点のメタ情報スナップショットとして固定する。依頼にはこの固定値を明示し、子は親の値を再解決、推測、上書きせず、そのままAI Work Metadataに使う。
+   4. 確定済みプラン原文、対象リポジトリ、固定したメタ情報表、送信指示を含む依頼を組み立て、同スキルの`send_request.py`でEnter込みで一度だけ送信する。Config再読込と送信の間に外部I/Oや識別情報の再取得を挟まない。送信後に壁打ち担当の識別情報を再取得または変更しない。送信失敗時は読み取り専用で状態を回収し、paneを保持して停止する。
 
 ## 3. Issue作成担当への依頼
 

--- a/herdr-github-create-issue/SKILL.md
+++ b/herdr-github-create-issue/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: herdr-github-create-issue
+description: >
+  Herdr上で確定済みプランのGitHub Issue作成をcagent lowの新規Agentへ委譲し、
+  AI作業メタ情報と作成結果を確認する。
+---
+
+# Herdr GitHub Create Issue
+
+確定済みプランをGitHub Issueへ起票する工程だけを、Herdrの新規paneで起動した安価なIssue作成担当へ同期委譲する。親は現在Agentを壁打ち担当として記録し、作成結果を確認する。壁打ち、プラン補完、再設計は行わない。
+
+## 使用条件と停止条件
+
+- Herdr環境で、ユーザーのIssue作成依頼、対象リポジトリ、会話内の確定済みプランがそろった時だけ使う。確定済みプランは、合意済みの`<proposed_plan>`または同等に最終版と明示された原文全体とする。
+- プランがない、未確定、対象リポジトリが不明、またはHerdr / `cagent` / `gh`のpreflightに失敗した場合、paneを作らずに停止する。Grill系スキルまたは設計会話で先にプランを確定するよう案内する。
+- `github-issue-create-from-plan`、`coding-agent-subagent`、`herdr-agent-delegate`、`ai-identity-resolve`を事前に読み、後者2つの起動・送信・Completion contractを適用する。本スキル固有の新規pane、責務、cleanup規則を優先する。
+- 自動再試行、親による代替起票、別Agentへの切替・再委譲はしない。失敗、`blocked`、timeout、Completion contract違反、作成結果の不一致ではpaneを保持して停止する。
+
+## 1. 役割とメタ情報を確定する
+
+- 親の現在Agentを`壁打ち`、新規paneで起動するAgentを`Issue作成`とする。親を`オーケストレーター`として別行に記録しない。
+- 壁打ち担当は、`ai-identity-resolve`に従い、現在の実行環境からAgentとModelを直接取得する。Codexは読める場合に限り`~/.codex/config.toml`の`model`を使う。Effortは実行環境または明示設定から直接取得する。
+- Issue作成担当は、`cagent low`のdoctor / dry-runで解決されたAgent、Model、Effortを使う。起動コマンド、Agent種別、既定値からModelやEffortを推測しない。
+- 各セルは取得できない時だけ`—`とする。親は両役割の確定値を、起動前にスナップショットとして保持して子へ明示する。
+
+作成Issue本文の最終セクションは必ず次の形にする。追加の最終セクションを置かない。
+
+```markdown
+## AI作業メタ情報
+
+| Role | Agent | Model | Effort |
+| --- | --- | --- | --- |
+| 壁打ち | `<agent>` | `<model>` | `<effort>` |
+| Issue作成 | `<agent>` | `<model>` | `<effort>` |
+```
+
+## 2. Issue作成担当を毎回新規起動する
+
+1. `HERDR_ENV=1`、空でない`HERDR_PANE_ID`、`herdr`、`jq`、`cagent`、`gh`を確認し、`herdr pane current --current`から現在のIDと作業ディレクトリを都度取得する。
+2. `coding-agent-subagent`のpreflightを実施する。Agent、Model、Effortは指定せず、task levelだけを`low`と判断して、対話起動コマンドを必ず`cagent low`として解決する。doctor、dry-run、provider / adapterから`base-agent-type`を確認できなければ停止する。
+3. 既存idle Agentは検索も再利用もしない。`herdr-agent-delegate`の新規pane配置、ID検証、`herdr pane run`、semantic検出、input-ready確認を順に適用し、今回のIssue作成担当だけを起動する。`agent-command`と`base-agent-type`を混同せず、`pane run`へ`--no-focus`を渡さない。
+4. 入力可能確認後にだけ、同スキルの`send_request.py`で依頼をEnter込みで一度だけ送信し、working遷移を確認する。送信失敗時は読み取り専用で状態を回収し、paneを保持して停止する。
+
+## 3. Issue作成担当への依頼
+
+依頼には、確定済みプラン原文、対象リポジトリ、両担当のメタ情報表、次をすべて含める。
+
+```text
+- $github-issue-create-from-plan を読み、同スキルのIssue生成・作成工程だけを適用すること
+- プラン作成、再壁打ち、再設計、プランの補完、HTML確認・生成をしないこと
+- 規模に応じてテンプレートを片方だけ選び、既存Labelを確認し、具体例・表・コード・設計判断を保持すること
+- 本文を一時ファイルへ書き、gh issue create --body-file で対象リポジトリへ起票すること
+- 本文の最後に、親から渡された値をそのまま使う「## AI作業メタ情報」表を追加すること。不明セルは — とすること
+- gh issue view でURL、title、labels、本文末尾のメタ情報表を確認すること
+- 別Agentへの再委譲、実装、commit、push、PR作成をしないこと
+- Issue URL、title、labels、確認したメタ情報、未解決事項、ユーザー判断事項を返すこと
+- HerdrのCompletion contractに従って結果を確定すること
+```
+
+`github-issue-create-from-plan`のプラン提示・モード分岐・HTML確認はこの委譲に含めない。Issue作成担当がプランの内容を変える必要を見つけた場合も起票せず、未解決事項またはユーザー判断事項として返す。
+
+## 4. 完了確認とcleanup
+
+親は対象tabのfocused状態に応じて、HerdrのCompletion contractどおりforegroundでは`idle`、backgroundでは`done`を最大30分待つ。waitの終了理由にかかわらず`herdr pane get`を再取得し、最終状態が`idle`または`done`の場合だけ`recent-unwrapped`の出力を回収する。`working`、`blocked`、`unknown`、取得不能は未完了である。
+
+正常回収後、親は子の報告だけで成功とせず、`gh issue view <url> --json url,title,labels,body`で次を直接確認する。
+
+- URL、title、labelsが子の報告と一致する。
+- 本文に確定済みプランの必要な具体例と判断が保持されている。
+- 本文の最終セクションが`## AI作業メタ情報`で、壁打ちとIssue作成の2行だけを持ち、渡した各セルまたは`—`と一致する。
+- 子が再設計、HTML生成、再委譲、実装、commit、push、PR作成をしていない。
+
+Completion contract、回収、上記確認をすべて満たした成功時だけ、親が今回作成したpaneをHerdr公式操作で閉じる。close後は対象paneが閉じたことを確認する。失敗、ユーザー判断待ち、確認不能、cleanup失敗ではpaneを診断用に保持し、既存paneや今回作成していない資源は閉じない。
+
+## 最終報告
+
+成功時はIssue URL、title、labels、確認済みメタ情報、閉じたpaneを返す。停止時はpane ID、状態、失敗箇所、回収出力、作成済みIssueの有無、未解決事項、必要なユーザー判断を返す。
+
+## 品質チェック
+
+- [ ] 確定済みプランがなければpaneを作らない
+- [ ] `cagent low`をAgent・Model・Effort無指定で解決し、毎回新規paneへ起動する
+- [ ] 2役割のメタ情報を推測せず、Issue本文の最終表へ伝達する
+- [ ] `github-issue-create-from-plan`のIssue生成・作成工程だけを適用し、既存スキルを変更しない
+- [ ] `gh issue view`でURL、title、labels、本文末尾を親が確認する
+- [ ] 成功時だけ今回作成したpaneを閉じ、失敗時は保持する

--- a/herdr-github-create-issue/agents/openai.yaml
+++ b/herdr-github-create-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Herdr GitHub Create Issue"
+  short_description: "確定済みプランのIssue作成をHerdr新規Agentへ安全に委譲する"
+  default_prompt: "Use $herdr-github-create-issue to delegate creation of a GitHub issue from a finalized plan through Herdr."

--- a/herdr-github-create-issue/tests/test_issue_creation_contract.py
+++ b/herdr-github-create-issue/tests/test_issue_creation_contract.py
@@ -1,0 +1,56 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+class IssueCreationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+        template = re.search(
+            r"```markdown\n(.*?)\n```", cls.skill, flags=re.DOTALL
+        )
+        assert template is not None
+        cls.issue_body_template = template.group(1)
+
+    def test_issue_body_ends_with_english_metadata_heading(self):
+        sections = re.split(r"^## ", self.issue_body_template, flags=re.MULTILINE)
+        self.assertTrue(sections[-1].startswith("AI Work Metadata\n"))
+        self.assertIn("| Role | Agent | Model | Effort |", sections[-1])
+        self.assertNotIn("AI作業メタ情報", self.skill)
+
+    def test_parent_compares_pre_and_post_delegation_snapshots(self):
+        for command in (
+            "git status --short",
+            "git rev-parse HEAD",
+            "git ls-remote --heads",
+            "gh issue list --author @me --state all",
+            "gh pr list --author @me --state all",
+            "--limit 1000 --json number,url",
+        ):
+            self.assertIn(command, self.skill)
+
+        self.assertIn("送信前スナップショットと完全一致", self.skill)
+        self.assertIn("今回のIssue 1件だけ", self.skill)
+        self.assertIn("PR作成を検出していない", self.skill)
+
+    def test_forbidden_operations_fail_closed_and_keep_pane(self):
+        self.assertIn("herdr pane read --source recent-unwrapped", self.skill)
+        self.assertIn("出力が欠ける、判定できない", self.skill)
+        self.assertIn("禁止操作の検出、スナップショット不一致、確認不能", self.skill)
+        self.assertIn("paneを診断用に保持して停止", self.skill)
+        for operation in (
+            "HTML生成",
+            "再委譲",
+            "commit",
+            "push",
+            "PR作成",
+        ):
+            self.assertIn(operation, self.skill)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/herdr-github-create-issue/tests/test_issue_creation_contract.py
+++ b/herdr-github-create-issue/tests/test_issue_creation_contract.py
@@ -37,6 +37,49 @@ class IssueCreationContractTest(unittest.TestCase):
         self.assertIn("今回のIssue 1件だけ", self.skill)
         self.assertIn("PR作成を検出していない", self.skill)
 
+    def test_handoff_rereads_and_freezes_parent_codex_identity_before_send(self):
+        dispatch_step = re.search(
+            r"4\. 入力可能確認後、`send_request\.py`で依頼を送信する直前に、"
+            r"親が次の順で送信前処理を完了する。(?P<steps>.*?)\n\n## 3\.",
+            self.skill,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(dispatch_step)
+        steps = dispatch_step.group("steps")
+
+        worktree_snapshot_index = steps.index("送信前スナップショットとして保持")
+        reread_index = steps.index(
+            "親自身が`~/.codex/config.toml`を直接再読込"
+        )
+        for command in (
+            "git status --short",
+            "git rev-parse HEAD",
+            "git ls-remote --heads",
+            "gh issue list --author @me --state all --limit 1000 --json number,url",
+            "gh pr list --author @me --state all --limit 1000 --json number,url",
+        ):
+            command_index = steps.index(command)
+            self.assertLess(command_index, reread_index, command)
+        metadata_snapshot_index = steps.index(
+            "ハンドオフ時点のメタ情報スナップショットとして固定"
+        )
+        send_index = steps.index("`send_request.py`でEnter込みで一度だけ送信")
+
+        self.assertLess(worktree_snapshot_index, reread_index)
+        self.assertLess(reread_index, metadata_snapshot_index)
+        self.assertLess(metadata_snapshot_index, send_index)
+        self.assertIn("会話開始時または過去の取得値を使わない", steps)
+        self.assertIn(
+            "Configを読めない場合は、`ai-identity-resolve`の契約どおり、"
+            "実行環境が提供する明示的なモデル情報を使い、"
+            "それも取得できない場合のみModelを`—`とする",
+            steps,
+        )
+        self.assertIn("モデル名は推測せず", steps)
+        self.assertIn("子は親の値を再解決、推測、上書きせず", steps)
+        self.assertIn("Config再読込と送信の間に外部I/Oや識別情報の再取得を挟まない", steps)
+        self.assertIn("送信後に壁打ち担当の識別情報を再取得または変更しない", steps)
+
     def test_forbidden_operations_fail_closed_and_keep_pane(self):
         self.assertIn("herdr pane read --source recent-unwrapped", self.skill)
         self.assertIn("出力が欠ける、判定できない", self.skill)


### PR DESCRIPTION
## Issues

- Close #183

## Why

確定済みプランのIssue化は、壁打ちを担当した高コストAgent自身ではなく、Herdr上の低コストAgentへ安全に委譲できるようにするためです。

## Summary

`herdr-github-create-issue` を追加し、確定済みプランからのIssue作成、`AI Work Metadata` の記録、禁止操作の検証、作成結果の確認、pane cleanupまでの契約を定義します。

## Changes

- `cagent low` で毎回新規paneへIssue作成を委譲する手順を追加
- 壁打ち担当とIssue作成担当のAgent・Model・Effortを `AI Work Metadata` として記録する規則を追加
- 委譲前後のworktree・HEAD・remote ref・GitHub Issue/PR一覧を比較する契約を追加
- 壁打ち担当のCodexモデルを委譲直前にConfigから再取得し、固定値として子へ渡す契約を追加
- 成功・失敗時の確認、停止、pane cleanup契約を追加
- Agent表示設定とREADMEのAvailable Skills表を更新

## Verification

- `bash scripts/validate-skills.sh` - passed（33 skills）
- `python3 -m unittest herdr-github-create-issue/tests/test_issue_creation_contract.py` - passed（4 tests）
- `python3 -m unittest herdr-github-implement-pr/tests/test_ai_work_metadata_contract.py` - passed（3 tests）
- `git diff --check` - passed
- Herdr実動スモークテスト - passed（テストIssue #185を作成・確認後にclose）

## AI Work Metadata

| Role | Agent | Model | Effort |
| --- | --- | --- | --- |
| オーケストレーター | Codex | gpt-5.6-sol | low |
| 実装 | Codex | gpt-5.6-terra | high |
| レビュー | Codex | gpt-5.6-terra | high |
| レビューFB | Codex | gpt-5.6-terra | high |
| 追加FB調整 | Codex | gpt-5.6-sol | high |
| 追加FB実装 | Codex | gpt-5.6-terra | high |
| 追加FB検証・補正 | Codex | gpt-5.6-luna | xhigh |
