### PR TITLE
refactor(phase4): github カテゴリの責務整理

### DIFF
--- a/.rules/skill-categories.yaml
+++ b/.rules/skill-categories.yaml
@@ -153,7 +153,7 @@ skills:
     external_dependencies_ref: inventory/skills.yaml
     known_issues:
       - ref: F008
-        note: "github-pr-orchestrate との重複候補。共通フロー抽出を検討。"
+        note: "Phase 4 で境界確認済み。github-pr-orchestrate は非Herdr環境の直接統括、herdr-github-pr-orchestrate は Herdr Agent 委譲による統括。利用コンテキストが異なるため統合不要。共通スキル（github-pr-create 等）の参照は適切に共有。"
 
   - name: herdr-prompt-evaluate
     path: herdr-prompt-evaluate
@@ -201,7 +201,7 @@ skills:
     external_dependencies_ref: inventory/skills.yaml
     known_issues:
       - ref: F008
-        note: "herdr-github-pr-orchestrate との重複候補。"
+        note: "Phase 4 で境界確認済み。herdr-github-pr-orchestrate とは Herdr 利用の有無で責務が分離。Herdr 非使用の直接統括。共通スキル（github-pr-create 等）への委譲は適切。"
 
   # --- github (7) ---
   - name: github-issue-create-from-plan

--- a/.scripts/inventory.py
+++ b/.scripts/inventory.py
@@ -794,7 +794,7 @@ def add_manual_findings(skills_meta: list[dict], auto_count: int) -> list[dict]:
             "skills": [gpo["name"], hgo["name"]],
             "reason": "両者ともPR作成の統括フロー。github-pr-orchestrate は非Herdr環境、herdr-github-pr-orchestrate はHerdr環境向け。herdr版はgithub版の共通スキルを参照している。",
             "auto_detected": False,
-            "recommendation": "統合候補。共通フローを抽出し、Herdr/非Herdrの差異だけを切り替え可能にする。",
+            "recommendation": "Phase 4 で境界確認済み。github-pr-orchestrate は非Herdr環境の直接統括、herdr-github-pr-orchestrate は Herdr Agent 委譲による統括。利用コンテキストが異なるため統合不要。共通スキル（github-pr-create 等）の参照は適切に共有。",
         })
 
     asd = name_map.get("agent-skill-design")

--- a/inventory/findings.yaml
+++ b/inventory/findings.yaml
@@ -27,7 +27,8 @@ findings:
   - herdr-github-pr-orchestrate
   reason: 両者ともPR作成の統括フロー。github-pr-orchestrate は非Herdr環境、herdr-github-pr-orchestrate はHerdr環境向け。herdr版はgithub版の共通スキルを参照している。
   auto_detected: false
-  recommendation: 統合候補。共通フローを抽出し、Herdr/非Herdrの差異だけを切り替え可能にする。
+  recommendation: Phase 4 で境界確認済み。github-pr-orchestrate は非Herdr環境の直接統括、herdr-github-pr-orchestrate は Herdr Agent 委譲による統括。利用コンテキストが異なるため統合不要。共通スキル（github-pr-create
+    等）の参照は適切に共有。
 - id: F009
   type: duplication_candidate
   skills:


### PR DESCRIPTION
## Issues

- Close #233

## Why

skill-reorganization Phase 4 の github カテゴリ。7スキルを検証。

## Summary

全7スキルが Phase 4 基準（単一責務、180行以内、製品固有名なし、絶対パスなし）を満たしており、SKILL.md の修正は不要。F008 の orchestration 重複候補（github-pr-orchestrate / herdr-github-pr-orchestrate）は境界確認のうえ統合不要と判断。

## Changes

- `.rules/skill-categories.yaml`: F008 note を「Phase 4 境界確認済み」に更新
- `.scripts/inventory.py`: F008 recommendation を更新
- `inventory/findings.yaml`: inventory 再生成による自動反映

## Verification

- `bash .scripts/validate-skills.sh` - passed
- `python3 .scripts/inventory.py` - 差分なし
