### PR TITLE
docs: improve setup guide

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,10 @@
-# Setup
+# セットアップ
 
-## Claude Code を使用する場合
+このリポジトリをローカルにクローンし、各エージェントのスキルディレクトリから参照できるようにシンボリックリンクを作成します。
+
+## Claude Code
+
+次のコマンドを実行します。
 
 ```sh
 git clone git@github.com:u7chan/agent-skills.git
@@ -9,10 +13,11 @@ mkdir -p "$HOME/.claude/skills"
 ln -sf "$(pwd)" "$HOME/.claude/skills"
 ```
 
-> [!NOTE]
-> `$HOME/.claude/skills` ディレクトリが既に存在する場合は、上記コマンドをそのまま実行してください。
+これにより、`$HOME/.claude/skills/agent-skills` からこのリポジトリを参照できるようになります。`$HOME/.claude/skills` がすでに存在していても、そのまま実行できます。
 
-## Codex を使用する場合
+## Codex
+
+次のコマンドを実行します。
 
 ```sh
 git clone git@github.com:u7chan/agent-skills.git
@@ -21,15 +26,19 @@ mkdir -p "$HOME/.codex"
 ln -sfn "$(pwd)" "$HOME/.codex/skills"
 ```
 
-> [!NOTE]
-> `"$HOME/.codex/skills"` が既に存在する場合は、上記コマンドをそのまま実行してください。
+これにより、`$HOME/.codex/skills` からこのリポジトリを参照できるようになります。既存のシンボリックリンクがある場合は、新しいリンク先に更新されます。
 
-## シンボリックリンクを解除する場合
+## その他のエージェント
+
+`.claude/skills` と互換性があるエージェントでは、Claude Code と同じ手順でセットアップできます。対応状況は、使用するエージェントのドキュメントを確認してください。
+
+## シンボリックリンクを解除する
+
+使用しているエージェントに合わせて、対象のシンボリックリンクを削除します。
 
 ```sh
-rm "$HOME/.claude/skills"
+rm "$HOME/.claude/skills/agent-skills"
 rm "$HOME/.codex/skills"
 ```
 
-> [!NOTE]
-> Claude Code 以外のエージェントでは、設定ディレクトリのパスが異なる場合があります。
+リポジトリ本体も不要な場合は、シンボリックリンクを解除したあとに、クローンしたディレクトリを別途削除してください。


### PR DESCRIPTION
## Why

既存のセットアップ手順は、各コマンドで作成されるシンボリックリンクの構成が分かりにくく、Claude Code の解除コマンドも実際のリンク先と一致していませんでした。

## Summary

`SETUP.md` 全体の文章と構成を整理し、セットアップ結果や解除方法を分かりやすくします。あわせて、`.claude/skills` と互換性があるエージェント向けの案内を追加します。

## Changes

- 見出しと説明文を簡潔で自然な日本語に整理
- Claude Code と Codex のセットアップ結果を明記
- Claude Code のシンボリックリンク解除先を修正
- `.claude/skills` 互換エージェント向けの案内を追加
- リポジトリ本体を削除する場合の補足を追加

## Checklist

- [x] `git diff --check`
- [x] `bash .scripts/validate-skills.sh`

## AI Work Metadata

| Role | Agent | Model | Effort |
| --- | --- | --- | --- |
| 実装・PR作成 | Codex | gpt-5.6-sol | high |
