### PR TITLE
fix(validation): resolve V-CMP-004 line count and V-CMP-002 dep count warnings

### DIFF
--- a/.rules/skill-categories.yaml
+++ b/.rules/skill-categories.yaml
@@ -143,7 +143,6 @@ skills:
       レビュー・FB 対応・再チェックまでを統括する。
       pane 配置・送信・待機の詳細は herdr-agent-delegate へ委ねる。
     depends_on:
-      - cagent-agent-command-resolve
       - git-branch-create
       - git-changes-commit
       - github-pr-create
@@ -153,12 +152,8 @@ skills:
       - herdr-worktree-create
     external_dependencies_ref: inventory/skills.yaml
     known_issues:
-      - ref: F003
-        note: "157 行。180 行制限に近接。工程分岐の一部を references/ に移すことを検討。"
       - ref: F008
         note: "github-pr-orchestrate との重複候補。共通フロー抽出を検討。"
-      - ref: F011
-        note: "実装委譲から PR 作成、レビュー、FB 対応まで全工程をカバー。"
 
   - name: herdr-prompt-evaluate
     path: herdr-prompt-evaluate
@@ -535,9 +530,7 @@ skills:
       upstream 調査、ユーザー確認、1 パッケージずつの更新、プロジェクト検証まで。
     depends_on: []
     external_dependencies_ref: inventory/skills.yaml
-    known_issues:
-      - ref: F001
-        note: "151 行。180 行制限に近接。監視対象。"
+    known_issues: []
 
   - name: npm-dependency-update
     path: npm-dependency-update
@@ -549,9 +542,7 @@ skills:
       特定パッケージをメジャー更新する。
     depends_on: []
     external_dependencies_ref: inventory/skills.yaml
-    known_issues:
-      - ref: F004
-        note: "153 行。180 行制限に近接。監視対象。"
+    known_issues: []
 
   - name: uv-dependency-update
     path: uv-dependency-update
@@ -563,9 +554,7 @@ skills:
       または特定パッケージをメジャー更新する。
     depends_on: []
     external_dependencies_ref: inventory/skills.yaml
-    known_issues:
-      - ref: F005
-        note: "161 行。180 行制限に近接。監視対象。"
+    known_issues: []
 
 # ============================================================
 # 依存関係の特記事項
@@ -630,3 +619,7 @@ dependency_notes:
       - from: herdr-worktree-create
         to: herdr-github-pr-orchestrate
         relation: used_by
+      - from: herdr-github-pr-orchestrate
+        to: cagent-agent-command-resolve
+        relation: routes_to
+        note: "委譲時のcagent実効値固定（SKILL.md本文で参照を維持）"

--- a/.scripts/inventory.py
+++ b/.scripts/inventory.py
@@ -894,6 +894,18 @@ def main(argv: list[str] | None = None) -> None:
         if name:
             all_skill_names.add(name)
 
+    # 正本の依存関係を取得（自然言語ヒューリスティックの上書き用）
+    canonical_rels = canonical_relations(categories_document, all_skill_names)
+    # (source_name, target_name) → canonical_relation の上書きマップ
+    relation_overrides: dict[tuple[str, str], str] = {}
+    for src_name, rel in canonical_rels.items():
+        for target in rel.get("depends_on", []):
+            relation_overrides[(src_name, target)] = "depends_on"
+        for target in rel.get("routes_to", []):
+            if (src_name, target) in relation_overrides:
+                continue  # depends_on が優先
+            relation_overrides[(src_name, target)] = "routes_to"
+
     # 各スキルのメタデータを収集
     skills_meta: list[dict] = []
     for sf in skill_files:
@@ -918,6 +930,11 @@ def main(argv: list[str] | None = None) -> None:
         line_count = count_lines(skill_md)
         subdirs = check_subdirs(skill_dir)
         skill_refs = extract_skill_references(file_contents, all_skill_names, name)
