### PR TITLE
refactor: remove external dependency type annotations (R/C/O/F)

### DIFF
--- a/.claude/skills/skills-readme-sync/SKILL.md
+++ b/.claude/skills/skills-readme-sync/SKILL.md
@@ -69,10 +69,10 @@ README の説明文は `SKILL.md` の front matter と本文冒頭から短く�
 - `SKILL.md` だけでなく、直接参照する `references/`、`scripts/`、プログラムの import・subprocess 呼び出しも確認する
 - リポジトリ内の別スキルは外部依存に含めない
 - Python 標準ライブラリは個別名ではなく `Python 3` と記載し、外部ライブラリだけをパッケージ名で記載する
-- 特定フローだけで必要な依存は `(C)`、代替手段は `(O)`、fallback は `(F)`、必須依存は `(R)` と記載する
-- README の依存注記は R/C/O/F の1文字 grammar に揃え、`—` は外部依存が1件もない場合だけ使う
-- 複数候補のうち1つで足りる場合は各候補を `(O)` とし、README の説明で少なくとも1つ必要である旨を明記する
+- 依存名はバッククォートで囲まず、カンマ区切りで列挙する。種別注記 `(R)/(C)/(O)/(F)` は付けない
+- 複数候補のうち1つで足りる場合はカンマ区切りで列挙し、README の説明で少なくとも1つ必要である旨を明記する
 - 外部依存が1件もない場合だけ `—` とする
+- 正本は `.rules/skill-categories.yaml` の `external_dependencies` フィールド。README は人間向けの表示用
 - 表の列は `Skill | Description | External Dependencies` に揃える
 
 ### Step 3: README の一覧を同期する

--- a/.rules/skill-categories.yaml
+++ b/.rules/skill-categories.yaml
@@ -74,6 +74,12 @@ skills:
   known_issues:
   - ref: F012
     note: cagent のバージョンアップ追従が必要。scripts/ への分離は適切。
+  external_dependencies:
+  - Herdr
+  - cagent
+  - Python 3
+  - selected Agent CLI
+  - POSIX shell
 - name: herdr-agent-delegate
   path: skills/orchestration/herdr-agent-delegate
   category: orchestration
@@ -86,6 +92,12 @@ skills:
   - cagent-agent-command-resolve
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Herdr
+  - jq
+  - Python 3
+  - POSIX shell
+  - Agent CLI
 - name: herdr-github-create-issue
   path: skills/orchestration/herdr-github-create-issue
   category: orchestration
@@ -101,6 +113,15 @@ skills:
   - herdr-agent-delegate
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Herdr
+  - cagent
+  - gh
+  - jq
+  - Git
+  - Python 3
+  - POSIX shell
+  - selected Agent CLI
 - name: herdr-github-pr-orchestrate
   path: skills/orchestration/herdr-github-pr-orchestrate
   category: orchestration
@@ -122,6 +143,15 @@ skills:
   known_issues:
   - ref: F008
     note: Phase 4 で境界確認済み。github-pr-orchestrate は非Herdr環境の直接統括、herdr-github-pr-orchestrate は Herdr Agent 委譲による統括。利用コンテキストが異なるため統合不要。共通スキル（github-pr-create 等）の参照は適切に共有。
+  external_dependencies:
+  - Herdr
+  - cagent
+  - gh
+  - jq
+  - Git
+  - Python 3
+  - POSIX shell
+  - Agent CLI
 - name: herdr-prompt-evaluate
   path: skills/orchestration/herdr-prompt-evaluate
   category: orchestration
@@ -135,6 +165,13 @@ skills:
   - herdr-worktree-create
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Herdr
+  - jq
+  - Git
+  - Python 3
+  - POSIX shell
+  - Agent CLI
 - name: herdr-worktree-create
   path: skills/orchestration/herdr-worktree-create
   category: orchestration
@@ -149,6 +186,10 @@ skills:
   known_issues:
   - ref: F006
     note: Phase 4 で境界確認済み。git-worktree-create は純粋な git 操作、herdr-worktree-create は Herdr ラッパー。利用コンテキストが異なるため統合不要。
+  external_dependencies:
+  - Herdr
+  - Git
+  - POSIX shell
 - name: github-pr-orchestrate
   path: skills/orchestration/github-pr-orchestrate
   category: orchestration
@@ -164,6 +205,12 @@ skills:
   known_issues:
   - ref: F008
     note: Phase 4 で境界確認済み。herdr-github-pr-orchestrate とは Herdr 利用の有無で責務が分離。Herdr 非使用の直接統括。共通スキル（github-pr-create 等）への委譲は適切。
+  external_dependencies:
+  - gh
+  - jq
+  - Git
+  - GitHub
+  - POSIX shell
 - name: github-issue-create-from-plan
   path: skills/github/github-issue-create-from-plan
   category: github
@@ -176,6 +223,10 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - GitHub
+  - POSIX shell
 - name: github-issue-decompose
   path: skills/github/github-issue-decompose
   category: github
@@ -187,6 +238,10 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - GitHub
+  - POSIX shell
 - name: github-pr-comment-reply
   path: skills/github/github-pr-comment-reply
   category: github
@@ -198,6 +253,10 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - GitHub API
+  - POSIX shell
 - name: github-pr-create
   path: skills/github/github-pr-create
   category: github
@@ -209,6 +268,11 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - Git
+  - GitHub
+  - POSIX shell
 - name: github-pr-feedback-address
   path: skills/github/github-pr-feedback-address
   category: github
@@ -221,6 +285,11 @@ skills:
   - github-pr-comment-reply
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - Git
+  - GitHub API
+  - POSIX shell
 - name: github-pr-post-merge-cleanup
   path: skills/github/github-pr-post-merge-cleanup
   category: github
@@ -233,6 +302,10 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - Git
+  - POSIX shell
 - name: github-pr-review
   path: skills/github/github-pr-review
   category: github
@@ -244,6 +317,11 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - gh
+  - jq
+  - GitHub API
+  - POSIX shell
 - name: git-branch-create
   path: skills/git/git-branch-create
   category: git
@@ -255,6 +333,9 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Git
+  - POSIX shell
 - name: git-changes-commit
   path: skills/git/git-changes-commit
   category: git
@@ -267,6 +348,9 @@ skills:
   - git-commit-message-suggest
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Git
+  - POSIX shell
 - name: git-commit-message-suggest
   path: skills/git/git-commit-message-suggest
   category: git
@@ -278,6 +362,9 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Git
+  - POSIX shell
 - name: git-worktree-create
   path: skills/git/git-worktree-create
   category: git
@@ -292,6 +379,9 @@ skills:
   known_issues:
   - ref: F006
     note: Phase 4 で境界確認済み。git-worktree-create は純粋な git 操作、herdr-worktree-create は Herdr ラッパー。利用コンテキストが異なるため統合不要。
+  external_dependencies:
+  - Git
+  - POSIX shell
 - name: design-plan-grill
   path: skills/design/design-plan-grill
   category: design
@@ -306,6 +396,7 @@ skills:
   known_issues:
   - ref: F007
     note: Phase 4 で境界確認済み。grilling の特殊化として責務分離は適切。routes_to で条件付き委譲。
+  external_dependencies: []
 - name: grilling
   path: skills/design/grilling
   category: design
@@ -320,6 +411,7 @@ skills:
   known_issues:
   - ref: F007
     note: Phase 4 で境界確認済み。design-plan-grill は設計特化、grilling は領域非依存。責務分離は適切。
+  external_dependencies: []
 - name: agent-skill-design
   path: skills/skill/agent-skill-design
   category: skill
@@ -333,6 +425,7 @@ skills:
   known_issues:
   - ref: F009
     note: Phase 4 で境界確認済み。design は挙動変更（新規作成・要件追加・再設計）、refine は意味保存改善。責務分離は適切。
+  external_dependencies: []
 - name: agent-skill-refine
   path: skills/skill/agent-skill-refine
   category: skill
@@ -346,6 +439,7 @@ skills:
   known_issues:
   - ref: F009
     note: Phase 4 で境界確認済み。design は挙動変更、refine は意味保存改善。責務分離は適切。
+  external_dependencies: []
 - name: skills-readme-sync
   path: .claude/skills/skills-readme-sync
   category: skill
@@ -370,6 +464,7 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies: []
 - name: codex-skills-link
   path: skills/tool/codex-skills-link
   category: tool
@@ -381,6 +476,9 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - POSIX shell
+  - coreutils
 - name: html-artifact-format
   path: skills/tool/html-artifact-format
   category: tool
