### PR TITLE
fix: READMEの配布スキル数から内部スキルを除外

### DIFF
--- a/.claude/skills/skills-readme-sync/SKILL.md
+++ b/.claude/skills/skills-readme-sync/SKILL.md
@@ -2,14 +2,14 @@
 name: skills-readme-sync
 description: >
   このリポジトリでスキルを追加・改名・削除・大幅変更し、READMEの更新が必要なときに使う。
-  Available Skills表を現在のスキル構成へ同期する。
+  Available Skills表を現在の配布対象スキル構成へ同期する。
 ---
 
 # Skills README Sync
 
 ## 概要
 
-このスキルは、`agent-skills` リポジトリ内のスキル変更に合わせて `README.md` のスキル一覧を同期する。
+このスキルは、`agent-skills` リポジトリ内の配布対象スキルの変更に合わせて `README.md` のスキル一覧を同期する。
 スキル本体だけ直して README を更新し忘れる漏れを防ぐためのもの。
 
 ## このスキルを使用するタイミング
@@ -41,13 +41,14 @@ description: >
 
 確認するもの:
 - リポジトリ直下の各スキルディレクトリ
-- `.claude/skills/` 配下の各スキルディレクトリ
+- `.claude/skills/` 配下のリポジトリ保守専用スキル
 - 各スキルの `SKILL.md`
 - 各スキルの `references/`、`scripts/`、プログラム内の import と外部コマンド参照
 - `README.md` の `Available Skills`
 
 `.archive/` 配下は利用・保守対象外のため、スキル一覧の収集対象から除外する。
-`find . -path './.archive' -prune -o -name SKILL.md -print | sort` などで実在するアクティブなスキルを確認し、README の列挙漏れや古い名前を見つける。
+`.claude/skills/` 配下は品質検証対象だが配布対象外のため、README の一覧とスキル数から除外する。
+実在する配布対象スキルを確認し、README の列挙漏れや古い名前を見つける。
 
 ### Step 2: 一覧表の説明を決める
 
@@ -58,11 +59,6 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 - スキルの用途を先に書く
 - README では詳細手順を書きすぎない
 - 既存の日本語トーンに合わせる
-- 性質バッジを Description セルの先頭に付ける場合は次の書式に揃える
-  - 書式: `**<バッジ>** — <用途の短い説明>`
-  - 用途が定まっているバッジ:
-    - `**本リポジトリ専用**`: 他リポジトリで使うことを想定していない、この `agent-skills` リポジトリ自身のメンテに紐付くスキル (例: `skills-readme-sync`)
-  - 列は増やさない (該当スキルが少数のため、列追加は表が広がるだけ)
 - 実験的なスキルは Description の `experimental` バッジではなく、`Experimental` グループに置く
 
 ### Step 2.5: 外部依存を決める
@@ -81,7 +77,7 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 
 更新対象:
 - `Available Skills` のグループ別の表
-- README 先頭の Shields.io スキル数バッジ
+- README 先頭の Shields.io 配布スキル数バッジ
 
 #### グルーピング方針
 
@@ -116,7 +112,6 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 - スキル追加時は適切なグループの表に追記する
 - スキル名変更時は一覧の名前とリンク先を揃える
 - スキル削除時は一覧から消す。グループが空になったら見出しも消す
-- 配置場所が `.claude/skills/` の場合は一覧のリンク先にそのパスを反映する
 - セットアップ手順など無関係な箇所は変更しない
 
 ### Step 4: 差分を検証する
@@ -128,8 +123,9 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 
 ## 品質チェック
 
-- [ ] `.archive/` を除く実在する全スキルが `Available Skills` のいずれかのグループに載っている
-- [ ] Shields.io スキル数バッジが実在するスキル数と一致している
+- [ ] 実在する全配布対象スキルが `Available Skills` のいずれかのグループに載っている
+- [ ] `.claude/skills/` 配下のリポジトリ保守専用スキルが `Available Skills` に載っていない
+- [ ] Shields.io スキル数バッジが実在する配布対象スキル数と一致している
 - [ ] 各グループ見出しの直後に表が続き、空のグループ見出しが残っていない
 - [ ] 各スキルのリンク先が正しい
 - [ ] 説明文が古いスキル名や古い用途を含んでいない

--- a/.claude/skills/skills-readme-sync/agents/openai.yaml
+++ b/.claude/skills/skills-readme-sync/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Skills README Sync"
-  short_description: "スキル追加・変更後にREADMEのAvailable Skills表を同期する"
-  default_prompt: "Use $skills-readme-sync to update the README Available Skills table after skill changes."
+  short_description: "配布対象スキルの変更後にREADMEの一覧と件数を同期する"
+  default_prompt: "Use $skills-readme-sync to update the README Available Skills table and count after distributable skill changes."