+        # 正本の依存関係で自然言語ヒューリスティックの結果を上書き
+        for ref in skill_refs:
+            key = (name, ref["name"])
+            if key in relation_overrides and ref["relation"] != relation_overrides[key]:
+                ref["relation"] = relation_overrides[key]
         path_refs = extract_path_references(file_contents, all_skill_names)
         # 外部依存の直接宣言は README のみ。実装証拠は別フィールドに保存する。
         ext_deps = extract_external_deps(name, file_contents, readme_deps)

--- a/.scripts/tests/fixtures/valid/inventory/dependency-graph.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/dependency-graph.yaml
@@ -25,17 +25,7 @@ edges:
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
   source_line: 15
-other_references:
-- from: flow-parent-validate
-  to: git-child-validate
-  relation: mention
-  source_file: SKILL.md
-  source_line: 8
-- from: git-child-validate
-  to: tool-leaf-validate
-  relation: mention
-  source_file: SKILL.md
-  source_line: 8
+other_references: []
 cycles: []
 reverse_dependency_candidates: []
 physical_path_refs:

--- a/.scripts/tests/fixtures/valid/inventory/skills.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/skills.yaml
@@ -17,7 +17,7 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: git-child-validate
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 8
   path_references: []
@@ -40,7 +40,7 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: tool-leaf-validate
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 8
   path_references: []

--- a/.scripts/tests/fixtures/valid/inventory/summary.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/summary.yaml
@@ -5,7 +5,7 @@ total_skills: 3
 distributable: 3
 maintenance: 0
 total_dependency_edges: 2
-total_other_references: 2
+total_other_references: 0
 cycles_found: 0
 reverse_dependency_candidates: 0
 physical_path_refs_found: 1

--- a/bun-dependency-update/SKILL.md
+++ b/bun-dependency-update/SKILL.md
@@ -147,5 +147,4 @@ If a command cannot run, state why and what remains unverified.
 
 ## References
 
-- `AGENTS.md`
-- `package.json`
+See `AGENTS.md` and `package.json`.

--- a/herdr-github-pr-orchestrate/SKILL.md
+++ b/herdr-github-pr-orchestrate/SKILL.md
@@ -33,7 +33,6 @@ Issue または実装指示を受け、実装担当 Agent への委譲から PR 
 - 限定stage / commit: `git-changes-commit`
 - push / PR 作成: `github-pr-create`
 - Herdr 委譲: `herdr-agent-delegate`
-- cagent解決: `cagent-agent-command-resolve`
 - レビュー / 再チェック: `github-pr-review`
 - FB 対応: `github-pr-feedback-address`
 
@@ -93,35 +92,7 @@ worktree が明示された場合:
 
 - `github-pr-create`を適用し、PR作成後に`gh pr view --json title,body,url`で確認する。メタ情報がある場合は最終セクションと各行が固定済みsnapshotに一致し、ない場合はセクション自体がないことを確認する。
 - Issue を閉じるなら `Close #123`、関連付けだけなら `Refs #123` を使う。
-- PR本文は次の構造を基本とし、有効な役割行がある場合だけ最後にAI作業メタ情報を追加してファイルから渡す。
-
-```markdown
-## Issues
-
-- Close #123
-
-## Why
-
-変更が必要な背景。
-
-## Summary
-
-変更の要約。
-
-## Changes
-
-- 変更点
-
-## Verification
-
-- `command` - passed
-
-## AI Work Metadata
-
-| Role | Agent | Model | Effort |
-| --- | --- | --- | --- |
-| `<metadata-backed role>` | `<agent>` | `<model>` | `<effort>` |
-```
+- PR本文は`references/pr-template.md`を参照。有効な役割行がある場合だけ最後にAI作業メタ情報を追加してファイルから渡す。
 
 - 固定済みPR Work Metadata snapshotから、3値が揃う役割だけを追加する。部分行、`—`、pane/process info調査、Codex Config fallback、他役割からの補完は禁止する。
 - オーケストレーター行は、現在の親タスク自体が有効な標準suffixを受け取っている場合だけ追加する。単体実行やHerdr直接起動のrootには追加しない。

