### PR TITLE
docs: expose skill external dependencies

### DIFF
--- a/.claude/skills/skills-readme-sync/SKILL.md
+++ b/.claude/skills/skills-readme-sync/SKILL.md
@@ -43,6 +43,7 @@ description: >
 - リポジトリ直下の各スキルディレクトリ
 - `.claude/skills/` 配下の各スキルディレクトリ
 - 各スキルの `SKILL.md`
+- 各スキルの `references/`、`scripts/`、プログラム内の import と外部コマンド参照
 - `README.md` の `Available Skills`
 
 `.archive/` 配下は利用・保守対象外のため、スキル一覧の収集対象から除外する。
@@ -64,10 +65,23 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
   - 列は増やさない (該当スキルが少数のため、列追加は表が広がるだけ)
 - 実験的なスキルは Description の `experimental` バッジではなく、`Experimental` グループに置く
 
+### Step 2.5: 外部依存を決める
+
+`External Dependencies` には、スキル実行に必要な CLI、ランタイム、外部サービスを短く列挙する。
+
+ルール:
+- `SKILL.md` だけでなく、直接参照する `references/`、`scripts/`、プログラムの import・subprocess 呼び出しも確認する
+- リポジトリ内の別スキルは外部依存に含めない
+- Python 標準ライブラリは個別名ではなく `Python 3` と記載し、外部ライブラリだけをパッケージ名で記載する
+- 特定フローだけで必要な依存は `(conditional)`、代替手段は `(optional)`、fallback は `(fallback)` と記載する
+- 必須の外部依存がない場合は `—` とする
+- 表の列は `Skill | Description | External Dependencies` に揃える
+
 ### Step 3: README の一覧を同期する
 
 更新対象:
 - `Available Skills` のグループ別の表
+- README 先頭の Shields.io スキル数バッジ
 
 #### グルーピング方針
 
@@ -115,8 +129,10 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 ## 品質チェック
 
 - [ ] `.archive/` を除く実在する全スキルが `Available Skills` のいずれかのグループに載っている
+- [ ] Shields.io スキル数バッジが実在するスキル数と一致している
 - [ ] 各グループ見出しの直後に表が続き、空のグループ見出しが残っていない
 - [ ] 各スキルのリンク先が正しい
 - [ ] 説明文が古いスキル名や古い用途を含んでいない
+- [ ] 各スキルの `External Dependencies` がプロンプト、参照資料、スクリプト、コードの実態と一致している
 - [ ] グループ内の並びが、関連の強さや作業フローの順として説明できる
 - [ ] README 以外のファイルを変更する場合は、その必要性が明確である

--- a/.scripts/validate-skills.sh
+++ b/.scripts/validate-skills.sh
@@ -100,15 +100,19 @@ else
   fi
 
   if ! awk -F '|' '
+    /^\| Skill \|/ {
+      headers++
+      if ($0 != "| Skill | Description | External Dependencies |") invalid = 1
+    }
     /^\| \[[^]]+\]\([^)]+\/SKILL\.md\)/ {
       dependency = $4
       gsub(/^[[:space:]]+|[[:space:]]+$/, "", dependency)
       if (NF != 5 || dependency == "") invalid = 1
       rows++
     }
-    END { exit rows > 0 && !invalid ? 0 : 1 }
+    END { exit headers > 0 && rows > 0 && !invalid ? 0 : 1 }
   ' README.md; then
-    report_failure 'README skill rows must use Skill | Description | External Dependencies with a non-empty dependency cell'
+    report_failure 'README skill tables must use Skill | Description | External Dependencies with a non-empty dependency cell'
   fi
 fi
 

--- a/.scripts/validate-skills.sh
+++ b/.scripts/validate-skills.sh
@@ -90,6 +90,26 @@ else
     [[ -z "$stale_skill" ]] && continue
     report_failure "README Available Skills references missing skill: $stale_skill"
   done < "$tmp_dir/readme.stale"
