### PR TITLE
refactor(phase4): dependency + tool カテゴリの責務整理

### DIFF
--- a/bun-dependency-update/SKILL.md
+++ b/bun-dependency-update/SKILL.md
@@ -147,4 +147,4 @@ If a command cannot run, state why and what remains unverified.
 
 ## References
 
-See `AGENTS.md` and `package.json`.
+See `AGENTS.md`, `package.json`, and `bun.lock`.


### PR DESCRIPTION
- Closes #230

## Phase 4-2: dependency + tool カテゴリ責務整理

### 変更内容

- `bun-dependency-update`: `## References` セクションに `bun.lock` を追加（npm/uv スキルとの一貫性確保）

### 判断サマリ（全11スキル）

| スキル | 行数 | 責務数 | 判断 |
|--------|------|--------|------|
| bun-dependency-update | 150 | 1 | 維持（References 追記） |
| npm-dependency-update | 150 | 1 | 維持 |
| uv-dependency-update | 150 | 1 | 維持 |
| apple-interface-design | 52 | 1 | 維持 |
| codex-skills-link | 104 | 1 | 維持（Codex特化スキル、製品名は責務上必須） |
| html-artifact-format | 56 | 1 | 維持 |
| image-to-svg | 131 | 1 | 維持 |
| japanese-text-refine | 63 | 1 | 維持 |
| playwright-cli | 68 | 1 | 維持 |
| qa-test-design | 51 | 1 | 維持 |
| tailwind-ui-compose | 69 | 1 | 維持 |

### Acceptance Criteria

- [x] 全対象スキルの責務を1文で説明できる（全スキル単一責務）
- [x] 不要な重複責務と下位手順の再定義が整理されている
- [x] 肥大化したSKILL.mdが分割または短縮されている（52〜150行、180行以内）
- [x] 物理パスによる他スキル参照が存在しない（codex-skills-link の `../.claude/skills` は symlink 操作指示）
- [x] 汎用スキル本文に特定エージェント製品への不要な依存がない
- [x] 依存関係と外部依存メタデータが実装に一致する
- [x] `bash .scripts/validate-skills.sh` 成功、全テストパス