--- a/.scripts/validate-skills.sh
+++ b/.scripts/validate-skills.sh
@@ -33,6 +33,7 @@ find_skill_files() {
 }
 
 find_skill_files > "$tmp_dir/skills.actual"
+sed '/^\.claude\/skills\//d' "$tmp_dir/skills.actual" > "$tmp_dir/skills.distributable"
 
 if [[ ! -s "$tmp_dir/skills.actual" ]]; then
   report_failure 'no SKILL.md files found'
@@ -78,8 +79,8 @@ else
     sed -E 's#.*\(([^)]+)\).*#\1#' |
     sort -u > "$tmp_dir/skills.readme"
 
-  comm -23 "$tmp_dir/skills.actual" "$tmp_dir/skills.readme" > "$tmp_dir/readme.missing"
-  comm -13 "$tmp_dir/skills.actual" "$tmp_dir/skills.readme" > "$tmp_dir/readme.stale"
+  comm -23 "$tmp_dir/skills.distributable" "$tmp_dir/skills.readme" > "$tmp_dir/readme.missing"
+  comm -13 "$tmp_dir/skills.distributable" "$tmp_dir/skills.readme" > "$tmp_dir/readme.stale"
 
   while IFS= read -r missing_skill; do
     [[ -z "$missing_skill" ]] && continue
@@ -91,7 +92,7 @@ else
     report_failure "README Available Skills references missing skill: $stale_skill"
   done < "$tmp_dir/readme.stale"
 
-  skill_count="$(wc -l < "$tmp_dir/skills.actual" | tr -d ' ')"
+  skill_count="$(wc -l < "$tmp_dir/skills.distributable" | tr -d ' ')"
   badge_count="$(sed -nE 's#.*img\.shields\.io/badge/skills-([0-9]+)-.*#\1#p' README.md | head -n 1)"
   if [[ -z "$badge_count" ]]; then
     report_failure 'README Shields.io skill count badge is missing'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ README のグルーピングはスキル名の prefix ではなく、利用目�
 - 長い例、詳細手順、CLI/APIサンプル、トラブルシュートは `references/` に用途別で分割する
 - スキルの追加・変更時は、`SKILL.md`、`references/`、`scripts/`、プログラム内の import・外部コマンドを確認し、README の `External Dependencies` を同期する
 - スキルの追加・削除時は、README 先頭の Shields.io スキル数バッジも同期する
+- `.claude/skills/` 配下のリポジトリ保守専用スキルは品質検証対象に含めるが、README の `Available Skills` とスキル数バッジには含めない
 - 依存が特定フローに限られる場合は `conditional`、代替手段の場合は `optional` と明記する
 
 ローカル検証:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent skills
 
-[![Skills](https://img.shields.io/badge/skills-32-2ea44f?style=flat-square)](#available-skills)
+[![Skills](https://img.shields.io/badge/skills-31-2ea44f?style=flat-square)](#available-skills)
 [![Validation](https://img.shields.io/github/actions/workflow/status/u7chan/agent-skills/validate-skills.yml?branch=main&style=flat-square&label=validation)](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml)
 
 コーディングエージェント用のカスタムスキル集です。
@@ -101,7 +101,6 @@
 |-------|-------------|-----------------------|
 | [agent-skill-design](agent-skill-design/SKILL.md) | Agent Skillの新規作成、仕様変更、全面再設計、設計レビューを行う | — |
 | [agent-skill-refine](agent-skill-refine/SKILL.md) | 既存Agent Skillを挙動を変えず短く高密度に改善する | — |
-| [skills-readme-sync](.claude/skills/skills-readme-sync/SKILL.md) | **本リポジトリ専用** — README のスキル一覧を現在のスキル構成へ同期する | Bash, Python 3, coreutils |
 | [codex-skills-link](codex-skills-link/SKILL.md) | `.codex/skills`だけを操作し、`.claude/skills`をCodexから再利用できるようにリンクする | POSIX shell, coreutils |
 
 ## Setup


### PR DESCRIPTION
## Why

リポジトリ保守専用の `skills-readme-sync` が、配布スキルの一覧と件数に含まれていました。内部スキルの品質検証は維持しつつ、利用者向けカタログとは分離します。

## Summary

`.claude/skills/` 配下をリポジトリ保守専用として扱い、README の `Available Skills` とスキル数バッジから除外しました。検証スクリプトでは、全スキルの品質検証と配布対象スキルのREADME照合を分離しています。

## Changes

- 内部スキルをREADME掲載・件数集計から除外する規約を追加
- `skills-readme-sync` の責務とメタデータを配布対象スキルの同期に更新
- README照合用の配布対象リストを検証スクリプトに追加
- READMEから内部スキルを削除し、スキル数を31件へ更新

## Verification

- `bash -n .scripts/validate-skills.sh` - passed
- `bash .scripts/validate-skills.sh` - passed（全32スキルの品質検証、配布対象31スキルのREADME照合）
- `git diff --check` - passed