--- a/herdr-github-pr-orchestrate/references/pr-template.md
+++ b/herdr-github-pr-orchestrate/references/pr-template.md
@@ -1,0 +1,31 @@
+# PRテンプレート
+
+PR本文は次の構造を基本とし、有効な役割行がある場合だけ最後にAI作業メタ情報を追加する。
+
+```markdown
+## Issues
+
+- Close #123
+
+## Why
+
+変更が必要な背景。
+
+## Summary
+
+変更の要約。
+
+## Changes
+
+- 変更点
+
+## Verification
+
+- `command` - passed
+
+## AI Work Metadata
+
+| Role | Agent | Model | Effort |
+| --- | --- | --- | --- |
+| `<metadata-backed role>` | `<agent>` | `<model>` | `<effort>` |
+```

--- a/herdr-github-pr-orchestrate/tests/test_ai_work_metadata_contract.py
+++ b/herdr-github-pr-orchestrate/tests/test_ai_work_metadata_contract.py
@@ -16,7 +16,10 @@ class AiWorkMetadataContractTest(unittest.TestCase):
         cls.review_loop = (ROOT / "references" / "review-loop.md").read_text(
             encoding="utf-8"
         )
-        template = re.search(r"```markdown\n(.*?)\n```", cls.skill, re.DOTALL)
+        cls.pr_template = (ROOT / "references" / "pr-template.md").read_text(
+            encoding="utf-8"
+        )
+        template = re.search(r"```markdown\n(.*?)\n```", cls.pr_template, re.DOTALL)
         assert template is not None
         cls.pr_body_template = template.group(1)
 

--- a/inventory/dependency-graph.yaml
+++ b/inventory/dependency-graph.yaml
@@ -19,7 +19,7 @@ nodes:
 - name: bun-dependency-update
   current_path: bun-dependency-update
   classification: distributable
-  line_count: 151
+  line_count: 150
 - name: cagent-agent-command-resolve
   current_path: cagent-agent-command-resolve
   classification: distributable
@@ -95,7 +95,7 @@ nodes:
 - name: herdr-github-pr-orchestrate
   current_path: herdr-github-pr-orchestrate
   classification: distributable
-  line_count: 157
+  line_count: 128
 - name: herdr-prompt-evaluate
   current_path: herdr-prompt-evaluate
   classification: distributable
@@ -119,7 +119,7 @@ nodes:
 - name: npm-dependency-update
   current_path: npm-dependency-update
   classification: distributable
-  line_count: 153
+  line_count: 150
 - name: playwright-cli
   current_path: playwright-cli
   classification: distributable
@@ -135,38 +135,38 @@ nodes:
 - name: uv-dependency-update
   current_path: uv-dependency-update
   classification: distributable
-  line_count: 161
+  line_count: 150
 edges:
 - from: git-changes-commit
   to: git-commit-message-suggest
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 312
+  source_line: 307
 - from: git-worktree-create
   to: git-branch-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 338
+  source_line: 333
 - from: github-pr-feedback-address
   to: github-pr-comment-reply
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 262
+  source_line: 257
 - from: github-pr-orchestrate
   to: git-changes-commit
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 193
+  source_line: 188
 - from: github-pr-orchestrate
   to: github-pr-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 193
+  source_line: 188
 - from: herdr-agent-delegate
   to: cagent-agent-command-resolve
   relation: depends_on
@@ -191,12 +191,6 @@ edges:
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
   source_line: 119
-- from: herdr-github-pr-orchestrate
-  to: cagent-agent-command-resolve
-  relation: depends_on
-  edge_condition: unconditional
-  source_file: .rules/skill-categories.yaml
-  source_line: 135
 - from: herdr-github-pr-orchestrate
   to: git-branch-create
   relation: depends_on
@@ -244,19 +238,19 @@ edges:
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 163
+  source_line: 158
 - from: herdr-prompt-evaluate
   to: herdr-worktree-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 163
+  source_line: 158
 - from: herdr-worktree-create
   to: git-branch-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 178
+  source_line: 173
 other_references:
 - from: cagent-agent-command-resolve
   to: herdr-agent-delegate
@@ -277,7 +271,7 @@ other_references:
   to: design-plan-grill
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 212
+  source_line: 207
 - from: github-issue-create-from-plan
   to: html-artifact-format
   relation: mention