@@ -392,6 +490,8 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - POSIX shell
 - name: image-to-svg
   path: skills/tool/image-to-svg
   category: tool
@@ -404,6 +504,10 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - librsvg
+  - Inkscape
+  - browser
 - name: japanese-text-refine
   path: skills/tool/japanese-text-refine
   category: tool
@@ -415,6 +519,7 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies: []
 - name: playwright-cli
   path: skills/tool/playwright-cli
   category: tool
@@ -427,6 +532,12 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Playwright CLI
+  - browser
+  - POSIX shell
+  - Node.js
+  - npx
 - name: qa-test-design
   path: skills/tool/qa-test-design
   category: tool
@@ -438,6 +549,7 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies: []
 - name: tailwind-ui-compose
   path: skills/tool/tailwind-ui-compose
   category: tool
@@ -449,6 +561,8 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Tailwind CSS project
 - name: bun-dependency-update
   path: skills/dependency/bun-dependency-update
   category: dependency
@@ -460,6 +574,11 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Bun
+  - rg
+  - POSIX shell
+  - web access
 - name: npm-dependency-update
   path: skills/dependency/npm-dependency-update
   category: dependency
@@ -471,6 +590,12 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - Node.js
+  - npm
+  - rg
+  - POSIX shell
+  - web access
 - name: uv-dependency-update
   path: skills/dependency/uv-dependency-update
   category: dependency
@@ -482,6 +607,12 @@ skills:
   depends_on: []
   external_dependencies_ref: inventory/skills.yaml
   known_issues: []
+  external_dependencies:
+  - uv
+  - Python
+  - rg
+  - POSIX shell
+  - web access
 dependency_notes:
   reverse_violations:
     description: '既知のカテゴリ逆方向依存。現在は該当なし。

--- a/.rules/skill-rules.yaml
+++ b/.rules/skill-rules.yaml
@@ -316,63 +316,7 @@ dependencies:
 # ============================================================
 external_dependencies:
 
-  # --- 5.1 種別定義 ---
-  types:
-    - id: required
-      symbol: "R"
-      definition: >
-        スキルの主要機能が動作するために必須。
-        利用可能でない場合、スキルは機能しない。
-      example: "gh CLI（github-* スキル）"
-
-    - id: conditional
-      symbol: "C"
-      definition: >
-        特定のフロー・条件下でのみ必要。
-        該当フロー以外ではスキルは動作する。
-      example: "web access（bun-dependency-update の major update 調査時）"
-
-    - id: optional
-      symbol: "O"
-      definition: >
-        推奨だが必須ではない。代替手段が存在するか、
-        または複数候補のうち 1 つで十分。
-        この依存なしでもスキルは動作する（機能制限はありうる）。
-      example: "librsvg / inkscape / browser（image-to-svg、いずれか 1 つ）"
-
-    - id: fallback
-      symbol: "F"
-      definition: >
-        主たる手段が利用できない場合の最終代替。
-        通常フローでは使用されない。
-      example: "npx（playwright-cli、Playwright CLI 非存在時のフォールバック）"
-
-  # --- 5.2 入力形式（README セルからの機械抽出規則） ---
-  input_format:
-    description: >
-      各スキルの README.md の External Dependencies 列から機械的に type を抽出する規則。
-
-    grammar:
-      cell_format: "依存名1, 依存名2 (type), 依存名3"
-      type_annotation: >
-        依存名の直後に半角丸括弧で type 記号 1 文字を記述する。
-        記号は R / C / O / F のいずれか 1 文字。
-        例: `gh CLI (R)`, `web access (C)`, `librsvg (O)`, `npx (F)`
-      default:
-        when_absent: "type 注記がない依存は required (R) とみなす。既定値で問題ない場合も明示的な R 注記を推奨する。"
-      normalization:
-        rule: "依存名先頭・末尾の空白を除去し、連続する空白を 1 つに正規化する。type 注記内の空白も除去する。"
-      error_rules:
-        unknown_type: >
-          定義された 4 種別（R/C/O/F）以外の注記（typo 含む）は ERROR として報告する。
-          例: `(conditonal)` → ERROR（正しくは `(C)`）
-        unclosed_paren: "閉じ括弧のない注記 `(R` など）は ERROR とする。"
-        multiple_annotations: "1 依存名に複数の type 注記がある場合は ERROR とする。"
-
-    canonical_source: "README.md 各スキルの External Dependencies 列"
-    parser_spec: "検証スクリプトはこの grammar に従って README をパースし、V-EXT-001 で未知 type を検出する。"
-
-  # --- 5.3 Effective External Dependencies の算出 ---
+  # --- 5.1 Effective External Dependencies の算出 ---
   effective_calculation:
     description: >
       各スキルの effective external dependencies（実効外部依存）は以下で算出する。
@@ -402,22 +346,8 @@ external_dependencies:
       step_3:
         label: "結合"
         description: "Effective = Direct ∪ Transitive（依存名で dedup）"
-      step_4:
-        label: "type 解決（条件付き伝搬考慮）"
-        description: >
-          同一の依存名が異なる type で出現した場合、以下を優先順に適用して解決する。
-          1. conditional エッジのみを経由する推移依存は、元の type に関わらず自スキルの conditional として扱う
-          2. それ以外の重複は厳しさ順 required > conditional > optional > fallback で解決する
-      step_5:
-        label: "optional/fallback の伝搬抑制"
-        description: >
-          optional および fallback 依存は、conditional エッジの有無に関わらず推移伝搬しない。
-          依存先スキルが optional/fallback で動作するなら、
-          呼び出し元にとって必須ではないとみなす。
-
     source_of_truth: >
-      直接依存の宣言元は各スキルの README.md（External Dependencies 列）とする。
-      inventory/skills.yaml は検証により最新化される。
+      直接依存の宣言元は .rules/skill-categories.yaml の external_dependencies フィールドとする。
 
 # ============================================================
 # 6. 管理構造・公開構造・アーカイブ
@@ -624,15 +554,10 @@ validation:
     # --- 外部依存 ---
     - id: V-EXT-001
       level: ERROR
-      subject: "外部依存 type の有効性"
-      description: >
-        全スキルの外部依存 type が §5.1 の 4 種別（R/C/O/F）のいずれかであり、
-        §5.2 の入力形式 grammar に従ってパース可能であること。
-        未知の type 注記、不完全な注記、複数注記は ERROR とする。
+      subject: "外部依存セルの有効性"
+      description: "全スキルの外部依存セルが README に存在し空欄でないこと"
       mechanical_check: >
-        README の External Dependencies 列を §5.2 grammar でパースし、
-        各依存の type が required/conditional/optional/fallback に解決されることを確認。
-        未注記は required へ解決し、定義外の注記は ERROR として報告する。
+        README の External Dependencies 列の各セルが存在し、空欄でないことを確認。
 
     - id: V-EXT-002
       level: WARNING
@@ -640,7 +565,7 @@ validation:
       description: "各スキルの effective external dependencies が算出可能である"
       mechanical_check: >
         depends_on を辿って推移依存を収集し、
-        type 解決が完了することを確認。
+        解決が完了することを確認。
         循環参照があると算出不能になるため、V-DEP-001 の前提で実施。
 
     - id: V-EXT-003
@@ -662,7 +587,7 @@ validation:
       level: ERROR
       subject: "公開Skillの外部依存セル"
       description: "全配布SkillがREADMEのAvailable Skills表に重複のないExternal Dependenciesセルを持つ"
-      mechanical_check: "配布対象のSKILL.mdパスごとにセルの存在、重複、空欄を確認し、R/C/O/F grammarで解析する"
+      mechanical_check: "配布対象のSKILL.mdパスごとにセルの有無・空欄・重複を確認する"
 
     # --- 命名 ---
     - id: V-NAM-001

--- a/.scripts/inventory.py
+++ b/.scripts/inventory.py
@@ -25,9 +25,6 @@ MAINTENANCE_PREFIX = ".claude/skills"
 SKILL_FILE_EXTS = {".md", ".py", ".sh", ".yaml", ".yml"}
 SKILL_FILE_EXCLUDES = {"agents/openai.yaml"}  # agent設定は走査対象外
 
-# ── 外部依存の種別 ────────────────────────────────────────
-DEP_TYPES = ("required", "conditional", "optional", "fallback")
-
 # ── 外部依存の別名正規化マップ（canonical → 別名集合） ───
 DEP_ALIAS_MAP = {name: set(aliases) for name, aliases in CANONICAL_DEPENDENCY_ALIASES.items()}
 
