### PR TITLE
refactor(phase4): git カテゴリの責務整理

### DIFF
--- a/.rules/skill-categories.yaml
+++ b/.rules/skill-categories.yaml
@@ -183,7 +183,7 @@ skills:
     external_dependencies_ref: inventory/skills.yaml
     known_issues:
       - ref: F006
-        note: "git-worktree-create との重複候補。共通ロジックの抽出を検討。"
+        note: "Phase 4 で境界確認済み。git-worktree-create は純粋な git 操作、herdr-worktree-create は Herdr ラッパー。利用コンテキストが異なるため統合不要。"
 
   - name: github-pr-orchestrate
     path: github-pr-orchestrate
@@ -343,7 +343,7 @@ skills:
     external_dependencies_ref: inventory/skills.yaml
     known_issues:
       - ref: F006
-        note: "herdr-worktree-create との重複候補。"
+        note: "Phase 4 で境界確認済み。git-worktree-create は純粋な git 操作、herdr-worktree-create は Herdr ラッパー。利用コンテキストが異なるため統合不要。"
 
   # --- design (2) ---
   - name: design-plan-grill

--- a/.scripts/inventory.py
+++ b/.scripts/inventory.py
@@ -770,7 +770,7 @@ def add_manual_findings(skills_meta: list[dict], auto_count: int) -> list[dict]:
             "skills": [gwt["name"], hwt["name"]],
             "reason": "両者とも独立したworktree作成が責務。git-worktree-create は純粋なgit操作、herdr-worktree-create はHerdrコマンドによる作成。責務が重複しているが、利用コンテキストが異なるため統合には慎重な判断が必要。",
             "auto_detected": False,
-            "recommendation": "統合候補。共通のworktree作成ロジックを抽出し、ラッパーとしてgit/herdr版を提供する構成を検討。",
+            "recommendation": "Phase 4 で境界確認済み。git-worktree-create は純粋な git 操作、herdr-worktree-create は Herdr ラッパー。利用コンテキストが異なるため統合不要。",
         })
 
     gr = name_map.get("grilling")

--- a/inventory/findings.yaml
+++ b/inventory/findings.yaml
@@ -11,7 +11,7 @@ findings:
   - herdr-worktree-create
   reason: 両者とも独立したworktree作成が責務。git-worktree-create は純粋なgit操作、herdr-worktree-create はHerdrコマンドによる作成。責務が重複しているが、利用コンテキストが異なるため統合には慎重な判断が必要。
   auto_detected: false
-  recommendation: 統合候補。共通のworktree作成ロジックを抽出し、ラッパーとしてgit/herdr版を提供する構成を検討。
+  recommendation: Phase 4 で境界確認済み。git-worktree-create は純粋な git 操作、herdr-worktree-create は Herdr ラッパー。利用コンテキストが異なるため統合不要。
 - id: F007
   type: duplication_candidate
   skills:


### PR DESCRIPTION
## Issues

- Close #232

## Why

skill-reorganization Phase 4 の git カテゴリ。4スキル（git-branch-create, git-changes-commit, git-commit-message-suggest, git-worktree-create）を検証。

## Summary

全4スキルが Phase 4 基準（単一責務、180行以内、製品固有名なし、絶対パスなし）を満たしており、SKILL.md の修正は不要。F006 の worktree 重複候補は境界確認のうえ統合不要と判断。

## Changes

- `.rules/skill-categories.yaml`: herdr-worktree-create / git-worktree-create の F006 note を「Phase 4 境界確認済み」に更新
- `.scripts/inventory.py`: F006 recommendation を更新
- `inventory/findings.yaml`: inventory 再生成による自動反映

## Verification

- `bash .scripts/validate-skills.sh` - passed
- `python3 .scripts/inventory.py` - 差分なし