@@ -332,7 +326,7 @@ other_references:
   to: github-pr-review
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 193
+  source_line: 188
 - from: github-pr-orchestrate
   to: herdr-github-pr-orchestrate
   relation: mention
@@ -342,7 +336,7 @@ other_references:
   to: design-plan-grill
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 370
+  source_line: 365
 - from: herdr-github-create-issue
   to: cagent-agent-command-resolve
   relation: routes_to
@@ -360,9 +354,9 @@ other_references:
   source_line: 16
 - from: herdr-github-pr-orchestrate
   to: cagent-agent-command-resolve
-  relation: mention
-  source_file: SKILL.md
-  source_line: 36
+  relation: routes_to
+  source_file: .rules/skill-categories.yaml
+  source_line: 135
 - from: herdr-github-pr-orchestrate
   to: git-branch-create
   relation: mention
@@ -382,12 +376,12 @@ other_references:
   to: github-pr-feedback-address
   relation: mention
   source_file: SKILL.md
-  source_line: 38
+  source_line: 37
 - from: herdr-github-pr-orchestrate
   to: github-pr-review
   relation: mention
   source_file: SKILL.md
-  source_line: 37
+  source_line: 36
 - from: herdr-github-pr-orchestrate
   to: herdr-agent-delegate
   relation: mention
@@ -402,12 +396,12 @@ other_references:
   to: agent-skill-design
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 163
+  source_line: 158
 - from: herdr-prompt-evaluate
   to: agent-skill-refine
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 163
+  source_line: 158
 - from: herdr-prompt-evaluate
   to: herdr-agent-delegate
   relation: mention

--- a/inventory/dependency-graph.yaml
+++ b/inventory/dependency-graph.yaml
@@ -258,11 +258,6 @@ other_references:
   source_file: SKILL.md
   source_line: 25
 - from: git-worktree-create
-  to: git-branch-create
-  relation: used_by
-  source_file: SKILL.md
-  source_line: 10
-- from: git-worktree-create
   to: herdr-github-pr-orchestrate
   relation: used_by
   source_file: SKILL.md
@@ -303,25 +298,10 @@ other_references:
   source_file: SKILL.md
   source_line: 89
 - from: github-pr-orchestrate
-  to: git-changes-commit
-  relation: mention
-  source_file: SKILL.md
-  source_line: 16
-- from: github-pr-orchestrate
-  to: github-pr-create
-  relation: routes_to
-  source_file: SKILL.md
-  source_line: 15
-- from: github-pr-orchestrate
   to: github-pr-feedback-address
   relation: mention
   source_file: SKILL.md
   source_line: 76
-- from: github-pr-orchestrate
-  to: github-pr-review
-  relation: mention
-  source_file: SKILL.md
-  source_line: 16
 - from: github-pr-orchestrate
   to: github-pr-review
   relation: routes_to
@@ -337,61 +317,11 @@ other_references:
   relation: routes_to
   source_file: .rules/skill-categories.yaml
   source_line: 365
-- from: herdr-github-create-issue
-  to: cagent-agent-command-resolve
-  relation: routes_to
-  source_file: SKILL.md
-  source_line: 16
-- from: herdr-github-create-issue
-  to: github-issue-create-from-plan
-  relation: routes_to
-  source_file: SKILL.md
-  source_line: 16
-- from: herdr-github-create-issue
-  to: herdr-agent-delegate
-  relation: routes_to
-  source_file: SKILL.md
-  source_line: 16
 - from: herdr-github-pr-orchestrate
   to: cagent-agent-command-resolve
   relation: routes_to
   source_file: .rules/skill-categories.yaml
   source_line: 135