@@ -349,55 +346,30 @@ def extract_path_references(file_contents: list[dict],
 # 外部依存抽出
 # ====================================================================
 
-def parse_readme_deps() -> dict[str, list[dict]]:
-    """README.md の Available Skills テーブルから外部依存を取得する。
-
-    README の External Dependencies 列を直接の正本として扱い、
-    R/C/O/F grammar を解析する。実装中の import・command はここへ混ぜない。
-    """
-    readme_path = REPO_ROOT / "README.md"
-    if not readme_path.exists():
+def parse_canonical_deps() -> dict[str, list[dict]]:
+    """skill-categories.yaml の external_dependencies フィールドから外部依存を取得する。"""
+    categories_path = REPO_ROOT / ".rules/skill-categories.yaml"
+    if not categories_path.exists():
         return {}
 
-    with open(readme_path, encoding="utf-8") as f:
-        content = f.read()
+    with open(categories_path, encoding="utf-8") as f:
+        document = yaml.safe_load(f) or {}
 
     deps: dict[str, list[dict]] = {}
-    row = re.compile(r"^\|\s*\[([^]]+)\]\(([^)]+/SKILL\.md)\)\s*\|[^|]*\|\s*(.*?)\s*\|\s*$")
-    type_by_symbol = {"R": "required", "C": "conditional", "O": "optional", "F": "fallback"}
-    for line in content.splitlines():
-        match = row.match(line)
-        if not match:
+    for entry in document.get("skills", []):
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
             continue
-        name, dep_text = match.group(1), match.group(3).strip()
+        name = entry["name"]
+        raw = entry.get("external_dependencies", [])
+        if not isinstance(raw, list):
+            continue
         dep_list: list[dict] = []
-        if dep_text not in ("—", ""):
-            for part in _split_dependency_items(dep_text):
-                annotation = re.search(r"\(\s*([RCOF])\s*\)\s*$", part, re.IGNORECASE)
-                dep_type = type_by_symbol.get(annotation.group(1).upper(), "required") if annotation else "required"
-                if annotation:
-                    part = part[:annotation.start()].strip()
-                part = part.replace("`", "").strip()
-                if part and part != "—":
-                    dep_list.append({"name": part, "type": dep_type, "source": "README"})
+        for item in raw:
+            if isinstance(item, str):
+                dep_list.append({"name": item, "source": "skill-categories.yaml"})
         deps[name] = dep_list
 
     return deps
-
-
-def _split_dependency_items(text: str) -> list[str]:
-    """カンマ区切りを基本に、旧来の ``A / B (O)`` も個別化する。"""
-    items: list[str] = []
-    for raw in text.split(","):
-        raw = raw.strip()
-        if not raw or raw == "—":
-            continue
-        annotation = re.search(r"(\(\s*[RCOF]\s*\))\s*$", raw, re.IGNORECASE)
-        suffix = annotation.group(1) if annotation else ""
-        body = raw[:annotation.start()].strip() if annotation else raw
-        alternatives = [value.strip() for value in re.split(r"\s+/\s+", body) if value.strip()]
-        items.extend(f"{alternative} {suffix}".strip() for alternative in alternatives)
-    return items
 
 
 def extract_external_dependency_evidence(file_contents: list[dict]) -> list[dict]:
@@ -474,12 +446,12 @@ def extract_external_dependency_evidence(file_contents: list[dict]) -> list[dict
 
 def extract_external_deps(skill_name: str,
                           file_contents: list[dict],
-                          readme_deps: dict[str, list[dict]]) -> list[dict]:
-    """READMEの直接宣言だけをinventory形式へ変換する互換ヘルパー。"""
+                          canonical_deps: dict[str, list[dict]]) -> list[dict]:
+    """skill-categories.yamlの直接宣言だけをinventory形式へ変換するヘルパー。"""
     del file_contents
     return [
-        {"name": normalize_dep_name(dependency["name"]), "type": dependency["type"], "source": "README"}
-        for dependency in readme_deps.get(skill_name, [])
+        {"name": normalize_dep_name(dependency["name"]), "source": "skill-categories.yaml"}
+        for dependency in canonical_deps.get(skill_name, [])
     ]
 
 
@@ -845,19 +817,18 @@ def add_manual_findings(skills_meta: list[dict], auto_count: int) -> list[dict]:
         })
 
     # ── 共通依存 ──
-    deps_summary: dict[tuple[str, str], int] = {}
+    deps_summary: dict[str, int] = {}
     for s in skills_meta:
         for dep in s.get("external_dependencies", []):
-            key = (dep["name"], dep["type"])
+            key = dep["name"]
             deps_summary[key] = deps_summary.get(key, 0) + 1
 
