### PR TITLE
feat: add github-issue-decompose skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent skills
 
-[![Skills](https://badgen.net/static/skills/32/2ea44f)](#available-skills)
+[![Skills](https://badgen.net/static/skills/33/2ea44f)](#available-skills)
 [![Validation](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml/badge.svg?branch=main)](https://github.com/u7chan/agent-skills/actions/workflows/validate-skills.yml)
 
 コーディングエージェント用のカスタムスキル集です。
@@ -25,6 +25,7 @@
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
+| [github-issue-decompose](github-issue-decompose/SKILL.md) | 既存Issueを本文・全コメントを根拠にSub-issueへ分解し、親をEpic化する | `gh`, GitHub, POSIX shell |
 | [github-issue-create-from-plan](github-issue-create-from-plan/SKILL.md) | 確定済みプランからテンプレートを選び、GitHub Issueを作成・確認する | `gh`, GitHub, POSIX shell |
 | [github-pr-orchestrate](github-pr-orchestrate/SKILL.md) | 未コミット変更の確認から限定commit、PR作成、指定レビュー工程まで統括する | `gh`, `jq` (conditional), Git, GitHub, POSIX shell |
 | [github-pr-create](github-pr-create/SKILL.md) | 非修正型の品質チェック後、commit済み変更をpushしてPRを作成・確認する | `gh`, Git, GitHub, POSIX shell |

--- a/github-issue-decompose/SKILL.md
+++ b/github-issue-decompose/SKILL.md
@@ -49,6 +49,8 @@ description: >
 ### 3. Preflight - 書き込み前の確認を行う
 
 - 書き込み権限を確認する。
+- `gh issue edit --help` で `--parent` フラグの存在を確認する。非対応なら書き込み前に停止する。
+- 利用するJSONフィールド（`gh issue view --json parent`、`gh issue view --json subIssues`）が取得可能か確認し、非対応なら停止する。
 - 既存Sub-issueのタイトル・本文・目的を分割提案と照合し、同一目的の重複を除外する。
 - `gh label list`で既存Labelを確認し、各Sub-issueに明確に合うものを特定する。
 - 分割案・ラベル割り当て・情報の移動先マッピングを提示し、ユーザー確認を得る。
@@ -56,9 +58,9 @@ description: >
 
 ### 4. Create - Sub-issueを作成する
 
-- 確定した分割単位ごとに、`github-issue-create-from-plan`のStandardテンプレートを適用して本文を生成する。
-- 各本文に含めるもの: `Related Issues / PRs`（親Issue番号）、`Summary`（目的と範囲）、`Implementation Approach`と`Design Details`（親Issue・コメントから該当する具体情報を移す）、`Tasks`、`Testing`、独立して完了判断できる`Acceptance Criteria`。
-- `gh issue create --body-file`で作成する。
+- Preflightで確定した各分割単位を「確定済みプラン」として`github-issue-create-from-plan`へ渡す。
+- 既存Skillのテンプレート選択・本文生成・Issue作成・結果確認に任せ、本Skill側で重複実装しない。
+- 作成されたIssueのURLと確認結果をLink工程へ引き継ぐ。
 
 ### 5. Link - ネイティブSub-issueとして親子付けする
 
@@ -68,7 +70,7 @@ description: >
 
 ### 6. Verify - 作成結果を再取得して確認する
 
-- 各Sub-issueを`gh issue view --json url,title,body,labels,parentIssue`で再取得する。
+- 各Sub-issueを`gh issue view --json url,title,body,labels,parent`で再取得する。
 - URL、title、labels、本文、親子関係が正しいことを確認する。
 - 元の情報が親またはSub-issueのどこかに保持されていることを確認する。
 - 確認失敗時は親本文を変更せず、作成済みIssue URLと差異を報告して停止する。
@@ -76,6 +78,7 @@ description: >
 ### 7. Compact - 親IssueをEpicへ短縮する
 
 - 全Sub-issueの作成・親子付け・確認が成功した後にだけ実行する。
+- 実行前に親Issueの元本文を退避し、復旧に備える。
 - 親に残す情報: 背景・目的、全体方針、共通制約、完了条件、Phase区分。
 - Sub-issueへ移す情報: 具体的作業、実装詳細、個別Acceptance Criteria、テスト方法。
 - `gh issue edit <parent> --body-file`で本文を更新し、Sub-issue progressが保持されることを確認する。
@@ -84,6 +87,10 @@ description: >
 
 - `gh issue view <parent> --json url,title,body,subIssues`でEpicと全Sub-issue progressを確認する。
 - 情報保持、親子関係、ラベルを最終確認する。
+- **失敗時の復旧**: Compactで親本文がすでに変更済みのため、以下の手順で復旧する。
+  1. 再取得不能、情報欠落、親子不一致の「変更済み」状態を報告する。
+  2. 退避した元本文を`gh issue edit <parent> --body-file`で書き戻し、Compact前の状態に復旧する。
+  3. 作成済みSub-issue URL（リンク済みの「状態不明」を含む）、復旧操作の成否を報告して停止する。
 
 ## 出力
 

--- a/github-issue-decompose/SKILL.md
+++ b/github-issue-decompose/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: github-issue-decompose
+description: >
+  既存のGitHub Issueを本文と全コメントを根拠にレビュー可能な作業単位へ分解し、GitHubネイティブのSub-issueとして登録するときに使う。
+  単一Issue作成や合意前の設計作業には使わない。
+---
+
+# GitHub Issue Decompose
+
+既存Issueの本文・全コメント・既存Sub-issueを取得し、独立して完了・レビューできる単位へ分解し、GitHubネイティブSub-issueとして登録する。
+親IssueはEpicとして要点だけを残し、具体的な作業はSub-issueへ移す。
+
+## 責務境界と停止条件
+
+- 既存Issueの分解とSub-issue登録、親IssueのEpic化だけを行う。
+- 単一Issue作成が目的なら`github-issue-create-from-plan`を単体で使い、本Skillは起動しない。
+- 合意前の設計・壁打ち・要件補完は行わない。設計が必要なら`design-plan-grill`へ別依頼する。
+- Issue本文やコメントにない要件・ブランチ名・依存関係を推測で追加しない。
+- 分割単位によって意図やスコープが変わる場合は書き込み前に停止して確認する。
+- 途中失敗時は親本文を変更せず、部分結果と復旧対象を報告する。
+- 対象リポジトリ、`gh`認証、対象Issueを確認できなければ停止する。
+
+## 必須ルール
+
+- Issue本文やコメントにない要件を推測で追加しない。
+- 既存コメントは編集・削除しない。
+- 既存Sub-issueと同一目的のIssueを重複作成しない。
+- GitHubネイティブのSub-issue関係を正本とし、重複するMarkdownチェックリストは作らない。
+- 親Issueの詳細を削る前に、その情報が親またはSub-issueのどこかへ保持されていることを確認する。
+- 新しいラベルは作成せず、既存ラベルのうち明確に合うものだけを使う。
+- 汎用スキル本文に特定のエージェント製品名を含めない。
+
+## 処理順序: Fetch → Analyze → Preflight → Create → Link → Verify → Compact → FinalVerify
+
+各工程の成功後にだけ次へ進む。失敗時は親本文を変更せず、部分結果と復旧対象を報告して停止する。
+
+### 1. Fetch - 親Issueの情報を取得する
+
+- `gh issue view`で本文・全コメントを取得し、`gh issue list`で既存Sub-issueを取得する。
+- コマンドオプションとJSONフィールドの詳細は`references/github-api-details.md`参照。
+- 取得データから以下を抽出する: 背景・目的、全体方針、共通制約、完了条件、具体的作業、実装詳細、テスト方法、Phase区分、既存Sub-issue一覧。
+
+### 2. Analyze - 分割案を作成する
+
+- 抽出内容を独立して完了・レビューできる成果物単位へ分割する。
+- 分割基準: (1) 独立した成果物、(2) 依存順（明示されたPhaseを優先）、(3) 変更範囲（同一モジュールへの変更は1つにまとめる）。
+- 過剰に細分化せず、各Sub-issueが明確なAcceptance Criteriaを持つ単位とする。
+
+### 3. Preflight - 書き込み前の確認を行う
+
+- 書き込み権限を確認する。
+- 既存Sub-issueのタイトル・本文・目的を分割提案と照合し、同一目的の重複を除外する。
+- `gh label list`で既存Labelを確認し、各Sub-issueに明確に合うものを特定する。
+- 分割案・ラベル割り当て・情報の移動先マッピングを提示し、ユーザー確認を得る。
+- 分割単位によって意図やスコープが変わる場合は停止して確認する。
+
+### 4. Create - Sub-issueを作成する
+
+- 確定した分割単位ごとに、`github-issue-create-from-plan`のStandardテンプレートを適用して本文を生成する。
+- 各本文に含めるもの: `Related Issues / PRs`（親Issue番号）、`Summary`（目的と範囲）、`Implementation Approach`と`Design Details`（親Issue・コメントから該当する具体情報を移す）、`Tasks`、`Testing`、独立して完了判断できる`Acceptance Criteria`。
+- `gh issue create --body-file`で作成する。
+
+### 5. Link - ネイティブSub-issueとして親子付けする
+
+- `gh issue edit <child> --parent <parent>`でGitHubネイティブ親子関係を設定する。
+- Markdownチェックリストは作らず、GitHub Sub-issue関係を正本とする。
+- 依存順がある場合はSub-issueの作成順をそれに合わせる。
+
+### 6. Verify - 作成結果を再取得して確認する
+
+- 各Sub-issueを`gh issue view --json url,title,body,labels,parentIssue`で再取得する。
+- URL、title、labels、本文、親子関係が正しいことを確認する。
+- 元の情報が親またはSub-issueのどこかに保持されていることを確認する。
+- 確認失敗時は親本文を変更せず、作成済みIssue URLと差異を報告して停止する。
+
+### 7. Compact - 親IssueをEpicへ短縮する
+
+- 全Sub-issueの作成・親子付け・確認が成功した後にだけ実行する。
+- 親に残す情報: 背景・目的、全体方針、共通制約、完了条件、Phase区分。
+- Sub-issueへ移す情報: 具体的作業、実装詳細、個別Acceptance Criteria、テスト方法。
+- `gh issue edit <parent> --body-file`で本文を更新し、Sub-issue progressが保持されることを確認する。
+
+### 8. FinalVerify - 最終確認する
+
+- `gh issue view <parent> --json url,title,body,subIssues`でEpicと全Sub-issue progressを確認する。
+- 情報保持、親子関係、ラベルを最終確認する。
+
+## 出力
+
+- 親Issue URL、Epic化後のtitle/body概要
+- 作成したSub-issue一覧（URL、title、labels、親子関係）
+- 情報の移動先マッピング（親→子）
+- 未解決事項、ユーザー判断事項
+- 部分失敗時は作成済みIssue URLと未完了操作
+
+## 完了条件
+
+- 親IssueがEpicの要点に整理され、詳細情報が失われていない
+- 全Sub-issueがGitHubネイティブ親子関係で登録されている
+- 既存Sub-issueと重複するIssueが作成されていない
+- `github-issue-create-from-plan`と責務が重複していない
+- 汎用スキル本文に特定エージェント製品名が含まれていない

--- a/github-issue-decompose/agents/openai.yaml
+++ b/github-issue-decompose/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "GitHub Issue Decompose"
+  short_description: "既存IssueをSub-issueへ分解しEpic化する"
+  default_prompt: "Use $github-issue-decompose to decompose an existing GitHub Issue into native Sub-issues, using github-issue-create-from-plan for each child."
+

--- a/github-issue-decompose/references/github-api-details.md
+++ b/github-issue-decompose/references/github-api-details.md
@@ -1,0 +1,120 @@
+# GitHub API / CLI Reference
+
+github-issue-decompose が使用する `gh` コマンドとGitHub APIの詳細。
+
+## 前提
+
+- GitHubのSub-issue機能が有効なリポジトリであること
+- `gh auth status` が成功し、対象リポジトリへの読み取り・書き込み権限があること
+- `--parent` オプションおよび `--json subIssues` フィールドは `gh` の比較的新しいバージョンで提供される
+
+## 使用コマンド一覧
+
+### 1. 親Issueの取得
+
+```sh
+gh issue view <issue-number> \
+  --repo <owner/repo> \
+  --json number,title,body,labels,comments,url,state,projectItems
+```
+
+- `comments` フィールドには全コメントの本文・作成者の配列が含まれる
+- `--comments` フラグではなく `--json` に `comments` を含める
+
+### 2. 既存Sub-issueの取得
+
+GitHub CLIでネイティブSub-issueを検索する:
+
+```sh
+gh issue list \
+  --repo <owner/repo> \
+  --search "is:issue parent:<parent-number>" \
+  --json number,title,body,url,labels,state \
+  --state all
+```
+
+- `parent:` 検索はGitHubのSub-issue機能に依存する
+- `--state all` でOpen/Closed両方を取得し、重複防止に使う
+
+### 3. 既存ラベルの取得
+
+```sh
+gh label list --repo <owner/repo> --json name --jq '.[].name'
+```
+
+- 新しいラベルは作成しない
+- 既存ラベルのうち、Sub-issueの内容に明確に合うものだけを使う
+
+### 4. Sub-issueの作成
+
+```sh
+gh issue create \
+  --repo <owner/repo> \
+  --title "<title>" \
+  --body-file <temp-file> \
+  --label "<label1>,<label2>"
+```
+
+- `--body-file` を使い、Markdownをシェル引数へ埋め込まない
+- ラベルはカンマ区切りで指定する
+
+### 5. Sub-issueの親子付け
+
+```sh
+gh issue edit <child-number> \
+  --repo <owner/repo> \
+  --parent <parent-number>
+```
+
+- GitHubネイティブの親子関係が設定される
+- 親子付け後、親Issueに自動でSub-issue progressが表示される
+- この操作はMarkdownチェックリストの代わりになる
+
+### 6. Sub-issueの再取得確認
+
+```sh
+gh issue view <child-number> \
+  --repo <owner/repo> \
+  --json url,title,body,labels,state,parentIssue
+```
+
+- `parentIssue` フィールドで親子関係を確認する
+
+### 7. 親Issue本文の更新
+
+```sh
+gh issue edit <parent-number> \
+  --repo <owner/repo> \
+  --body-file <temp-file>
+```
+
+- 全Sub-issueの作成・親子付け・確認が成功した後にだけ実行する
+- `--body-file` を使い、Markdownをシェル引数へ埋め込まない
+
+### 8. 最終確認
+
+```sh
+gh issue view <parent-number> \
+  --repo <owner/repo> \
+  --json url,title,body,labels,state,subIssues
+```
+
+- `subIssues` フィールドで全Sub-issueの一覧とprogressを確認する
+- 各Sub-issueのURL、title、stateが含まれる
+
+## エラーハンドリング
+
+| 状況 | 対応 |
+|------|------|
+| `gh` 未認証 | 停止。`gh auth status` で確認を促す |
+| 書き込み権限なし | 停止。読み取りは可能でも親子付け・作成は不可 |
+| Sub-issue機能未対応 | 停止。GitHubのSub-issueが有効か確認を促す |
+| `--parent` オプション非対応 | 停止。`gh` のバージョンアップデートを促す |
+| 作成途中のAPI失敗 | 親本文変更せず、成功したIssue URLと失敗操作を報告 |
+| 再実行時の重複 | 既存Sub-issueを再取得し、同一目的の重複作成を防止 |
+
+## 冪等性
+
+- 再実行時は Fetch 工程で既存Sub-issueをすべて取得する
+- Analyze で提案した分割単位のうち、既存Sub-issueと同一目的のものはCreate対象から除外する
+- すでにEpic化済みの親Issueを再分解しようとした場合は、現状のSub-issue構成を報告し、追加工のみ確認する

--- a/github-issue-decompose/references/github-api-details.md
+++ b/github-issue-decompose/references/github-api-details.md
@@ -7,6 +7,7 @@ github-issue-decompose が使用する `gh` コマンドとGitHub APIの詳細�
 - GitHubのSub-issue機能が有効なリポジトリであること
 - `gh auth status` が成功し、対象リポジトリへの読み取り・書き込み権限があること
 - `--parent` オプションおよび `--json subIssues` フィールドは `gh` の比較的新しいバージョンで提供される
+- 必要ghバージョン: `gh` v2.94.0 以降（`--parent` フラグ、`parent` / `subIssues` JSONフィールド対応のため）
 
 ## 使用コマンド一覧
 
@@ -28,12 +29,12 @@ GitHub CLIでネイティブSub-issueを検索する:
 ```sh
 gh issue list \
   --repo <owner/repo> \
-  --search "is:issue parent:<parent-number>" \
+  --search "is:issue parent-issue:\"<owner>/<repo>#<parent-number>\"" \
   --json number,title,body,url,labels,state \
   --state all
 ```
 
-- `parent:` 検索はGitHubのSub-issue機能に依存する
+- `parent-issue:` 検索はGitHubのSub-issue機能に依存する
 - `--state all` でOpen/Closed両方を取得し、重複防止に使う
 
 ### 3. 既存ラベルの取得
@@ -75,10 +76,10 @@ gh issue edit <child-number> \
 ```sh
 gh issue view <child-number> \
   --repo <owner/repo> \
-  --json url,title,body,labels,state,parentIssue
+  --json url,title,body,labels,state,parent
 ```
 
-- `parentIssue` フィールドで親子関係を確認する
+- `parent` フィールドで親子関係を確認する
 
 ### 7. 親Issue本文の更新
 


### PR DESCRIPTION
## Issues

- Close #219

## Why

既存のGitHub Issueをレビュー可能な作業単位へ分解し、GitHubネイティブのSub-issueとして登録するスキルが必要。

## Summary

`github-issue-decompose` スキルを新規追加。既存Issueの本文・全コメント・既存Sub-issueを取得し、独立して完了・レビューできる単位へ分解、GitHubネイティブSub-issueとして登録、親IssueをEpic化する8工程のワークフロー（Fetch → Analyze → Preflight → Create → Link → Verify → Compact → FinalVerify）を実装。

## Changes

- `github-issue-decompose/SKILL.md` - 102行。責務境界、必須ルール、8工程ワークフロー、出力・完了条件
- `github-issue-decompose/references/github-api-details.md` - ghコマンド8種のオプション・JSONフィールド・エラーハンドリング・冪等性
- `github-issue-decompose/agents/openai.yaml` - display_name / short_description / default_prompt
- `README.md` - スキル数バッジ 32→33、Available Skills表に追加

## Verification

- `bash .scripts/validate-skills.sh` - 20エラーはすべて既存の `.system/` 由来。今回変更由来の新規エラーなし