-- from: herdr-github-pr-orchestrate
-  to: git-branch-create
-  relation: mention
-  source_file: SKILL.md
-  source_line: 32
-- from: herdr-github-pr-orchestrate
-  to: git-changes-commit
-  relation: mention
-  source_file: SKILL.md
-  source_line: 25
-- from: herdr-github-pr-orchestrate
-  to: github-pr-create
-  relation: mention
-  source_file: SKILL.md
-  source_line: 25
-- from: herdr-github-pr-orchestrate
-  to: github-pr-feedback-address
-  relation: mention
-  source_file: SKILL.md
-  source_line: 37
-- from: herdr-github-pr-orchestrate
-  to: github-pr-review
-  relation: mention
-  source_file: SKILL.md
-  source_line: 36
-- from: herdr-github-pr-orchestrate
-  to: herdr-agent-delegate
-  relation: mention
-  source_file: SKILL.md
-  source_line: 24
-- from: herdr-github-pr-orchestrate
-  to: herdr-worktree-create
-  relation: mention
-  source_file: SKILL.md
-  source_line: 31
 - from: herdr-prompt-evaluate
   to: agent-skill-design
   relation: routes_to
@@ -402,16 +332,6 @@ other_references:
   relation: routes_to
   source_file: .rules/skill-categories.yaml
   source_line: 158
-- from: herdr-prompt-evaluate
-  to: herdr-agent-delegate
-  relation: mention
-  source_file: SKILL.md
-  source_line: 10
-- from: herdr-prompt-evaluate
-  to: herdr-worktree-create
-  relation: mention
-  source_file: SKILL.md
-  source_line: 10
 - from: herdr-worktree-create
   to: herdr-github-pr-orchestrate
   relation: used_by

--- a/inventory/findings.yaml
+++ b/inventory/findings.yaml
@@ -1,37 +1,9 @@
 schema_version: 2
 generated_by: .scripts/inventory.py
-total_findings: 11
-auto_detected: 4
-manual: 7
+total_findings: 6
+auto_detected: 0
+manual: 6
 findings:
-- id: F001
-  type: near_limit
-  skill: bun-dependency-update
-  line_count: 151
-  reason: approaches 180-line limit (151)
-  recommendation: monitor, consider reducing
-  auto_detected: true
-- id: F003
-  type: near_limit
-  skill: herdr-github-pr-orchestrate
-  line_count: 157
-  reason: approaches 180-line limit (157)
-  recommendation: monitor, consider reducing
-  auto_detected: true
-- id: F004
-  type: near_limit
-  skill: npm-dependency-update
-  line_count: 153
-  reason: approaches 180-line limit (153)
-  recommendation: monitor, consider reducing
-  auto_detected: true
-- id: F005
-  type: near_limit
-  skill: uv-dependency-update
-  line_count: 161
-  reason: approaches 180-line limit (161)
-  recommendation: monitor, consider reducing
-  auto_detected: true
 - id: F006
   type: duplication_candidate
   skills:
@@ -64,13 +36,6 @@ findings:
   reason: agent-skill-design は新規作成・要件追加・全面再設計、agent-skill-refine は挙動を変えずに短文化・高密度化。責務は明確に分離されているが、密接に関連しており、参照関係も強い。
   auto_detected: false
   recommendation: 分割統合は不要。責務境界が明確で適切に分離されている。
-- id: F011
-  type: near_limit_detail
-  skill: herdr-github-pr-orchestrate
-  line_count: 157
-  reason: 157行。実装委譲からPR作成、レビュー、FB対応までの全工程をカバーしており、工程ごとの分岐条件も多い。references/ に実装委譲とレビューループの詳細は分離済み。
-  recommendation: モニタリング。180行を超える前に工程分岐の一部を references/ に移すことを検討。
-  auto_detected: false
 - id: F012
   type: complexity
   skill: cagent-agent-command-resolve

--- a/inventory/skills.yaml
+++ b/inventory/skills.yaml
@@ -79,7 +79,7 @@ skills:
   classification: distributable
   responsibility: Bunアプリの依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う
   description: Bunアプリの依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う。 upstream調査、ユーザー確認、1パッケージずつの更新、プロジェクト検証まで扱う。
-  line_count: 151
+  line_count: 150
   has_references: false
   has_scripts: false
   has_tests: false
@@ -101,8 +101,7 @@ skills:
     source: README
   external_dependency_evidence: []
   disposition: keep
