### PR TITLE
fix: Codex生成の.systemをGit管理対象外にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__/
 .herdr-agent-delegate/
 
 # Codexが生成するシステム用生成物（Git管理対象外）
-.system/
+/.system/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 *.py[cod]
 .herdr-agent-delegate/
+
+# Codexが生成するシステム用生成物（Git管理対象外）
+.system/


### PR DESCRIPTION
## Issues

- Close #211

## Why

Codex 組み込み Skill の初回展開で生成される `.system/` が、clone 直後のリポジトリに未追跡差分として現れるためです。

## Summary

Codex 管理の `.system/` を Git の追跡対象外にします。ユーザー管理の Skill は従来どおり追跡可能なままです。

## Changes

- `.gitignore` に Codex 生成物であることを示すコメントを追加
- `/.system/` をリポジトリルート限定の ignore 対象に追加

## Verification

- `git check-ignore -v .system/.codex-system-skills.marker` - passed
- `git check-ignore -v --no-index image-to-svg/.system/example` - not ignored as expected
- `git diff --check` - passed
- `bash .scripts/validate-skills.sh` - passed (33 skills)

## AI Work Metadata

| Role | Agent | Model | Effort |
| --- | --- | --- | --- |
| Implementation | Codex | gpt-5.6-luna | xhigh |