+
+  skill_count="$(wc -l < "$tmp_dir/skills.actual" | tr -d ' ')"
+  badge_count="$(sed -nE 's#.*img\.shields\.io/badge/skills-([0-9]+)-.*#\1#p' README.md | head -n 1)"
+  if [[ -z "$badge_count" ]]; then
+    report_failure 'README Shields.io skill count badge is missing'
+  elif [[ "$badge_count" != "$skill_count" ]]; then
+    report_failure "README skill count badge is $badge_count; expected $skill_count"
+  fi
+
+  if ! awk -F '|' '
+    /^\| \[[^]]+\]\([^)]+\/SKILL\.md\)/ {
+      dependency = $4
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", dependency)
+      if (NF != 5 || dependency == "") invalid = 1
+      rows++
+    }
+    END { exit rows > 0 && !invalid ? 0 : 1 }
+  ' README.md; then
+    report_failure 'README skill rows must use Skill | Description | External Dependencies with a non-empty dependency cell'
+  fi
 fi
 
 # Validate agents/openai.yaml metadata for each skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Instructions
+
+日本語で簡潔かつ丁寧に回答してください。
+
+## GitHub PRレビューコメント
+
+GitHub PRへレビューコメントを投稿するとき、AI識別メタ情報には Codex の設定モデルを明記します。
+
+- `/home/u7dev/.codex/config.toml` の `model = "..."` を参照できる場合は、その値をそのまま使う
+- 例: `model = "gpt-1.0"` の場合は `AIレビュー補助（Codex / gpt-1.0）によるレビューです 🤖`
+- 再チェックコメントでは `AIレビュー補助（Codex / gpt-1.0）による再チェックコメントです 🤖`
+
+## Skill Naming Convention
+
+スキル名は原則として `service-target-action` の順で付けます。
+
+- `service`: `git` `github` `bun` `codex` `skill` のような対象領域
+- `target`: `branch` `pr` `issue` `dependency` `skills` のような主対象
+- `action`: `create` `review` `update` `description` のような操作内容
+
+一覧を見た時に「どこで」「何に対して」「何をする」スキルかを判断できる名前にします。
+README のグルーピングはスキル名の prefix ではなく、利用目的を優先して決めます。
+
+## Skill Maintenance
+
+- `SKILL.md` は原則として180行以内に収め、必須ルール・禁止事項・主要ワークフローは先頭150行以内に置く
+- 長い例、詳細手順、CLI/APIサンプル、トラブルシュートは `references/` に用途別で分割する
+- スキルの追加・変更時は、`SKILL.md`、`references/`、`scripts/`、プログラム内の import・外部コマンドを確認し、README の `External Dependencies` を同期する
+- スキルの追加・削除時は、README 先頭の Shields.io スキル数バッジも同期する
+- 依存が特定フローに限られる場合は `conditional`、代替手段の場合は `optional` と明記する
+
+ローカル検証:
+
+```sh
+bash .scripts/validate-skills.sh
+```
+
+この検証では、`SKILL.md` の行数、`references/` の参照切れ、README の `Available Skills` と実スキル一覧、スキル数バッジ、依存カラムの一致を確認します。

--- a/README.md
+++ b/README.md
@@ -1,121 +1,102 @@
 # agent skills
 