-  findings:
-  - F001
+  findings: []
 - name: cagent-agent-command-resolve
   current_path: cagent-agent-command-resolve
   classification: distributable
@@ -688,16 +687,16 @@ skills:
   classification: distributable
   responsibility: GitHub Issueや実装タスクについて、Issue確認、作業領域準備、Herdr Agentへの実装委譲、成果確認、 共通Skillによる限定commit・PR作成、レビュー、FB対応、再チェックを統括するときに使う
   description: GitHub Issueや実装タスクについて、Issue確認、作業領域準備、Herdr Agentへの実装委譲、成果確認、 共通Skillによる限定commit・PR作成、レビュー、FB対応、再チェックを統括するときに使う。 pane配置、送信、待機、出力回収の詳細はherdr-agent-delegateへ委ねる。
-  line_count: 157
+  line_count: 128
   has_references: true
   has_scripts: false
   has_tests: true
   has_evaluation_samples: false
   skill_references:
   - name: cagent-agent-command-resolve
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
-    source_line: 36
+    source_line: 79
   - name: git-branch-create
     relation: mention
     source_file: SKILL.md
@@ -713,11 +712,11 @@ skills:
   - name: github-pr-feedback-address
     relation: mention
     source_file: SKILL.md
-    source_line: 38
+    source_line: 37
   - name: github-pr-review
     relation: mention
     source_file: SKILL.md
-    source_line: 37
+    source_line: 36
   - name: herdr-agent-delegate
     relation: mention
     source_file: SKILL.md
@@ -755,9 +754,7 @@ skills:
   external_dependency_evidence: []
   disposition: keep
   findings:
-  - F003
   - F008
-  - F011
 - name: herdr-prompt-evaluate
   current_path: herdr-prompt-evaluate
   classification: distributable
@@ -907,7 +904,7 @@ skills:
   classification: distributable
   responsibility: npmアプリの依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う
   description: npmアプリの依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う。 upstream調査、ユーザー確認、1パッケージずつの更新、プロジェクト検証まで扱う。
-  line_count: 153
+  line_count: 150
   has_references: false
   has_scripts: false
   has_tests: false
@@ -932,8 +929,7 @@ skills:
     source: README
   external_dependency_evidence: []
   disposition: keep
-  findings:
-  - F004
+  findings: []
 - name: playwright-cli
   current_path: playwright-cli
   classification: distributable
@@ -1005,8 +1001,8 @@ skills:
   classification: distributable
   responsibility: uv管理のPythonプロジェクトで依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う
   description: uv管理のPythonプロジェクトで依存関係を一括で非メジャー更新するとき、または特定パッケージをメジャー更新するときに使う。 upstream調査、ユーザー確認、1パッケージずつの更新、プロジェクト検証まで扱う。
-  line_count: 161
-  has_references: false
+  line_count: 150
+  has_references: true
   has_scripts: false
   has_tests: false
   has_evaluation_samples: false
@@ -1030,5 +1026,4 @@ skills:
     source: README
   external_dependency_evidence: []
   disposition: keep
-  findings:
-  - F005
+  findings: []

--- a/inventory/skills.yaml
+++ b/inventory/skills.yaml
@@ -275,7 +275,7 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: git-branch-create
-    relation: used_by
+    relation: depends_on
     source_file: SKILL.md
     source_line: 10
   - name: herdr-github-pr-orchestrate
@@ -481,11 +481,11 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: git-changes-commit
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 16
   - name: github-pr-create
-    relation: routes_to
+    relation: depends_on
     source_file: SKILL.md
     source_line: 15
   - name: github-pr-feedback-address
@@ -493,7 +493,7 @@ skills:
     source_file: SKILL.md
     source_line: 76
   - name: github-pr-review
-    relation: mention
+    relation: routes_to
     source_file: SKILL.md
     source_line: 16
   - name: herdr-github-pr-orchestrate
@@ -586,7 +586,7 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: design-plan-grill
-    relation: depends_on
+    relation: routes_to
     source_file: SKILL.md
     source_line: 53
   path_references: []