-    for (dname, dtype), count in sorted(deps_summary.items(), key=lambda x: -x[1]):
+    for dname, count in sorted(deps_summary.items(), key=lambda x: -x[1]):
         if count >= len(skills_meta) * 0.5:
             findings.append({
                 "id": f"F-COMMON-{normalize_dep_name(dname).replace(' ', '-').upper()}",
                 "type": "common_dependency",
                 "dependency": dname,
-                "type_class": dtype,
                 "usage_count": count,
                 "reason": f"全スキルの {count}/{len(skills_meta)} が依存。共通依存として暗黙的に扱うことを検討。",
                 "auto_detected": False,
@@ -880,7 +851,7 @@ def main(argv: list[str] | None = None) -> None:
     skill_files = find_skill_files()
     print(f"Found {len(skill_files)} SKILL.md files (distributable + maintenance)")
 
-    readme_deps = parse_readme_deps()
+    canonical_deps = parse_canonical_deps()
     categories_document = load_yaml_document(CANONICAL_CATEGORIES)
     rules_document = load_yaml_document(CANONICAL_RULES)
 
@@ -936,8 +907,8 @@ def main(argv: list[str] | None = None) -> None:
             if key in relation_overrides and ref["relation"] != relation_overrides[key]:
                 ref["relation"] = relation_overrides[key]
         path_refs = extract_path_references(file_contents, all_skill_names)
-        # 外部依存の直接宣言は README のみ。実装証拠は別フィールドに保存する。
-        ext_deps = extract_external_deps(name, file_contents, readme_deps)
+        # 外部依存の正本は skill-categories.yaml。実装証拠は別フィールドに保存する。
+        ext_deps = extract_external_deps(name, file_contents, canonical_deps)
         ext_evidence = extract_external_dependency_evidence(file_contents)
 
         meta = {

--- a/.scripts/skill_validation/dependencies.py
+++ b/.scripts/skill_validation/dependencies.py
@@ -27,9 +27,7 @@ from .external import (
 CANONICAL_PATH = Path(".rules/skill-categories.yaml")
 INVENTORY_PATH = Path("inventory/skills.yaml")
 EDGE_CONDITIONS = {"unconditional", "conditional"}
-TYPE_BY_SYMBOL = {"R": "required", "C": "conditional", "O": "optional", "F": "fallback"}
-SYMBOL_BY_TYPE = {value: key for key, value in TYPE_BY_SYMBOL.items()}
-TYPE_PRIORITY = {"fallback": 0, "optional": 1, "conditional": 2, "required": 3}
+
 MARKDOWN_LINK = re.compile(r"!?\[[^]]*\]\(([^)]+)\)")
 INLINE_CODE = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
 DYNAMIC_PATH = re.compile(r"(?:\$\{?[^/\s}]+\}?|<[^>/\s]+>|\{[^}/\s]+\})")
@@ -80,7 +78,6 @@ SHELL_BUILTINS_AND_STANDARD = {
 @dataclass(frozen=True)
 class ExternalDependency:
     name: str
-    kind: str
 
 
 @dataclass(frozen=True)
@@ -463,11 +460,8 @@ def _normalize_dependency_name(value: str) -> str:
     return normalize_dependency_name(value)
 
 
-def _merge_dependency(target: dict[str, ExternalDependency], dependency: ExternalDependency) -> None:
-    key = _normalize_dependency_name(dependency.name)
-    existing = target.get(key)
-    if existing is None or TYPE_PRIORITY[dependency.kind] > TYPE_PRIORITY[existing.kind]:
-        target[key] = dependency
+def _merge_name(target: set[str], name: str) -> None:
+    target.add(_normalize_dependency_name(name))
 
 
 def _parse_external_cell(
@@ -476,8 +470,8 @@ def _parse_external_cell(
     cell: str,
     line: int,
     emit: bool,
-) -> dict[str, ExternalDependency]:
-    result: dict[str, ExternalDependency] = {}
+) -> set[str]:
+    result: set[str] = set()
     if cell.strip() == "—":
         return result
     for raw_item in cell.split(","):
@@ -486,44 +480,15 @@ def _parse_external_cell(
             if emit:
                 model.diagnostics.error("V-EXT-001", "README.md", line, f"{skill_name} has an empty dependency item")
             continue
-        annotations = re.findall(r"\(([^()]*)\)", item)
-        malformed = item.count("(") != item.count(")")
-        if malformed:
-            if emit:
-                model.diagnostics.error("V-EXT-001", "README.md", line, f"{skill_name} has an unclosed dependency annotation: {item}")
-            continue
-        if ("(" in item or ")" in item) and not annotations:
-            if emit:
-                model.diagnostics.error("V-EXT-001", "README.md", line, f"{skill_name} has a malformed dependency annotation: {item}")
-            continue
-        if len(annotations) > 1:
-            if emit:
-                model.diagnostics.error("V-EXT-001", "README.md", line, f"{skill_name} has multiple dependency annotations: {item}")
-            continue
-        kind = "required"
-        name = item
-        if annotations:
-            annotation = annotations[0].strip()
-            suffix = re.search(r"\(\s*([^()]*)\s*\)\s*$", item)
-            if suffix is None or annotation not in TYPE_BY_SYMBOL:
-                if emit:
-                    model.diagnostics.error("V-EXT-001", "README.md", line, f"{skill_name} has unknown dependency type annotation: {item}")
-                continue
-            kind = TYPE_BY_SYMBOL[annotation]
-            name = item[:suffix.start()].strip()
-        if not name or name == "—":
-            if emit:
-                model.diagnostics.error("V-EXT-001", "README.md", line, f"{skill_name} has an invalid dependency name: {item}")
-            continue
-        _merge_dependency(result, ExternalDependency(name, kind))
+        _merge_name(result, item)
     return result
 
 
-def _readme_dependencies(model: RepositoryModel, emit: bool) -> dict[str, dict[str, ExternalDependency]]:
+def _readme_dependencies(model: RepositoryModel, emit: bool) -> dict[str, set[str]]:
     entries: dict[str, list[Any]] = {}
     for entry in model.readme_entries:
         entries.setdefault(entry.path.removeprefix("./"), []).append(entry)
-    result: dict[str, dict[str, ExternalDependency]] = {name: {} for name in model.canonical_skills}
+    result: dict[str, set[str]] = {name: set() for name in model.canonical_skills}
     distributable = {skill.name for skill in model.distributable_skills if skill.name}
     for name in sorted(distributable):
         skill = model.skill_by_name[name]
@@ -544,66 +509,62 @@ def _readme_dependencies(model: RepositoryModel, emit: bool) -> dict[str, dict[s
     return result
 
 
+def _canonical_external_dependencies(model: RepositoryModel) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for skill in model.skills:
+        if not skill.name or not isinstance(skill.canonical, dict):
+            continue
+        raw = skill.canonical.get("external_dependencies")
+        if isinstance(raw, list):
+            deps: set[str] = set()
+            for item in raw:
+                if isinstance(item, str):
+                    _merge_name(deps, item)
+            result[skill.name] = deps
+        elif skill.name not in result:
+            result[skill.name] = set()
+    return result
+
+
 def _external_dependency_views(
     model: RepositoryModel,
-    direct: dict[str, dict[str, ExternalDependency]],
+    direct: dict[str, set[str]],
     edges: dict[str, tuple[str, ...]],
 ) -> tuple[dict[str, ExternalDependencyView], set[str]]:
-    cache: dict[str, tuple[dict[str, ExternalDependency], dict[str, ExternalDependency]]] = {}
+    cache: dict[str, tuple[set[str], set[str]]] = {}
     unresolvable: set[str] = set()
 
-    def calculate(name: str, stack: tuple[str, ...]) -> tuple[dict[str, ExternalDependency], dict[str, ExternalDependency]]:
+    def calculate(name: str, stack: tuple[str, ...]) -> tuple[set[str], set[str]]:
         if name in cache:
             return cache[name]
         if name in stack:
             unresolvable.update(stack[stack.index(name):])
-            return {}, dict(direct.get(name, {}))
-        transitive: dict[str, ExternalDependency] = {}
+            return set(), set(direct.get(name, set()))
+        transitive: set[str] = set()
         for target in edges.get(name, ()):
             _, target_effective = calculate(target, (*stack, name))
-            conditional_edge = _edge_conditions(model, name).get(target, "unconditional") == "conditional"
-            for dependency in target_effective.values():
-                if dependency.kind in {"optional", "fallback"}:
-                    continue
-                inherited = ExternalDependency(dependency.name, "conditional" if conditional_edge else dependency.kind)
-                _merge_dependency(transitive, inherited)
-        effective = dict(transitive)
-        for dependency in direct.get(name, {}).values():
-            key = _normalize_dependency_name(dependency.name)
-            inherited = effective.get(key)
-            if inherited is None or TYPE_PRIORITY[dependency.kind] >= TYPE_PRIORITY[inherited.kind]:
-                effective[key] = dependency
+            transitive |= target_effective
+        effective = transitive | direct.get(name, set())
         cache[name] = transitive, effective
         return cache[name]
+
+    def ordered(values: set[str]) -> tuple[ExternalDependency, ...]:
+        return tuple(ExternalDependency(name) for name in sorted(values, key=_normalize_dependency_name))
 
     views: dict[str, ExternalDependencyView] = {}
     for name in sorted(edges):
         transitive, effective = calculate(name, ())
-        ordered = lambda values: tuple(sorted(values.values(), key=lambda item: (_normalize_dependency_name(item.name), item.kind)))
-        views[name] = ExternalDependencyView(ordered(direct.get(name, {})), ordered(transitive), ordered(effective))
+        views[name] = ExternalDependencyView(ordered(direct.get(name, set())), ordered(transitive), ordered(effective))
     return views, unresolvable
 
 
 def external_dependency_views(model: RepositoryModel) -> dict[str, ExternalDependencyView]:
-    """Build graph-renderer data without emitting a second set of diagnostics."""
-    direct = _readme_dependencies(model, emit=False)
-    for skill in model.skills:
-        if skill.classification != "maintenance" or not skill.name or not isinstance(skill.canonical, dict):
-            continue
-        raw = skill.canonical.get("external_dependencies")
-        if not isinstance(raw, list):
-            continue
-        deps: dict[str, ExternalDependency] = {}
-        for item in raw:
-            if isinstance(item, str):
-                name = _normalize_dependency_name(item)
-                _merge_dependency(deps, ExternalDependency(name, "required"))
-        direct.setdefault(skill.name, {}).update(deps)
+    direct = _canonical_external_dependencies(model)
     views, _ = _external_dependency_views(model, direct, _canonical_edges(model))
     return views
 
 
-def _inventory_dependencies(model: RepositoryModel) -> dict[str, dict[str, str]] | None:
+def _inventory_dependencies(model: RepositoryModel) -> dict[str, set[str]] | None:
     path = model.root / INVENTORY_PATH
     if not path.is_file():
         return None
@@ -614,51 +575,42 @@ def _inventory_dependencies(model: RepositoryModel) -> dict[str, dict[str, str]]
     items = document.get("skills", []) if isinstance(document, dict) else []
     if not isinstance(items, list):
         return None
-    result: dict[str, dict[str, str]] = {}
+    result: dict[str, set[str]] = {}
     for item in items:
         if not isinstance(item, dict) or not isinstance(item.get("name"), str):
             continue
-        dependencies: dict[str, str] = {}
+        deps: set[str] = set()
         raw = item.get("external_dependencies", [])
         if isinstance(raw, list):
             for dependency in raw:
-                if isinstance(dependency, dict) and isinstance(dependency.get("name"), str) and dependency.get("type") in SYMBOL_BY_TYPE:
-                    dependencies[_normalize_dependency_name(dependency["name"])] = dependency["type"]
-        result[item["name"]] = dependencies
+                if isinstance(dependency, dict) and isinstance(dependency.get("name"), str):
+                    deps.add(_normalize_dependency_name(dependency["name"]))
+        result[item["name"]] = deps
     return result
 
 
-def _check_inventory(model: RepositoryModel, direct: dict[str, dict[str, ExternalDependency]]) -> None:
+def _check_inventory(model: RepositoryModel, direct: dict[str, set[str]]) -> None:
     inventory = _inventory_dependencies(model)
     if inventory is None:
         model.diagnostics.warning("V-EXT-003", INVENTORY_PATH, 1, "inventory snapshot is missing or invalid")
         return
     for name in sorted(set(direct) | set(inventory)):
-        readme = {key: dependency.kind for key, dependency in direct.get(name, {}).items()}
-        snapshot = inventory.get(name, {})
-        if readme == snapshot:
+        canonical = direct.get(name, set())
+        snapshot = inventory.get(name, set())
+        if canonical == snapshot:
             continue
         parts: list[str] = []
-        if readme.keys() - snapshot.keys():
-            parts.append("README-only=" + ", ".join(sorted(readme.keys() - snapshot.keys())))
-        if snapshot.keys() - readme.keys():
-            parts.append("inventory-only=" + ", ".join(sorted(snapshot.keys() - readme.keys())))
-        mismatched = sorted(key for key in readme.keys() & snapshot.keys() if readme[key] != snapshot[key])
-        if mismatched:
-            parts.append("type mismatch=" + ", ".join(f"{key} ({readme[key]} != {snapshot[key]})" for key in mismatched))
+        if canonical - snapshot:
+            parts.append("canonical-only=" + ", ".join(sorted(canonical - snapshot)))
+        if snapshot - canonical:
+            parts.append("inventory-only=" + ", ".join(sorted(snapshot - canonical)))
         model.diagnostics.warning("V-EXT-003", INVENTORY_PATH, 1, f"{name}: " + "; ".join(parts))
 
 
 def _declared_external_text(model: RepositoryModel) -> dict[str, str]:
     result: dict[str, str] = {}
-    for entry in model.readme_entries:
-        chunks = [re.sub(r"\([^()]*\)", "", item) for item in entry.dependency.split(",")]
-        path = entry.path.removeprefix("./")
-        skill = next((item for item in model.distributable_skills if item.path.relative_to(model.root).as_posix() == path), None)
-        if skill and skill.name:
-            result[skill.name] = " ".join(_normalize_dependency_name(chunk) for chunk in chunks)
     for skill in model.skills:
-        if skill.classification != "maintenance" or not skill.name or not isinstance(skill.canonical, dict):
+        if not skill.name or not isinstance(skill.canonical, dict):
             continue
         raw = skill.canonical.get("external_dependencies")
         if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
@@ -807,7 +759,8 @@ def check(model: RepositoryModel) -> None:
     _check_category_direction(model, edges)
     _check_physical_references(model)
     _check_extracted_relations(model)
-    direct = _readme_dependencies(model, emit=True)
+    _readme_dependencies(model, emit=True)
+    direct = _canonical_external_dependencies(model)
     _, unresolvable = _external_dependency_views(model, direct, edges)
     for name in sorted(unresolvable):
         model.diagnostics.warning("V-EXT-002", CANONICAL_PATH, _canonical_line(model, name), f"effective external dependencies are not calculable because {name!r} is cyclic")

--- a/.scripts/skill_validation/graph.py
+++ b/.scripts/skill_validation/graph.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 import tempfile
 
-from .dependencies import SYMBOL_BY_TYPE, ExternalDependency, external_dependency_views
+from .dependencies import ExternalDependency, external_dependency_views
 from .model import RepositoryModel
 
 
@@ -21,7 +21,7 @@ def _node_id(index: int) -> str:
 def _format_dependencies(dependencies: tuple[ExternalDependency, ...]) -> str:
     if not dependencies:
         return "—"
-    values = (f"{dependency.name.replace('|', '&#124;')} ({SYMBOL_BY_TYPE[dependency.kind]})" for dependency in dependencies)
+    values = (dependency.name.replace("|", "&#124;") for dependency in dependencies)
     return "<br>".join(values)
 
 
@@ -58,7 +58,6 @@ def _markdown(model: RepositoryModel) -> str:
         "",
         "## External dependencies",
         "",
-        "Types: R = required, C = conditional, O = optional, F = fallback.",
         "",
         "| Skill | Direct | Transitive | Effective |",
         "| --- | --- | --- | --- |",

--- a/.scripts/tests/fixtures/valid/.rules/skill-categories.yaml
+++ b/.scripts/tests/fixtures/valid/.rules/skill-categories.yaml
@@ -12,6 +12,10 @@ skills:
     depends_on: []
     external_dependencies_ref: inventory/skills.yaml
     known_issues: []
+    external_dependencies:
+      - Leaf
+      - Shared
+      - Fallback
   - name: git-child-validate
     path: git-child-validate
     category: git
@@ -20,6 +24,10 @@ skills:
     depends_on: [tool-leaf-validate]
     external_dependencies_ref: inventory/skills.yaml
     known_issues: []
+    external_dependencies:
+      - Git
+      - Shared
+      - Optional
   - name: flow-parent-validate
     path: flow-parent-validate
     category: orchestration
@@ -30,6 +38,8 @@ skills:
       git-child-validate: conditional
     external_dependencies_ref: inventory/skills.yaml
     known_issues: []
+    external_dependencies:
+      - Parent
 dependency_notes:
   routes_to_not_depends:
     items: []

--- a/.scripts/tests/fixtures/valid/README.md
+++ b/.scripts/tests/fixtures/valid/README.md
@@ -6,6 +6,6 @@
 
 | Skill | Description | External Dependencies |
 | --- | --- | --- |
-| [tool-leaf-validate](tool-leaf-validate/SKILL.md) | leaf | Leaf (R), Shared (R), Fallback (F) |
-| [git-child-validate](git-child-validate/SKILL.md) | child | Git (C), Shared (O), Optional (O) |
-| [flow-parent-validate](flow-parent-validate/SKILL.md) | parent | Parent (O) |
+| [tool-leaf-validate](tool-leaf-validate/SKILL.md) | leaf | Leaf, Shared, Fallback |
+| [git-child-validate](git-child-validate/SKILL.md) | child | Git, Shared, Optional |
+| [flow-parent-validate](flow-parent-validate/SKILL.md) | parent | Parent |

--- a/.scripts/tests/fixtures/valid/inventory/dependency-graph.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/dependency-graph.yaml
@@ -18,13 +18,13 @@ edges:
   relation: depends_on
   edge_condition: conditional
   source_file: .rules/skill-categories.yaml
-  source_line: 23
+  source_line: 31
 - from: git-child-validate
   to: tool-leaf-validate
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 15
+  source_line: 19
 other_references: []
 cycles: []
 reverse_dependency_candidates: []

--- a/.scripts/tests/fixtures/valid/inventory/findings.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/findings.yaml
@@ -1,6 +1,12 @@
 schema_version: 2
 generated_by: .scripts/inventory.py
-total_findings: 0
+total_findings: 1
 auto_detected: 0
-manual: 0
-findings: []
+manual: 1
+findings:
+- id: F-COMMON-SHARED
+  type: common_dependency
+  dependency: shared
+  usage_count: 2
+  reason: 全スキルの 2/3 が依存。共通依存として暗黙的に扱うことを検討。
+  auto_detected: false

--- a/.scripts/tests/fixtures/valid/inventory/skills.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/skills.yaml
@@ -23,8 +23,7 @@ skills:
   path_references: []
   external_dependencies:
   - name: parent
-    type: optional
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -46,14 +45,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: git
-    type: conditional
-    source: README
+    source: skill-categories.yaml
   - name: shared
-    type: optional
-    source: README
+    source: skill-categories.yaml
   - name: optional
-    type: optional
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -75,14 +71,11 @@ skills:
     source_line: 1
   external_dependencies:
   - name: leaf
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: shared
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: fallback
-    type: fallback
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []

--- a/.scripts/tests/fixtures/valid/inventory/summary.yaml
+++ b/.scripts/tests/fixtures/valid/inventory/summary.yaml
@@ -9,7 +9,7 @@ total_other_references: 0
 cycles_found: 0
 reverse_dependency_candidates: 0
 physical_path_refs_found: 1
-total_findings: 0
+total_findings: 1
 oversize_skills: 0
 near_limit_skills: 0
 duplication_candidates: 0

--- a/.scripts/tests/test_validate_skill_rules.py
+++ b/.scripts/tests/test_validate_skill_rules.py
@@ -394,7 +394,7 @@ class ValidationCliTest(unittest.TestCase):
 
         output = root / "preserve.md"
         output.write_text("old", encoding="utf-8")
-        self.replace(root / "README.md", "Parent (O)", "Parent (Z)")
+        self.replace(root / "README.md", "Parent", "")
         error = self.invoke(root, "--graph", str(output))
         self.assertEqual(error.returncode, 1, error.stderr)
         self.assertEqual(output.read_text(encoding="utf-8"), "old")
@@ -481,7 +481,7 @@ class ValidationCliTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         graph = (root / "graph.md").read_text(encoding="utf-8")
         self.assertIn("maint-tool-validate", graph)
-        self.assertIn("maint cli (R)", graph)
+        self.assertIn("maint cli", graph)
 
 
 if __name__ == "__main__":

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,6 @@ README のグルーピングはスキル名の prefix ではなく、利用目�
 - スキルの追加・変更時は、`SKILL.md`、`references/`、`scripts/`、プログラム内の import・外部コマンドを確認し、README の `External Dependencies` を同期する
 - スキルの追加・削除時は、README 先頭の Shields.io スキル数バッジも同期する
 - `.claude/skills/` 配下のリポジトリ保守専用スキルは品質検証対象に含めるが、README の `Available Skills` とスキル数バッジには含めない
-- 依存が特定フローに限られる場合は `conditional`、代替手段の場合は `optional` と明記する
 
 ローカル検証:
 
@@ -49,11 +48,4 @@ bash .scripts/validate-skills.sh
 
 同一カテゴリ内のスキル間依存は §4.2 に従う（循環なし・汎用→特殊方向・正本への明記が条件）。
 
-#### 外部依存種別
 
-| 種別 | 記号 | 意味 |
-|------|------|------|
-| `required` | R | 必須。なければスキルは機能しない |
-| `conditional` | C | 特定フローでのみ必要 |
-| `optional` | O | 代替手段あり。なくても動作する |
-| `fallback` | F | 主手段が使えない場合の最終代替 |

--- a/README.md
+++ b/README.md
@@ -10,46 +10,46 @@
 ## Available Skills
 
 スキルは利用目的ごとにグルーピングしてあります。グループ内の並びは関連の強さや作業フローの順です。
-`External Dependencies` は実行に必要な CLI、ランタイム、外部サービスを示します。依存名の後ろに `(R)`（required: 必須）、`(C)`（conditional: 条件付き）、`(O)`（optional: 代替可能）、`(F)`（fallback: 最終代替）を付けます。`—` は外部依存が1件もない場合だけ使います。
+ `External Dependencies` は実行に必要な CLI、ランタイム、外部サービスを示します。`—` は外部依存が1件もない場合だけ使います。依存の種別定義は `.rules/skill-categories.yaml` を正本とします。
 
 ### Git ローカル操作
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [git-branch-create](skills/git/git-branch-create/SKILL.md) | ブランチ名を提案し、ブランチを作成する | Git (R), POSIX shell (R) |
-| [git-worktree-create](skills/git/git-worktree-create/SKILL.md) | 独立した git worktree を作成し、並列作業用の作業領域を用意する | Git (R), POSIX shell (R) |
-| [git-commit-message-suggest](skills/git/git-commit-message-suggest/SKILL.md) | 変更内容に合うコミットメッセージだけを提案し、stageやcommitは行わない | Git (R), POSIX shell (R) |
-| [git-changes-commit](skills/git/git-changes-commit/SKILL.md) | 今回の変更だけを限定stageし、安全にcommitして結果を確認する | Git (R), POSIX shell (R) |
+| [git-branch-create](skills/git/git-branch-create/SKILL.md) | ブランチ名を提案し、ブランチを作成する | Git, POSIX shell |
+| [git-worktree-create](skills/git/git-worktree-create/SKILL.md) | 独立した git worktree を作成し、並列作業用の作業領域を用意する | Git, POSIX shell |
+| [git-commit-message-suggest](skills/git/git-commit-message-suggest/SKILL.md) | 変更内容に合うコミットメッセージだけを提案し、stageやcommitは行わない | Git, POSIX shell |
+| [git-changes-commit](skills/git/git-changes-commit/SKILL.md) | 今回の変更だけを限定stageし、安全にcommitして結果を確認する | Git, POSIX shell |
 
 ### GitHub Issue / PR
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [github-issue-decompose](skills/github/github-issue-decompose/SKILL.md) | 既存Issueを本文・全コメントを根拠にSub-issueへ分解し、親をEpic化する | `gh` (R), GitHub (R), POSIX shell (R) |
-| [github-issue-create-from-plan](skills/github/github-issue-create-from-plan/SKILL.md) | 確定済みプランからテンプレートを選び、GitHub Issueを作成・確認する | `gh` (R), GitHub (R), POSIX shell (R) |
-| [github-pr-orchestrate](skills/orchestration/github-pr-orchestrate/SKILL.md) | 未コミット変更の確認から限定commit、PR作成、指定レビュー工程まで統括する | `gh` (R), `jq` (C), Git (R), GitHub (R), POSIX shell (R) |
-| [github-pr-create](skills/github/github-pr-create/SKILL.md) | 非修正型の品質チェック後、commit済み変更をpushしてPRを作成・確認する | `gh` (R), Git (R), GitHub (R), POSIX shell (R) |
-| [github-pr-feedback-address](skills/github/github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う | `gh` (R), Git (R), GitHub API (R), POSIX shell (R) |
-| [github-pr-review](skills/github/github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う | `gh` (R), `jq` (R), GitHub API (R), POSIX shell (R) |
-| [github-pr-comment-reply](skills/github/github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する | `gh` (R), GitHub API (R), POSIX shell (R) |
-| [github-pr-post-merge-cleanup](skills/github/github-pr-post-merge-cleanup/SKILL.md) | マージ済み PR の基準ブランチへ戻り、ローカル作業ブランチを安全に整理する | `gh` (R), Git (R), POSIX shell (R) |
+| [github-issue-decompose](skills/github/github-issue-decompose/SKILL.md) | 既存Issueを本文・全コメントを根拠にSub-issueへ分解し、親をEpic化する | `gh`, GitHub, POSIX shell |
+| [github-issue-create-from-plan](skills/github/github-issue-create-from-plan/SKILL.md) | 確定済みプランからテンプレートを選び、GitHub Issueを作成・確認する | `gh`, GitHub, POSIX shell |
+| [github-pr-orchestrate](skills/orchestration/github-pr-orchestrate/SKILL.md) | 未コミット変更の確認から限定commit、PR作成、指定レビュー工程まで統括する | `gh`, `jq`, Git, GitHub, POSIX shell |
+| [github-pr-create](skills/github/github-pr-create/SKILL.md) | 非修正型の品質チェック後、commit済み変更をpushしてPRを作成・確認する | `gh`, Git, GitHub, POSIX shell |
+| [github-pr-feedback-address](skills/github/github-pr-feedback-address/SKILL.md) | GitHub PR のレビュー指摘を確認し、実装対応から返信まで行う | `gh`, Git, GitHub API, POSIX shell |
+| [github-pr-review](skills/github/github-pr-review/SKILL.md) | 指定した GitHub PR をレビューし、FB 対応後の再チェックまで行う | `gh`, `jq`, GitHub API, POSIX shell |
+| [github-pr-comment-reply](skills/github/github-pr-comment-reply/SKILL.md) | GitHub PR の review comment や conversation comment に返信する | `gh`, GitHub API, POSIX shell |
+| [github-pr-post-merge-cleanup](skills/github/github-pr-post-merge-cleanup/SKILL.md) | マージ済み PR の基準ブランチへ戻り、ローカル作業ブランチを安全に整理する | `gh`, Git, POSIX shell |
 
 ### Agent委譲 / オーケストレーション
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [herdr-worktree-create](skills/orchestration/herdr-worktree-create/SKILL.md) | Herdr 公式コマンドで独立した worktree と workspace を作成する | Herdr (R), Git (R), POSIX shell (R) |
-| [cagent-agent-command-resolve](skills/orchestration/cagent-agent-command-resolve/SKILL.md) | cagentの実効Agent・Model・Effortをagent-kind・native-agent-argsへ固定し、任意の委譲メタ情報を返す | Herdr (R), `cagent` (R), Python 3 (R), selected Agent CLI (R), POSIX shell (R) |
-| [herdr-agent-delegate](skills/orchestration/herdr-agent-delegate/SKILL.md) | Herdr 0.7.5公式API（agent start/prompt/wait/read/send-keys）でCLI Agentを配置し、任意の起動時メタ情報付きで送信・待機・出力回収を行う | Herdr (R), `jq` (R), Python 3 (R), POSIX shell (R), Agent CLI (R) |
-| [herdr-github-create-issue](skills/orchestration/herdr-github-create-issue/SKILL.md) | 確定済みプランのIssue作成をHerdrの新規Agentへ委譲する | Herdr (R), `cagent` (R), `gh` (R), `jq` (R), Git (R), Python 3 (R), POSIX shell (R), selected Agent CLI (R) |
-| [herdr-github-pr-orchestrate](skills/orchestration/herdr-github-pr-orchestrate/SKILL.md) | Issue確認から実装委譲、commit、push、PR作成、レビュー・FB対応・再チェックまで統括する | Herdr (R), `cagent` (R), `gh` (R), `jq` (R), Git (R), Python 3 (R), POSIX shell (R), Agent CLI (R) |
-| [herdr-prompt-evaluate](skills/orchestration/herdr-prompt-evaluate/SKILL.md) | Herdrの独立Agentでプロンプトを実証評価し、観測した1テーマを最小改善する | Herdr (R), `jq` (R), Git (R), Python 3 (R), POSIX shell (R), Agent CLI (R) |
+| [herdr-worktree-create](skills/orchestration/herdr-worktree-create/SKILL.md) | Herdr 公式コマンドで独立した worktree と workspace を作成する | Herdr, Git, POSIX shell |
+| [cagent-agent-command-resolve](skills/orchestration/cagent-agent-command-resolve/SKILL.md) | cagentの実効Agent・Model・Effortをagent-kind・native-agent-argsへ固定し、任意の委譲メタ情報を返す | Herdr, `cagent`, Python 3, selected Agent CLI, POSIX shell |
+| [herdr-agent-delegate](skills/orchestration/herdr-agent-delegate/SKILL.md) | Herdr 0.7.5公式API（agent start/prompt/wait/read/send-keys）でCLI Agentを配置し、任意の起動時メタ情報付きで送信・待機・出力回収を行う | Herdr, `jq`, Python 3, POSIX shell, Agent CLI |
+| [herdr-github-create-issue](skills/orchestration/herdr-github-create-issue/SKILL.md) | 確定済みプランのIssue作成をHerdrの新規Agentへ委譲する | Herdr, `cagent`, `gh`, `jq`, Git, Python 3, POSIX shell, selected Agent CLI |
+| [herdr-github-pr-orchestrate](skills/orchestration/herdr-github-pr-orchestrate/SKILL.md) | Issue確認から実装委譲、commit、push、PR作成、レビュー・FB対応・再チェックまで統括する | Herdr, `cagent`, `gh`, `jq`, Git, Python 3, POSIX shell, Agent CLI |
+| [herdr-prompt-evaluate](skills/orchestration/herdr-prompt-evaluate/SKILL.md) | Herdrの独立Agentでプロンプトを実証評価し、観測した1テーマを最小改善する | Herdr, `jq`, Git, Python 3, POSIX shell, Agent CLI |
 
 ### 実装 / 成果物生成
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [html-artifact-format](skills/tool/html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLを判断し、視覚化要素入りの単一HTMLを生成する | POSIX shell (R) |
+| [html-artifact-format](skills/tool/html-artifact-format/SKILL.md) | AI向けMarkdownと人間向けHTMLを判断し、視覚化要素入りの単一HTMLを生成する | POSIX shell |
 
 ### 要件定義 / 設計対話
 
@@ -74,28 +74,28 @@
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [bun-dependency-update](skills/dependency/bun-dependency-update/SKILL.md) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める | Bun (R), `rg` (R), POSIX shell (R), web access (C) |
-| [npm-dependency-update](skills/dependency/npm-dependency-update/SKILL.md) | npm アプリの依存更新を非メジャー/major の分岐付きで安全に進める | Node.js (R), npm (R), `rg` (R), POSIX shell (R), web access (C) |
-| [uv-dependency-update](skills/dependency/uv-dependency-update/SKILL.md) | uv 管理の Python 依存更新を非メジャー/major の分岐付きで安全に進める | `uv` (R), Python (R), `rg` (R), POSIX shell (R), web access (C) |
+| [bun-dependency-update](skills/dependency/bun-dependency-update/SKILL.md) | Bun アプリの依存更新を非メジャー/major の分岐付きで安全に進める | Bun, `rg`, POSIX shell, web access |
+| [npm-dependency-update](skills/dependency/npm-dependency-update/SKILL.md) | npm アプリの依存更新を非メジャー/major の分岐付きで安全に進める | Node.js, npm, `rg`, POSIX shell, web access |
+| [uv-dependency-update](skills/dependency/uv-dependency-update/SKILL.md) | uv 管理の Python 依存更新を非メジャー/major の分岐付きで安全に進める | `uv`, Python, `rg`, POSIX shell, web access |
 
 ### UI / フロントエンド
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
 | [apple-interface-design](skills/tool/apple-interface-design/SKILL.md) | Appleの設計思想をWebへ翻案し、流体モーションとアクセシブルなUIを設計・レビューする | — |
-| [tailwind-ui-compose](skills/tool/tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える | Tailwind CSS project (R) |
+| [tailwind-ui-compose](skills/tool/tailwind-ui-compose/SKILL.md) | 画面構成から始めて Tailwind UI の設計と実装方針を整える | Tailwind CSS project |
 
 ### ブラウザ操作 / 検証
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [playwright-cli](skills/tool/playwright-cli/SKILL.md) | Playwright CLI の独立ブラウザで localhost などの画面検証を進める | Playwright CLI (R), browser (R), POSIX shell (R), Node.js (F), `npx` (F) |
+| [playwright-cli](skills/tool/playwright-cli/SKILL.md) | Playwright CLI の独立ブラウザで localhost などの画面検証を進める | Playwright CLI, browser, POSIX shell, Node.js, `npx` |
 
 ### Experimental
 
 | Skill | Description | External Dependencies |
 |-------|-------------|-----------------------|
-| [image-to-svg](skills/tool/image-to-svg/SKILL.md) | 画像（PNG/JPEG）を編集可能な SVG に変換する | librsvg (O), Inkscape (O), browser (O) |
+| [image-to-svg](skills/tool/image-to-svg/SKILL.md) | 画像（PNG/JPEG）を編集可能な SVG に変換する | librsvg, Inkscape, browser |
 
 ### スキル作成 / メンテナンス
 
@@ -103,9 +103,9 @@
 |-------|-------------|-----------------------|
 | [agent-skill-design](skills/skill/agent-skill-design/SKILL.md) | Agent Skillの新規作成、仕様変更、全面再設計、設計レビューを行う | — |
 | [agent-skill-refine](skills/skill/agent-skill-refine/SKILL.md) | 既存Agent Skillを挙動を変えず短く高密度に改善する | — |
-| [codex-skills-link](skills/tool/codex-skills-link/SKILL.md) | `.codex/skills`だけを操作し、`.claude/skills`をCodexから再利用できるようにリンクする | POSIX shell (R), coreutils (R) |
+| [codex-skills-link](skills/tool/codex-skills-link/SKILL.md) | `.codex/skills`だけを操作し、`.claude/skills`をCodexから再利用できるようにリンクする | POSIX shell, coreutils |
 
-`image-to-svg` は `librsvg`、Inkscape、browser のいずれか1つが必要です。候補を個別に `(O)` と記載し、複数導入を必須とはしません。
+`image-to-svg` は `librsvg`、Inkscape、browser のいずれか1つが必要です。候補を個別に記載し、複数導入を必須とはしません。
 
 ## Validation
 
@@ -117,9 +117,9 @@ bash .scripts/validate-skills.sh
 bash .scripts/validate-skills.sh --graph /tmp/skill-dependency-graph.md
 ```
 
-`--graph PATH` は `.rules/skill-categories.yaml` の `depends_on` と README の直接外部依存から決定的なグラフを生成します。ERROR が1件でもあれば終了コード1、WARNINGだけなら終了コード0です。検証ERROR時は既存の出力を変更せず、出力先I/Oエラーは通常diagnosticを表示した上で終了コード2にします。
+`--graph PATH` は `.rules/skill-categories.yaml` の `depends_on` と `external_dependencies` から決定的なグラフを生成します。ERROR が1件でもあれば終了コード1、WARNINGだけなら終了コード0です。検証ERROR時は既存の出力を変更せず、出力先I/Oエラーは通常diagnosticを表示した上で終了コード2にします。
 
-カテゴリとスキル間依存の正本は `.rules/skill-categories.yaml`、検証基準は `.rules/skill-rules.yaml`、配布Skillの外部依存の正本は README の `External Dependencies` 列です。保守Skillの直接外部依存は `skill-categories.yaml` の当該エントリへ記録します。スキルや依存を変更したときは `python3 .scripts/inventory.py` で4つのinventory YAMLを再生成します。通常検証は一時生成した期待値とchecked-in版を比較し、陳腐化をERRORにします。
+カテゴリ、スキル間依存、全スキルの外部依存の正本は `.rules/skill-categories.yaml`、検証基準は `.rules/skill-rules.yaml` です。README の `External Dependencies` 列は参照用です。スキルや依存を変更したときは `python3 .scripts/inventory.py` で4つのinventory YAMLを再生成します。通常検証は一時生成した期待値とchecked-in版を比較し、陳腐化をERRORにします。
 
 例外は `.rules/skill-rules.yaml` の `validation.exceptions` に記録します。WARNING と `V-STR-002` に限り、`check_id`、`target`、非空の具体的な`reason`が揃った一意な記録だけを認め、抑制結果も理由付きWARNINGとして表示します。他のERROR、未知ID、存在しないtargetは禁止です。
 

--- a/inventory/dependency-graph.yaml
+++ b/inventory/dependency-graph.yaml
@@ -142,115 +142,115 @@ edges:
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 258
+  source_line: 339
 - from: git-worktree-create
   to: git-branch-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 281
+  source_line: 368
 - from: github-pr-feedback-address
   to: github-pr-comment-reply
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 212
+  source_line: 276
 - from: github-pr-orchestrate
   to: git-changes-commit
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 152
+  source_line: 193
 - from: github-pr-orchestrate
   to: github-pr-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 152
+  source_line: 193
 - from: herdr-agent-delegate
   to: cagent-agent-command-resolve
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 77
+  source_line: 83
 - from: herdr-github-create-issue
   to: cagent-agent-command-resolve
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 89
+  source_line: 101
 - from: herdr-github-create-issue
   to: github-issue-create-from-plan
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 89
+  source_line: 101
 - from: herdr-github-create-issue
   to: herdr-agent-delegate
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 89
+  source_line: 101
 - from: herdr-github-pr-orchestrate
   to: git-branch-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-github-pr-orchestrate
   to: git-changes-commit
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-github-pr-orchestrate
   to: github-pr-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-github-pr-orchestrate
   to: github-pr-feedback-address
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-github-pr-orchestrate
   to: github-pr-review
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-github-pr-orchestrate
   to: herdr-agent-delegate
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-github-pr-orchestrate
   to: herdr-worktree-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-prompt-evaluate
   to: herdr-agent-delegate
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 125
+  source_line: 155
 - from: herdr-prompt-evaluate
   to: herdr-worktree-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 125
+  source_line: 155
 - from: herdr-worktree-create
   to: git-branch-create
   relation: depends_on
   edge_condition: unconditional
   source_file: .rules/skill-categories.yaml
-  source_line: 138
+  source_line: 175
 other_references:
 - from: cagent-agent-command-resolve
   to: herdr-agent-delegate
@@ -266,7 +266,7 @@ other_references:
   to: design-plan-grill
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 167
+  source_line: 214
 - from: github-issue-create-from-plan
   to: html-artifact-format
   relation: mention
@@ -306,7 +306,7 @@ other_references:
   to: github-pr-review
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 152
+  source_line: 193
 - from: github-pr-orchestrate
   to: herdr-github-pr-orchestrate
   relation: mention
@@ -316,22 +316,22 @@ other_references:
   to: design-plan-grill
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 309
+  source_line: 400
 - from: herdr-github-pr-orchestrate
   to: cagent-agent-command-resolve
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 104
+  source_line: 125
 - from: herdr-prompt-evaluate
   to: agent-skill-design
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 125
+  source_line: 155
 - from: herdr-prompt-evaluate
   to: agent-skill-refine
   relation: routes_to
   source_file: .rules/skill-categories.yaml
-  source_line: 125
+  source_line: 155
 - from: herdr-worktree-create
   to: herdr-github-pr-orchestrate
   relation: used_by

--- a/inventory/findings.yaml
+++ b/inventory/findings.yaml
@@ -46,7 +46,6 @@ findings:
 - id: F-COMMON-POSIX-SHELL
   type: common_dependency
   dependency: posix shell
-  type_class: required
   usage_count: 24
   reason: 全スキルの 24/34 が依存。共通依存として暗黙的に扱うことを検討。
   auto_detected: false

--- a/inventory/skills.yaml
+++ b/inventory/skills.yaml
@@ -35,17 +35,13 @@ skills:
   path_references: []
   external_dependencies:
   - name: bun
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: rg
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: web access
-    type: conditional
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -63,20 +59,15 @@ skills:
   path_references: []
   external_dependencies:
   - name: node
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: npm
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: rg
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: web access
-    type: conditional
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -94,20 +85,15 @@ skills:
   path_references: []
   external_dependencies:
   - name: uv
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: python
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: rg
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: web access
-    type: conditional
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -163,11 +149,9 @@ skills:
   path_references: []
   external_dependencies:
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -189,11 +173,9 @@ skills:
   path_references: []
   external_dependencies:
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -211,11 +193,9 @@ skills:
   path_references: []
   external_dependencies:
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -253,11 +233,9 @@ skills:
     source_line: 67
   external_dependencies:
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings:
@@ -284,14 +262,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -317,14 +292,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -346,14 +318,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github api
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -375,17 +344,13 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -411,17 +376,13 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github api
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -439,14 +400,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -464,17 +422,13 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: jq
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github api
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -496,20 +450,15 @@ skills:
   path_references: []
   external_dependencies:
   - name: herdr
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: cagent
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: python
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: agent cli
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence:
   - name: cagent
     evidence_type: command-v
@@ -560,20 +509,15 @@ skills:
   path_references: []
   external_dependencies:
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: jq
-    type: conditional
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: github
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings:
@@ -596,20 +540,15 @@ skills:
   path_references: []
   external_dependencies:
   - name: herdr
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: jq
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: python
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: agent cli
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -639,29 +578,21 @@ skills:
   path_references: []
   external_dependencies:
   - name: herdr
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: cagent
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: jq
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: python
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: agent cli
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -711,29 +642,21 @@ skills:
   path_references: []
   external_dependencies:
   - name: herdr
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: cagent
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: gh
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: jq
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: python
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: agent cli
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings:
@@ -768,23 +691,17 @@ skills:
   path_references: []
   external_dependencies:
   - name: herdr
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: jq
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: python
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: agent cli
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -810,14 +727,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: herdr
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: git
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings:
@@ -893,11 +807,9 @@ skills:
     source_line: 56
   external_dependencies:
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: coreutils
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -915,8 +827,7 @@ skills:
   path_references: []
   external_dependencies:
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -934,14 +845,11 @@ skills:
   path_references: []
   external_dependencies:
   - name: librsvg
-    type: optional
-    source: README
+    source: skill-categories.yaml
   - name: inkscape
-    type: optional
-    source: README
+    source: skill-categories.yaml
   - name: browser
-    type: optional
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -975,20 +883,15 @@ skills:
   path_references: []
   external_dependencies:
   - name: playwright
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: browser
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: posix shell
-    type: required
-    source: README
+    source: skill-categories.yaml
   - name: node
-    type: fallback
-    source: README
+    source: skill-categories.yaml
   - name: npx
-    type: fallback
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []
@@ -1022,8 +925,7 @@ skills:
   path_references: []
   external_dependencies:
   - name: tailwind css project
-    type: required
-    source: README
+    source: skill-categories.yaml
   external_dependency_evidence: []
   disposition: keep
   findings: []


### PR DESCRIPTION
## Issues

- Close #241

## Why

外部依存の種別注記 `(R)`/`(C)`/`(O)`/`(F)` は non-required 種別を持つスキルへの `depends_on` が存在せず、推移依存計算に寄与していない。README から種別を廃止し、構造化された正本を `skill-categories.yaml` に一本化する。

## Summary

外部依存の種別を完全に廃止。README は人間向けの依存名一覧にとどめ、正本は `skill-categories.yaml` の `external_dependencies` フィールド（文字列リスト）に一本化。検証システムのパース・型解決ロジックを簡略化。

## Changes

- `skill-categories.yaml`: 全34スキルに `external_dependencies` 追加（種別なし文字列リスト）
- `skill-rules.yaml`: 種別定義・パースgrammar・型解決ルールを削除、V-EXT-001/002/005 の description を更新
- `dependencies.py`: `TYPE_BY_SYMBOL`/`TYPE_PRIORITY` 等を削除、データソースを README → skill-categories.yaml に切替
- `inventory.py`: 正本参照元を README → skill-categories.yaml に変更、出力から type フィールドを削除
- `graph.py`: 凡例文字列・`SYMBOL_BY_TYPE` 参照を削除
- `README.md`: External Dependencies 列から `(R)`/`(C)`/`(O)`/`(F)` 注記を全削除
- `AGENTS.md`: 外部依存種別テーブルと conditional/optional ルールを削除
- `skills-readme-sync`: 種別注記ルールを新ルールに更新

## Verification

- `python3 .scripts/inventory.py` - passed (exit 0)
- `bash .scripts/validate-skills.sh` - passed (ERROR 0)
- `bash .scripts/run-tests.sh` - passed (18 test files, all OK)