+[![Skills](https://img.shields.io/badge/skills-31-2ea44f?style=flat-square)](#available-skills)
+[![Validation](https://img.shields.io/github/actions/workflow/status/u7chan/agent-skills/validate-skills.yml?branch=main&style=flat-square&label=validation)](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml)
+
 コーディングエージェント用のカスタムスキル集です。
+
+スキルの命名・メンテナンス規約は [AGENTS.md](AGENTS.md) を参照してください。
 
 ## Available Skills
 
 スキルは利用目的ごとにグルーピングしてあります。グループ内の並びは関連の強さや作業フローの順です。
+`External Dependencies` は実行に必要な CLI、ランタイム、外部サービスを示します。`—` は必須の外部依存がないこと、`conditional` は特定フローでのみ必要なこと、`optional` は代替手段、`fallback` は最終的な代替取得元であることを表します。
 
 ### Git ローカル操作
 
-| Skill | Description |
-|-------|-------------|
-| [git-branch-create](git-branch-create/SKILL.md) | ブランチ名を提案し、ブランチを作成する |
-| [git-worktree-create](git-worktree-create/SKILL.md) | 独立した git worktree を作成し、並列作業用の作業領域を用意する |
-| [git-commit-message](git-commit-message/SKILL.md) | コミットメッセージを提案する |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [git-branch-create](git-branch-create/SKILL.md) | ブランチ名を提案し、ブランチを作成する | Git, POSIX shell |
+| [git-worktree-create](git-worktree-create/SKILL.md) | 独立した git worktree を作成し、並列作業用の作業領域を用意する | Git, POSIX shell |
+| [git-commit-message](git-commit-message/SKILL.md) | コミットメッセージを提案する | Git, POSIX shell |
 
 ### GitHub Issue / PR
 
-| Skill | Description |
-|-------|-------------|
-| [github-issue-create-from-plan](github-issue-create-from-plan/SKILL.md) | 設計プラン合意後に GitHub Issue を作成する |
-| [herdr-github-create-issue](herdr-github-create-issue/SKILL.md) | 確定済みプランの Issue 作成を Herdr の新規 Agent へ委譲する |
-| [github-pr-create](github-pr-create/SKILL.md) | PR 本文生成を含めて GitHub に PR を作成する |
-| [github-pr-feedback-address](github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う |
-| [github-pr-review](github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う |
-| [github-pr-comment-reply](github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する |
-| [github-pr-post-merge-cleanup](github-pr-post-merge-cleanup/SKILL.md) | マージ済み PR の基準ブランチへ戻り、ローカル作業ブランチを安全に整理する |
-| [ai-identity-resolve](ai-identity-resolve/SKILL.md) | AIレビュー補助コメントやPR Work Metadata用のエージェント名・モデル名を推測せず取得する |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [github-issue-create-from-plan](github-issue-create-from-plan/SKILL.md) | 設計プラン合意後に GitHub Issue を作成する | `gh`, GitHub, POSIX shell |
+| [herdr-github-create-issue](herdr-github-create-issue/SKILL.md) | 確定済みプランの Issue 作成を Herdr の新規 Agent へ委譲する | Herdr, `cagent`, `gh`, `jq`, Git, Python 3, POSIX shell |
+| [github-pr-create](github-pr-create/SKILL.md) | PR 本文生成を含めて GitHub に PR を作成する | `gh`, Git, GitHub, POSIX shell |
+| [github-pr-feedback-address](github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う | `gh`, Git, GitHub API, POSIX shell |
+| [github-pr-review](github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う | `gh`, `jq`, GitHub API, POSIX shell |
+| [github-pr-comment-reply](github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する | `gh`, GitHub API, POSIX shell |
+| [github-pr-post-merge-cleanup](github-pr-post-merge-cleanup/SKILL.md) | マージ済み PR の基準ブランチへ戻り、ローカル作業ブランチを安全に整理する | `gh`, Git, POSIX shell |
+| [ai-identity-resolve](ai-identity-resolve/SKILL.md) | AIレビュー補助コメントやPR Work Metadata用のエージェント名・モデル名を推測せず取得する | Herdr / `cagent` (optional), Codex config (fallback) |
 
 ### 実装 / 成果物生成
 
-| Skill | Description |
-|-------|-------------|
-| [herdr-worktree-create](herdr-worktree-create/SKILL.md) | Herdr 公式コマンドで独立した worktree と workspace を作成する |
-| [herdr-github-implement-pr](herdr-github-implement-pr/SKILL.md) | Issue 確認から Herdr Agent による実装、PR 作成、レビュー・FB 対応までを一連で進める |
-| [coding-agent-subagent](coding-agent-subagent/SKILL.md) | Herdr委譲向けにcagentで基礎Agent種別と対話起動コマンドを解決する |
-| [herdr-agent-delegate](herdr-agent-delegate/SKILL.md) | Herdr公式プリミティブでCLI Agentを1タブあたり最大4paneに配置し、送信・待機・出力回収を行う |
-| [herdr-prompt-eval-loop](herdr-prompt-eval-loop/SKILL.md) | Herdrの独立Agentでプロンプトを反復実行し、非公開要件による評価と最小改善を行う |
-| [html-artifact-format](html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLを判断し、視覚化要素入りの単一HTMLを生成する |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [herdr-worktree-create](herdr-worktree-create/SKILL.md) | Herdr 公式コマンドで独立した worktree と workspace を作成する | Herdr, Git, POSIX shell |
+| [herdr-github-implement-pr](herdr-github-implement-pr/SKILL.md) | Issue 確認から Herdr Agent による実装、PR 作成、レビュー・FB 対応までを一連で進める | Herdr, `cagent`, `gh`, `jq`, Git, Python 3, POSIX shell |
+| [coding-agent-subagent](coding-agent-subagent/SKILL.md) | Herdr委譲向けにcagentで基礎Agent種別と対話起動コマンドを解決する | Herdr, `cagent`, Codex / Claude Code / OpenCode CLI, POSIX shell |
+| [herdr-agent-delegate](herdr-agent-delegate/SKILL.md) | Herdr公式プリミティブでCLI Agentを1タブあたり最大4paneに配置し、送信・待機・出力回収を行う | Herdr, `jq`, Python 3, POSIX shell, Agent CLI |
+| [herdr-prompt-eval-loop](herdr-prompt-eval-loop/SKILL.md) | Herdrの独立Agentでプロンプトを反復実行し、非公開要件による評価と最小改善を行う | Herdr, `jq`, Git, Python 3, POSIX shell, Agent CLI |
+| [html-artifact-format](html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLを判断し、視覚化要素入りの単一HTMLを生成する | POSIX shell |
 
 ### 要件定義 / 設計対話
 
-| Skill | Description |
-|-------|-------------|
-| [grilling](grilling/SKILL.md) | 計画・デザインを一問ずつ深掘りし、本格的な構築前にストレステストする |
-| [grill-with-docs](grill-with-docs/SKILL.md) | 既存ドキュメントと照合しながら設計を厳しく壁打ちする |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [grilling](grilling/SKILL.md) | 計画・デザインを一問ずつ深掘りし、本格的な構築前にストレステストする | — |
+| [grill-with-docs](grill-with-docs/SKILL.md) | 既存ドキュメントと照合しながら設計を厳しく壁打ちする | — |
 
 ### 文章チェック / 校正
 
-| Skill | Description |
-|-------|-------------|
-| [japanese-text-proofread](japanese-text-proofread/SKILL.md) | 日本語の文章や Markdown 原稿の誤字脱字・表記ゆれを点検する |
-| [japanese-ai-text-naturalize](japanese-ai-text-naturalize/SKILL.md) | AI生成っぽい技術・業務文を自然で実用的な日本語へ整える |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [japanese-text-proofread](japanese-text-proofread/SKILL.md) | 日本語の文章や Markdown 原稿の誤字脱字・表記ゆれを点検する | — |
+| [japanese-ai-text-naturalize](japanese-ai-text-naturalize/SKILL.md) | AI生成っぽい技術・業務文を自然で実用的な日本語へ整える | — |
 
 ### 品質 / テスト設計
 
-| Skill | Description |
-|-------|-------------|
-| [qa-test-design](qa-test-design/SKILL.md) | QA観点とテストケースを体系的に洗い出し、テスト実装前の設計を整える |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [qa-test-design](qa-test-design/SKILL.md) | QA観点とテストケースを体系的に洗い出し、テスト実装前の設計を整える | — |
 
 ### 依存パッケージ更新
 
-| Skill | Description |
-|-------|-------------|
-| [bun-dependency-update](bun-dependency-update/SKILL.md) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
-| [npm-dependency-update](npm-dependency-update/SKILL.md) | npm アプリの依存更新を非メジャー/major の分岐付きで安全に進める |
-| [uv-dependency-update](uv-dependency-update/SKILL.md) | uv 管理の Python 依存更新を非メジャー/major の分岐付きで安全に進める |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [bun-dependency-update](bun-dependency-update/SKILL.md) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める | Bun, `rg`, POSIX shell, web access (conditional) |
+| [npm-dependency-update](npm-dependency-update/SKILL.md) | npm アプリの依存更新を非メジャー/major の分岐付きで安全に進める | Node.js / npm, `rg`, POSIX shell, web access (conditional) |
+| [uv-dependency-update](uv-dependency-update/SKILL.md) | uv 管理の Python 依存更新を非メジャー/major の分岐付きで安全に進める | `uv`, Python, `rg`, POSIX shell, web access (conditional) |
 
 ### UI / フロントエンド
 
-| Skill | Description |
-|-------|-------------|
-| [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [tailwind-ui-compose](tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える | Tailwind CSS project |
 
 ### ブラウザ操作 / 検証
 
-| Skill | Description |
-|-------|-------------|
-| [playwright-cli](playwright-cli/SKILL.md) | Playwright CLI の独立ブラウザで localhost などの画面検証を進める |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [playwright-cli](playwright-cli/SKILL.md) | Playwright CLI の独立ブラウザで localhost などの画面検証を進める | Playwright CLI, browser, POSIX shell, Node.js / `npx` (fallback) |
 
 ### Experimental
 
-| Skill | Description |
-|-------|-------------|
-| [image-to-svg](image-to-svg/SKILL.md) | 画像（PNG/JPEG）を編集可能な SVG に変換する |
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [image-to-svg](image-to-svg/SKILL.md) | 画像（PNG/JPEG）を編集可能な SVG に変換する | librsvg / Inkscape / browser (one required) |
 
 ### スキル作成 / メンテナンス
 
-| Skill | Description |
-|-------|-------------|
-| [skill-author](skill-author/SKILL.md) | SKILL.md ファイルの作成と改善を行う |
-| [skills-readme-sync](.claude/skills/skills-readme-sync/SKILL.md) | **本リポジトリ専用** — README のスキル一覧を現在のスキル構成へ同期する |
-| [codex-skills-link-from-claude](codex-skills-link-from-claude/SKILL.md) | `.claude/skills` を `.codex/skills` から再利用できるようにリンクする |
-
-## Naming Convention
-
-スキル名は原則として `service-target-action` の順で付けます。
-
-- `service`: `git` `github` `bun` `codex` `skill` のような対象領域
-- `target`: `branch` `pr` `issue` `dependency` `skills` のような主対象
-- `action`: `create` `review` `update` `description` のような操作内容
-
-これにより、一覧を見た時に「どこで」「何に対して」「何をする」スキルかを判断しやすくします。
-
-README のグルーピングはスキル名の prefix ではなく、利用目的を優先して決めます。
-
-## Skill Maintenance
-
-`SKILL.md` は原則として180行以内に収め、必須ルール・禁止事項・主要ワークフローは先頭150行以内に置きます。
-長い例、詳細手順、CLI/APIサンプル、トラブルシュートは `references/` に用途別で分割します。
-
-ローカル検証は次のコマンドで実行できます。
-
-```sh
-bash .scripts/validate-skills.sh
-```
-
-この検証では、`SKILL.md` の行数、`references/` の参照切れ、README の `Available Skills` と実スキル一覧の一致を確認します。
+| Skill | Description | External Dependencies |
+|-------|-------------|-----------------------|
+| [skill-author](skill-author/SKILL.md) | SKILL.md ファイルの作成と改善を行う | — |
+| [skills-readme-sync](.claude/skills/skills-readme-sync/SKILL.md) | **本リポジトリ専用** — README のスキル一覧を現在のスキル構成へ同期する | Bash, Python 3, coreutils |
+| [codex-skills-link-from-claude](codex-skills-link-from-claude/SKILL.md) | `.claude/skills` を `.codex/skills` から再利用できるようにリンクする | POSIX shell, coreutils |
 
 ## Setup
 


### PR DESCRIPTION
## Why

スキル一覧だけでは、各スキルを実行するために必要な CLI、ランタイム、外部サービスを事前に判断できませんでした。

## Summary

README の全スキルに外部依存情報を追加し、先頭へ Shields.io バッジを配置します。あわせて、依存情報とスキル数を今後も同期できるようメンテナンス規約と検証を更新します。

## Changes

- 全31スキルへ `External Dependencies` カラムを追加
- スキル数と CI 状態の Shields.io バッジを追加
- Naming Convention と Skill Maintenance を `AGENTS.md` へ移動
- README 同期スキルへ依存監査ルールを追加
- スキル数バッジと依存カラムを検証スクリプトで確認

## Checklist

- [x] `bash .scripts/validate-skills.sh`
- [x] `quick_validate.py .claude/skills/skills-readme-sync`
- [x] `bash -n .scripts/validate-skills.sh`
- [x] `git diff --check`