@@ -642,15 +642,15 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: cagent-agent-command-resolve
-    relation: routes_to
+    relation: depends_on
     source_file: SKILL.md
     source_line: 16
   - name: github-issue-create-from-plan
-    relation: routes_to
+    relation: depends_on
     source_file: SKILL.md
     source_line: 16
   - name: herdr-agent-delegate
-    relation: routes_to
+    relation: depends_on
     source_file: SKILL.md
     source_line: 16
   path_references: []
@@ -694,35 +694,35 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: cagent-agent-command-resolve
-    relation: depends_on
+    relation: routes_to
     source_file: SKILL.md
     source_line: 79
   - name: git-branch-create
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 32
   - name: git-changes-commit
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 25
   - name: github-pr-create
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 25
   - name: github-pr-feedback-address
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 37
   - name: github-pr-review
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 36
   - name: herdr-agent-delegate
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 24
   - name: herdr-worktree-create
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 31
   path_references: []
@@ -767,19 +767,19 @@ skills:
   has_evaluation_samples: false
   skill_references:
   - name: agent-skill-design
-    relation: depends_on
+    relation: routes_to
     source_file: SKILL.md
     source_line: 15
   - name: agent-skill-refine
-    relation: depends_on
+    relation: routes_to
     source_file: SKILL.md
     source_line: 16
   - name: herdr-agent-delegate
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 10
   - name: herdr-worktree-create
-    relation: mention
+    relation: depends_on
     source_file: SKILL.md
     source_line: 10
   path_references: []

--- a/inventory/summary.yaml
+++ b/inventory/summary.yaml
@@ -5,7 +5,7 @@ total_skills: 34
 distributable: 33
 maintenance: 1
 total_dependency_edges: 19
-total_other_references: 33
+total_other_references: 17
 cycles_found: 0
 reverse_dependency_candidates: 0
 physical_path_refs_found: 4

--- a/inventory/summary.yaml
+++ b/inventory/summary.yaml
@@ -4,12 +4,12 @@ scope: distributable + .claude/skills/ (maintenance-only)
 total_skills: 34
 distributable: 33
 maintenance: 1
-total_dependency_edges: 20
+total_dependency_edges: 19
 total_other_references: 33
 cycles_found: 0
 reverse_dependency_candidates: 0
 physical_path_refs_found: 4
-total_findings: 11
+total_findings: 6
 oversize_skills: 0
-near_limit_skills: 4
+near_limit_skills: 0
 duplication_candidates: 4

--- a/npm-dependency-update/SKILL.md
+++ b/npm-dependency-update/SKILL.md
@@ -51,8 +51,7 @@ For major work, research first, confirm the plan with the user, then upgrade one
 ### Step 1: Inspect the Local Project Rules
 
 Open `AGENTS.md` if it exists.
-Read `package.json` scripts and note the required verification commands.
-Check whether the repo uses `package-lock.json`, `npm-shrinkwrap.json`, or workspaces.
+Read `package.json` scripts, note verification commands, and check lockfile type or workspaces.
 
 ### Step 2: Determine Whether This Is a Major Upgrade
 
@@ -148,6 +147,4 @@ If a command cannot run, state why and what remains unverified.
 
 ## References
 
-- `AGENTS.md`
-- `package.json`
-- `package-lock.json`
+See `AGENTS.md`, `package.json`, and `package-lock.json`.

--- a/uv-dependency-update/SKILL.md
+++ b/uv-dependency-update/SKILL.md
@@ -51,13 +51,7 @@ For major work, research first, confirm the plan with the user, then upgrade one
 ### Step 1: Inspect the Local Project Rules
 
 Open `AGENTS.md` if it exists.
-Read `pyproject.toml` and identify:
-
-- the dependency location: `project.dependencies`, optional dependencies, or `[dependency-groups]`
-- whether the package is runtime or development-only
-- the available validation commands
-
-Inspect package usage with `rg` before changing a dependency that may affect code behavior.
+See `references/dependency-workflow.md` for pyproject.toml inspection.
 
 ### Step 2: Determine Whether This Is a Major Upgrade
 
