### PR TITLE
docs: replace Shields.io README badges

### DIFF
--- a/.scripts/validate-skills.sh
+++ b/.scripts/validate-skills.sh
@@ -93,11 +93,11 @@ else
   done < "$tmp_dir/readme.stale"
 
   skill_count="$(wc -l < "$tmp_dir/skills.distributable" | tr -d ' ')"
-  badge_count="$(sed -nE 's#.*img\.shields\.io/badge/skills-([0-9]+)-.*#\1#p' README.md | head -n 1)"
+  badge_count="$(sed -nE 's#.*badgen\.net/static/skills/([0-9]+)/.*#\1#p' README.md | head -n 1)"
   if [[ -z "$badge_count" ]]; then
-    report_failure 'README Shields.io skill count badge is missing'
+    report_failure 'README Skills badge is missing'
   elif [[ "$badge_count" != "$skill_count" ]]; then
-    report_failure "README skill count badge is $badge_count; expected $skill_count"
+    report_failure "README Skills badge count is $badge_count; expected $skill_count"
   fi
 
   if ! awk -F '|' '

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # agent skills
 
-[![Skills](https://img.shields.io/badge/skills-32-2ea44f?style=flat-square)](#available-skills)
-[![Validation](https://img.shields.io/github/actions/workflow/status/u7chan/agent-skills/validate-skills.yml?branch=main&style=flat-square&label=validation)](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml)
+[![Skills](https://badgen.net/static/skills/32/2ea44f)](#available-skills)
+[![Validation](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml/badge.svg?branch=main)](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml)
 
 コーディングエージェント用のカスタムスキル集です。
 


### PR DESCRIPTION
## Issues

- Close #210

## Why

Shields.io の障害時にも README 冒頭の Skills と Validation バッジを安定して表示できるようにします。

## Summary

Skills バッジを Badgen、Validation バッジを GitHub Actions 公式配信へ移行しました。あわせてスキル数検証を Badgen の URL 形式に対応させています。

## Changes

- Skills バッジを Badgen の静的バッジへ変更
- Validation バッジを GitHub Actions 公式バッジへ変更
- スキル数バッジ検証を Badgen 形式へ更新
- 現在の配布対象スキル数 32 を維持

## Verification

- `bash .scripts/validate-skills.sh` - passed
- `git diff --check origin/main..HEAD` - passed
- Skills badge response - HTTP 200 / `image/svg+xml`
- Validation badge response - HTTP 200 / `image/svg+xml`
- GitHub Markdown API rendering - HTTP 200

## AI Work Metadata

| Role | Agent | Model | Effort |
| --- | --- | --- | --- |
| Implementation | Codex | gpt-5.6-luna | xhigh |