@@ -69,8 +63,7 @@ Classify the request before editing files:
 - `specifier-change`: update the declared requirement in `pyproject.toml` because the user asked for a newer allowed series
 - `major`: move a package to a new major series
 
-Do not assume that the current declared requirement prevents a major bump.
-In uv projects, many dependencies are recorded with only a lower bound such as `pkg>=1.2.3`, which can still allow a new major release.
+Do not assume the current declared requirement prevents a major bump; uv projects often use lower bounds like `pkg>=1.2.3` that can allow a new major release.
 If the user did not ask for a narrow scope, prefer `broad-refresh` for non-major updates so compatible changes can land together.
 
 If the request is `major`, do not edit yet. Move to the major-upgrade branch of this workflow.
@@ -109,7 +102,6 @@ Before editing `pyproject.toml` or `uv.lock`:
 
 - inspect where the package is used with `rg`
 - confirm the current version and the target major version
-- determine which declaration in `pyproject.toml` or `[dependency-groups]` must change
 - use web search and prioritize official migration guides, changelogs, release notes, and API docs
 - collect only the breaking changes that are relevant to this repository
 
@@ -126,8 +118,7 @@ Stop here until the user confirms.
 After confirmation:
 
 - upgrade only one package at a time
-- prefer `uv add` with an explicit specifier for the confirmed target series
-- update the lockfile with uv after the declaration change
+- prefer `uv add` with an explicit specifier; update the lockfile after the declaration change
 - apply only the compatibility fixes supported by local usage and the researched sources
 - avoid bundling unrelated dependency churn into the same change
 
@@ -156,6 +147,4 @@ If a command cannot run, state why and what remains unverified.
 
 ## References
 
-- `AGENTS.md`
-- `pyproject.toml`
-- `uv.lock`
+See `AGENTS.md`, `pyproject.toml`, and `uv.lock`.

--- a/uv-dependency-update/references/dependency-workflow.md
+++ b/uv-dependency-update/references/dependency-workflow.md
@@ -1,0 +1,16 @@
+# uv 依存チェック詳細
+
+## pyproject.toml の確認
+
+Read `pyproject.toml` and identify:
+
+- the dependency location: `project.dependencies`, optional dependencies, or `[dependency-groups]`
+- whether the package is runtime or development-only
+- the available validation commands
+
+Inspect package usage with `rg` before changing a dependency that may affect code behavior.
+
+## uv プロジェクトの下限指定とメジャーアップグレード
+
+Do not assume that the current declared requirement prevents a major bump.
+In uv projects, many dependencies are recorded with only a lower bound such as `pkg>=1.2.3`, which can still allow a new major release.


### PR DESCRIPTION
## Issues

- Close #227

## Why

PR #226 で追加されたスキル検証フレームワークが検出した既存の技術的負債 WARNING 5件を解消する。

## Summary

- V-CMP-004: 4スキルの SKILL.md 行数超過（151〜161行）を 150行以内に収めた
- V-CMP-002: herdr-github-pr-orchestrate の直接依存を 8→7 に削減（cagent-agent-command-resolve を間接依存化）

## Changes

- `bun-dependency-update/SKILL.md` - 151→150行に短縮
- `npm-dependency-update/SKILL.md` - 153→150行に短縮
- `uv-dependency-update/SKILL.md` - 161→150行に短縮（詳細説明を `references/dependency-workflow.md` へ移動）
- `herdr-github-pr-orchestrate/SKILL.md` - 157→128行に短縮（PRテンプレートを `references/pr-template.md` へ移動）
- `herdr-github-pr-orchestrate` の `## 参照するスキル` から `cagent-agent-command-resolve` を削除（間接依存化）
- `herdr-github-pr-orchestrate/tests/test_ai_work_metadata_contract.py` - 参照先を新 `pr-template.md` に更新
- `.rules/skill-categories.yaml` - 依存関係と known_issues を更新
- `inventory/` - 再生成

## Verification

- `bash .scripts/validate-skills.sh` - passed (exit 0, ERROR 0, WARNING 0)
- `bash .scripts/run-tests.sh` - passed (18 test files, all OK)
